### PR TITLE
add travis config to deploy PyPI packge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - '3.6'
+  - '3.7'
+install:
+  - pip install ".[all]"
+script:
+  - pytest
+deploy:
+  provider: pypi
+  user: koxudaxi
+  password:
+    secure: XXXXXXXX
+  on:
+    tags: true
+  distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ deploy:
   provider: pypi
   user: koxudaxi
   password:
-    secure: XXXXXXXX
+    secure: Djmf29FcrmJvL5cIqZMGwEwoCua1k8bI/dKoNTLG1UXVSAeh5EKQU8g7LztXAnEszWtzzHgXtQ7p6uYnylltuZToagViuFjQZyTwCr0B1jEP7b2Z86vR29suZh8Sffmqh18SinOchRF+Ey7mnZv5/YADOWpCjCKw+vXKElrkXo+/vVh5sGQzPbzZ2m2fdcbmnF53NDzDMXW4HI8WngIQcH/d8HST6yFMK0+deoYZgyYjXxRQ+eha4K4I5OWOvUg8hDmcPyOsQhaMAHi6UxQqV42I7Sl7sKxpW7PK8kX+Smkq/CilK8VYZWavoGs1lzuuE0JKTsm0Scz2b2EnmvR2tOJesn/hgPdq4+/XMY/lPTVK1Npw5YYk5hm/lpniS1ZB9hhRoeIlQwSuR9qtSbNPIJHT9zFBRE4yQEygx7MAKaoO9uPsFrBmrHMrElL4d0jgLSbWs6MXH05TT3ng56DUiWUsl5+3LclrXdRc2OUMnX+wkCxCh2nBxagLU0DmZBT/17SN57KPia1NxnZjGZCHPXqinVBykPe+72F3asv9vmz0OhM5Y6t54UosPudmPVY+9KaPovHxOJAEpGkXM5/jDLVWB/GMap19dyiyG/Ytk4Pt8AmgthWMnabZqZQq3Ko0/aFvDLmPUt9DR7F4H50gkMP/VjAGGsgWFjXTX262Suc=
   on:
     tags: true
   distributions: sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# datamodel_code_generator
+# datamodel-code-generator
 
 This generator creates pydantic mode from an openapi file.
 
@@ -6,11 +6,9 @@ This generator creates pydantic mode from an openapi file.
 
 ## Installation
 
-Install the package in editable mode:
-
+To install `datamodel-code-generator`:
 ```sh
-$ git clone git@github.com:koxudaxi/datamodel-code-generator.git
-$ pip install -e datamodel-code-generator
+$ pip install datamodel-code-generator
 ```
 
 ## Usage
@@ -203,4 +201,13 @@ class api(BaseModel):
 
 
 apis = List[api]
+```
+
+## Development
+
+Install the package in editable mode:
+
+```sh
+$ git clone git@github.com:koxudaxi/datamodel-code-generator.git
+$ pip install -e datamodel-code-generator
 ```


### PR DESCRIPTION
This will build and deploy packages to PyPI for each tag (as long as the tests pass (just one dummy test at the moment)

To get this working, this will require input from @koxudaxi to:
1. enable this project in TravisCI.org
2. generate the encrypted password for their PyPI account:
```
$ gem install travis # or gem install --user travis
$ git fetch origin pull/6/head:pypi
$ git checkout pypi
$ travis encrypt "your-password-here" --add deploy.password
```
This will update the `.travis.yml` - you can push it back to this branch/PR or if you post the encrypted password here I'll add it to the PR :)

Closes #5