### PR TITLE
fix to parse ref on object

### DIFF
--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -71,9 +71,12 @@ class OpenAPIParser(Parser):
                     yield from self.parse_object(class_name, filed)
                 field_type_hint: str = class_name
             else:
-                data_type = get_data_type(filed, self.data_model_type)
-                self.imports.append(data_type.import_)
-                field_type_hint = data_type.type_hint
+                if filed.ref:
+                    field_type_hint = filed.ref.split('/')[-1]
+                else:
+                    data_type = get_data_type(filed, self.data_model_type)
+                    self.imports.append(data_type.import_)
+                    field_type_hint = data_type.type_hint
             required: bool = field_name in requires
             if not required:
                 self.imports.append(IMPORT_OPTIONAL)

--- a/tests/data/api.yaml
+++ b/tests/data/api.yaml
@@ -164,3 +164,13 @@ components:
             type: string
             format: uri
             description: A URL to the API console for each API
+    Event:
+      type: object
+      properties:
+        name:
+          type: string
+    Result:
+        type: object
+        properties:
+          event:
+            $ref: '#/components/schemas/Event'

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -283,6 +283,14 @@ class api(BaseModel):
 
 class apis(BaseModel):
     __root__: List[api]
+
+
+class Event(BaseModel):
+    name: Optional[str] = None
+
+
+class Result(BaseModel):
+    event: Optional[Event] = None
 ''',
         ),
         (
@@ -331,6 +339,14 @@ class api(BaseModel):
 
 class apis(BaseModel):
     __root__: List[api]
+
+
+class Event(BaseModel):
+    name: Optional[str] = None
+
+
+class Result(BaseModel):
+    event: Optional[Event] = None
 ''',
         ),
         (
@@ -382,7 +398,15 @@ class api(BaseModel):
 
 
 class apis(BaseModel):
-    __root__: List[api]''',
+    __root__: List[api]
+
+
+class Event(BaseModel):
+    name: Optional[str] = None
+
+
+class Result(BaseModel):
+    event: Optional[Event] = None''',
         ),
         (
             True,
@@ -437,6 +461,14 @@ class api(Base):
 
 class apis(Base):
     __root__: List[api]
+
+
+class Event(Base):
+    name: Optional[str] = None
+
+
+class Result(Base):
+    event: Optional[Event] = None
 ''',
         ),
     ],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,6 +70,14 @@ class api(BaseModel):
 class apis(BaseModel):
     __root__: List[api]
 
+
+class Event(BaseModel):
+    name: Optional[str] = None
+
+
+class Result(BaseModel):
+    event: Optional[Event] = None
+
 '''
         )
 
@@ -147,6 +155,14 @@ class api(Base):
 
 class apis(Base):
     __root__: List[api]
+
+
+class Event(Base):
+    name: Optional[str] = None
+
+
+class Result(Base):
+    event: Optional[Event] = None
 
 '''
         )


### PR DESCRIPTION
The PR fixes to parse referencing external object on a object.

eg: 
```python
    Result:
      type: object
      properties:
        event:
          $ref: '#/components/schemas/Event'
```