### PR TITLE
Improve generating list object

### DIFF
--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -60,18 +60,19 @@ class OpenAPIParser(Parser):
         )
 
     def parse_object(self, name: str, obj: JsonSchemaObject) -> Iterator[TemplateBase]:
-        if name in self.created_model_names:
-            return
         requires: Set[str] = set(obj.required or [])
         fields: List[DataModelField] = []
         for field_name, filed in obj.properties.items():  # type: ignore
             if filed.is_array or filed.is_object:
                 class_name = create_class_name(field_name)
                 if filed.is_array:
-                    yield from self.parse_array(class_name, filed)
+                    models = list(self.parse_array(class_name, filed))
+                    yield from models[:-1]
+                    root_model = models[-1]
+                    field_type_hint: str = root_model.fields[0].type_hint
                 else:
                     yield from self.parse_object(class_name, filed)
-                field_type_hint: str = class_name
+                    field_type_hint = class_name
             else:
                 if filed.ref:
                     field_type_hint = filed.ref_object_name
@@ -97,9 +98,7 @@ class OpenAPIParser(Parser):
         self.created_model_names.add(name)
         yield data_model_type
 
-    def parse_array(self, name: str, obj: JsonSchemaObject) -> Iterator[TemplateBase]:
-        if name in self.created_model_names:
-            return
+    def parse_array(self, name: str, obj: JsonSchemaObject) -> Iterator[DataModel]:
         if isinstance(obj.items, JsonSchemaObject):
             items: List[JsonSchemaObject] = [obj.items]
         else:
@@ -118,20 +117,22 @@ class OpenAPIParser(Parser):
                 data_type = get_data_type(item, self.data_model_type)
                 items_obj_name.append(data_type.type_hint)
                 self.imports.append(data_type.import_)
-        support_types = f', '.join(items_obj_name)
+        if items_obj_name:
+            support_types = ', '.join(items_obj_name)
+            type_hint: str = f'List[{support_types}]'
+        else:
+            type_hint = 'List'
         self.imports.append(IMPORT_LIST)
         self.created_model_names.add(name)
         yield self.data_model_root_type(
             name,
-            [DataModelField(type_hint=f'List[{support_types}]', required=True)],
+            [DataModelField(type_hint=type_hint, required=True)],
             base_class=self.base_class,
         )
 
     def parse_root_type(
         self, name: str, obj: JsonSchemaObject
     ) -> Iterator[TemplateBase]:
-        if name in self.created_model_names:  # pragma: no cover
-            return
         if obj.type:
             data_type = get_data_type(obj, self.data_model_type)
             self.imports.append(data_type.import_)

--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -69,7 +69,9 @@ class OpenAPIParser(Parser):
                     models = list(self.parse_array(class_name, filed))
                     yield from models[:-1]
                     root_model = models[-1]
-                    field_type_hint: str = root_model.fields[0].type_hint  # type: ignore
+                    field_type_hint: str = root_model.fields[  # type: ignore
+                        0
+                    ].type_hint
                 else:
                     yield from self.parse_object(class_name, filed)
                     field_type_hint = class_name

--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -69,7 +69,7 @@ class OpenAPIParser(Parser):
                     models = list(self.parse_array(class_name, filed))
                     yield from models[:-1]
                     root_model = models[-1]
-                    field_type_hint: str = root_model.fields[0].type_hint
+                    field_type_hint: str = root_model.fields[0].type_hint  # type: ignore
                 else:
                     yield from self.parse_object(class_name, filed)
                     field_type_hint = class_name
@@ -98,7 +98,7 @@ class OpenAPIParser(Parser):
         self.created_model_names.add(name)
         yield data_model_type
 
-    def parse_array(self, name: str, obj: JsonSchemaObject) -> Iterator[DataModel]:
+    def parse_array(self, name: str, obj: JsonSchemaObject) -> Iterator[TemplateBase]:
         if isinstance(obj.items, JsonSchemaObject):
             items: List[JsonSchemaObject] = [obj.items]
         else:

--- a/tests/data/duplicate_models.yaml
+++ b/tests/data/duplicate_models.yaml
@@ -98,6 +98,7 @@ components:
         type: object
         properties:
           event:
+            type: array
             items:
               $ref: '#/components/schemas/Event'
     DuplicateObject2:

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -138,11 +138,13 @@ class Pets(BaseModel):
             {
                 'properties': {
                     'kind': {
-                        'type': 'object',
-                        'items': {
-                            'type': 'object',
-                            'properties': {'name': {'type': 'string'}},
-                        },
+                        'type': 'array',
+                        'items': [
+                            {
+                                'type': 'object',
+                                'properties': {'name': {'type': 'string'}},
+                            }
+                        ],
                     }
                 }
             },
@@ -150,12 +152,20 @@ class Pets(BaseModel):
     name: Optional[str] = None
 
 
-class Kind(BaseModel):
-    __root__: List[KindItem]
-
-
 class Pets(BaseModel):
-    kind: Optional[Kind] = None''',
+    kind: Optional[List[KindItem]] = None''',
+        ),
+        (
+            {
+                'properties': {
+                    'kind': {
+                        'type': 'array',
+                        'items': [],
+                    }
+                }
+            },
+            '''class Pets(BaseModel):
+    kind: Optional[List] = None''',
         ),
     ],
 )
@@ -553,6 +563,10 @@ class EventObject(BaseModel):
 
 
 class DuplicateObject1(BaseModel):
+    event: Optional[List[Event]] = None
+
+
+class Event(BaseModel):
     event: Optional[Event] = None
 
 

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -156,14 +156,7 @@ class Pets(BaseModel):
     kind: Optional[List[KindItem]] = None''',
         ),
         (
-            {
-                'properties': {
-                    'kind': {
-                        'type': 'array',
-                        'items': [],
-                    }
-                }
-            },
+            {'properties': {'kind': {'type': 'array', 'items': []}}},
             '''class Pets(BaseModel):
     kind: Optional[List] = None''',
         ),


### PR DESCRIPTION
The PR improve generating list object from an array.
the code generator creates a custom root object from an array.
However, the code generator should not create a custom root object from an array of inside an object.
The PR works to creates List's fields on an object.
Before
```python
class Item(BaseModel):
    name: str
class Items(BaseModel):
   __root__:  List[Item]
class Bucket(BaseModel):
    items: Items
```
After
```python
class Item(BaseModel):
    name: str
class Bucket(BaseModel):
   items: List[item]
```