### PR TITLE
add debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The `datamodel-codegen` command:
 ```                                                                                                 datamodel-code-generator[10:03:22]
 usage: datamodel-codegen [-h] [--input INPUT] [--output OUTPUT]
                          [--base-class BASE_CLASS]
-                         [--target-python-version {3.6,3.7}]
+                         [--target-python-version {3.6,3.7}] [--debug]
+
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -62,6 +63,8 @@ optional arguments:
                         Base Class (default: pydantic.BaseModel)
   --target-python-version {3.6,3.7}
                         target python version (default: 3.7)
+  --debug               show debug message
+
 ```
 
 ## Example

--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -1,7 +1,50 @@
+import inspect
 from enum import Enum
+from typing import Type, TypeVar
+
+import pysnooper
+
+T = TypeVar('T')
+
+pysnooper.tracer.DISABLED = True
+
+
+def enable_debug_message() -> None:  # pragma: no cover
+    pysnooper.tracer.DISABLED = False
 
 
 class PythonVersion(Enum):
     PY_36 = '3.6'
     PY_37 = '3.7'
     PY_38 = '3.8'
+
+
+def snooper_to_methods(
+    output=None,
+    watch=(),
+    watch_explode=(),
+    depth=1,
+    prefix='',
+    overwrite=False,
+    thread_info=False,
+    custom_repr=(),
+    max_variable_length=100,
+) -> Type[T]:
+    def inner(cls: Type[T]) -> None:
+        methods = inspect.getmembers(cls, predicate=inspect.isfunction)
+        for name, method in methods:
+            snooper_method = pysnooper.snoop(
+                output,
+                watch,
+                watch_explode,
+                depth,
+                prefix,
+                overwrite,
+                thread_info,
+                custom_repr,
+                max_variable_length,
+            )(method)
+            setattr(cls, name, snooper_method)
+        return cls
+
+    return inner

--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -1,6 +1,6 @@
 import inspect
 from enum import Enum
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Callable
 
 import pysnooper
 
@@ -19,7 +19,7 @@ class PythonVersion(Enum):
     PY_38 = '3.8'
 
 
-def snooper_to_methods(
+def snooper_to_methods(  # type: ignore
     output=None,
     watch=(),
     watch_explode=(),
@@ -29,8 +29,8 @@ def snooper_to_methods(
     thread_info=False,
     custom_repr=(),
     max_variable_length=100,
-) -> Type[T]:
-    def inner(cls: Type[T]) -> None:
+) -> Callable:
+    def inner(cls: Type[T]) -> Type[T]:
         methods = inspect.getmembers(cls, predicate=inspect.isfunction)
         for name, method in methods:
             snooper_method = pysnooper.snoop(

--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -1,6 +1,6 @@
 import inspect
 from enum import Enum
-from typing import Type, TypeVar, Callable
+from typing import Callable, Type, TypeVar
 
 import pysnooper
 

--- a/datamodel_code_generator/__main__.py
+++ b/datamodel_code_generator/__main__.py
@@ -12,13 +12,12 @@ from enum import IntEnum
 from typing import Optional, Sequence, Union
 
 import argcomplete
-from datamodel_code_generator import PythonVersion
+from datamodel_code_generator import PythonVersion, enable_debug_message
 from datamodel_code_generator.model.pydantic import (
     BaseModel,
     CustomRootType,
     dump_resolve_reference_action,
 )
-from datamodel_code_generator.parser.openapi import OpenAPIParser
 
 
 class Exit(IntEnum):
@@ -53,6 +52,7 @@ arg_parser.add_argument(
     choices=['3.6', '3.7'],
     default='3.7',
 )
+arg_parser.add_argument('--debug', help='show debug message', action='store_true')
 
 
 def main(args: Optional[Sequence[str]] = None) -> Exit:
@@ -65,6 +65,11 @@ def main(args: Optional[Sequence[str]] = None) -> Exit:
         args = sys.argv[1:]
 
     namespace: Namespace = arg_parser.parse_args(args)
+
+    if namespace.debug:  # pragma: no cover
+        enable_debug_message()
+
+    from datamodel_code_generator.parser.openapi import OpenAPIParser
 
     parser = OpenAPIParser(
         BaseModel,

--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -1,6 +1,6 @@
 from typing import Callable, Dict, List, Optional, Set, Tuple, Type
 
-from datamodel_code_generator import PythonVersion
+from datamodel_code_generator import PythonVersion, snooper_to_methods
 from datamodel_code_generator.format import format_code
 from datamodel_code_generator.imports import IMPORT_ANNOTATIONS
 from datamodel_code_generator.model.enum import Enum
@@ -17,6 +17,7 @@ from prance import BaseParser
 from ..model.base import DataModel, DataModelField
 
 
+@snooper_to_methods(max_variable_length=None)
 class OpenAPIParser(Parser):
     def __init__(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     pydantic[email,ujson] == 0.32.0
     black == 19.3b0
     isort == 4.3.21
+    PySnooper == 0.2.8
 
 tests_require =
     pytest


### PR DESCRIPTION
The PR supports to show debug message.

The option is enabled by cli argument.
```
datamodel-codegen --help                                       
usage: datamodel-codegen [-h] [--input INPUT] [--output OUTPUT]
                         [--base-class BASE_CLASS]
                         [--target-python-version {3.6,3.7}] [--debug]

optional arguments:
  -h, --help            show this help message and exit
  --input INPUT         Open API YAML file (default: stdin)
  --output OUTPUT       Output file (default: stdout)
  --base-class BASE_CLASS
                        Base Class (default: pydantic.BaseModel)
  --target-python-version {3.6,3.7}
                        target python version (default: 3.7)
  --debug               show debug message

```
