### PR TITLE
Support for Primitve union properties

### DIFF
--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -81,6 +81,9 @@ class OpenAPIParser(Parser):
                         version_compatible=True,
                     )
                 )
+            elif not any(v for k, v in vars(any_of_item).items() if k != 'type'):
+                # trivial types
+                any_of_data_types.append(self.get_data_type(any_of_item))
             else:
                 singular_name = get_singular_name(name)
                 self.parse_object(singular_name, any_of_item)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     openapi-spec-validator==0.2.8
     jinja2==2.10.3
     inflect==3.0.1
-    pydantic[email,ujson]==1.0
+    pydantic[email]==1.0
     black==19.3b0
     isort==4.3.21
     PySnooper==0.2.8

--- a/tests/data/modular.yaml
+++ b/tests/data/modular.yaml
@@ -178,7 +178,12 @@ components:
       type: object
       properties:
         name:
-          type: string
+          anyOf:
+            - type: string
+            - type: number
+            - type: integer
+            - type: boolean
+            - type: object
     Result:
       type: object
       properties:

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -945,7 +945,7 @@ class Result(BaseModel):
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel
 
@@ -970,7 +970,7 @@ class User(BaseModel):
 
 
 class Event(BaseModel):
-    name: Optional[str] = None
+    name: Optional[Union[str, float, int, bool, Dict[str, Any]]] = None
 ''',
                 (
                     'collections.py',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -302,7 +302,7 @@ class Result(BaseModel):
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel
 
@@ -327,7 +327,7 @@ class User(BaseModel):
 
 
 class Event(BaseModel):
-    name: Optional[str] = None
+    name: Optional[Union[str, float, int, bool, Dict[str, Any]]] = None
 ''',
             (
                 'collections.py',


### PR DESCRIPTION
For `anyOf` properties where the type is primitive (int, float, bool,
str, etc), produce a `Union` of primitive types without creating a
special "singular name" type