### PR TITLE
add support for arrays of simple primities to anyOf

### DIFF
--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -172,6 +172,20 @@ class JsonSchemaParser(Parser):
             elif not any(v for k, v in vars(any_of_item).items() if k != 'type'):
                 # trivial types
                 any_of_data_types.append(self.get_data_type(any_of_item))
+            elif (
+                any_of_item.is_array
+                and isinstance(any_of_item.items, JsonSchemaObject)
+                and not any(
+                    v for k, v in vars(any_of_item.items).items() if k != 'type'
+                )
+            ):
+                # trivial item types
+                any_of_data_types.append(
+                    self.data_type(
+                        type=f"List[{self.get_data_type(any_of_item.items).type_hint}]",
+                        imports_=[Import(from_='typing', import_='List')],
+                    )
+                )
             else:
                 singular_name = get_singular_name(name)
                 self.parse_object(singular_name, any_of_item)

--- a/tests/data/openapi/modular.yaml
+++ b/tests/data/openapi/modular.yaml
@@ -184,6 +184,9 @@ components:
             - type: integer
             - type: boolean
             - type: object
+            - type: array
+              items:
+                type: string
     Result:
       type: object
       properties:

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -961,7 +961,7 @@ class Result(BaseModel):
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -986,7 +986,7 @@ class User(BaseModel):
 
 
 class Event(BaseModel):
-    name: Optional[Union[str, float, int, bool, Dict[str, Any]]] = None
+    name: Optional[Union[str, float, int, bool, Dict[str, Any], List[str]]] = None
 ''',
                 (
                     'collections.py',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -414,7 +414,7 @@ class Result(BaseModel):
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -439,7 +439,7 @@ class User(BaseModel):
 
 
 class Event(BaseModel):
-    name: Optional[Union[str, float, int, bool, Dict[str, Any]]] = None
+    name: Optional[Union[str, float, int, bool, Dict[str, Any], List[str]]] = None
 ''',
             (
                 'collections.py',

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -310,7 +310,7 @@ class Result(BaseModel):
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -335,7 +335,7 @@ class User(BaseModel):
 
 
 class Event(BaseModel):
-    name: Optional[Union[str, float, int, bool, Dict[str, Any]]] = None
+    name: Optional[Union[str, float, int, bool, Dict[str, Any], List[str]]] = None
 ''',
             (
                 'collections.py',


### PR DESCRIPTION
- map `{"type": "array", "items": {"type": primitive_type}}` to `List[py_primitive_type]`
  in `anyOf`