### PR TITLE
correct string-normalization to skip-string-normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ some parent of the output directory).
 Example `pyproject.toml`:
 ```toml
 [tool.black]
-string-normalization = true
+skip-string-normalization = true
 line-length = 100
 
 [tool.isort]

--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -37,7 +37,7 @@ def apply_black(code: str, python_version: PythonVersion) -> str:
         mode=black.FileMode(
             target_versions={BLACK_PYTHON_VERSION[python_version]},
             line_length=config.get("line-length", black.DEFAULT_LINE_LENGTH),
-            string_normalization=config.get("string-normalization", False),
+            string_normalization=not config.get("skip-string-normalization", True),
         ),
     )
 

--- a/tests/data/project/pyproject.toml
+++ b/tests/data/project/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-string-normalization = true
+skip-string-normalization = false
 line-length = 30


### PR DESCRIPTION
Fixing `skip-string-normalization` option to be in the right direction (negative rather than positive) to match the _actual_ configuration item name in Black
(sorry - the config file option is the opposite to the library option)