### PR TITLE
Fix parse errors when property pattern is explicit.

### DIFF
--- a/datamodel_code_generator/model/pydantic/types.py
+++ b/datamodel_code_generator/model/pydantic/types.py
@@ -134,6 +134,8 @@ def get_data_float_type(types: Types, **kwargs: Any) -> DataType:
 def get_data_str_type(types: Types, **kwargs: Any) -> DataType:
     data_type_kwargs = transform_kwargs(kwargs, string_kwargs)
     if data_type_kwargs:
+        if 'regex' in data_type_kwargs.keys():
+            data_type_kwargs['regex'] = f'\'{data_type_kwargs["regex"]}\''
         return DataType(
             type='constr',
             is_func=True,

--- a/datamodel_code_generator/model/pydantic/types.py
+++ b/datamodel_code_generator/model/pydantic/types.py
@@ -134,7 +134,7 @@ def get_data_float_type(types: Types, **kwargs: Any) -> DataType:
 def get_data_str_type(types: Types, **kwargs: Any) -> DataType:
     data_type_kwargs = transform_kwargs(kwargs, string_kwargs)
     if data_type_kwargs:
-        if 'regex' in data_type_kwargs.keys():
+        if 'regex' in data_type_kwargs:
             data_type_kwargs['regex'] = f'\'{data_type_kwargs["regex"]}\''
         return DataType(
             type='constr',

--- a/tests/model/pydantic/test_types.py
+++ b/tests/model/pydantic/test_types.py
@@ -136,7 +136,7 @@ def test_get_data_float_type(types, params, data_type):
             DataType(
                 type='constr',
                 is_func=True,
-                kwargs={'regex': '^abc'},
+                kwargs={'regex': "'^abc'"},
                 imports_=[IMPORT_CONSTR],
             ),
         ),


### PR DESCRIPTION
Proposed workaround to fix parse error when declaring regex. (https://github.com/koxudaxi/datamodel-code-generator/issues/124)