### PR TITLE
the default for string-normalization was reversed

### DIFF
--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -43,7 +43,7 @@ def apply_black(code: str, python_version: PythonVersion) -> str:
         mode=black.FileMode(
             target_versions={BLACK_PYTHON_VERSION[python_version]},
             line_length=config.get("line-length", black.DEFAULT_LINE_LENGTH),
-            string_normalization=not config.get("skip-string-normalization", True),
+            string_normalization=not config.get("skip-string-normalization", False),
         ),
     )
 


### PR DESCRIPTION
The default value for `skip-string-normalization` is `False` in black while datamodel-code-generator has it as `True`. To avoid confusion, use the same default value. Otherwise it is required to have a black config present with `skip-string-normalization` set to its default value.