### PR TITLE
Fix multiple sub-type in List

### DIFF
--- a/datamodel_code_generator/model/base.py
+++ b/datamodel_code_generator/model/base.py
@@ -74,10 +74,8 @@ class DataModelFieldBase(BaseModel):
             return type_hint
         if self.is_list:
             self.imports.append(IMPORT_LIST)
-            if self.is_union:
-                self.imports.append(IMPORT_UNION)
-                return f'{LIST}[{UNION}[{type_hint}]]'
-            return f'{LIST}[{type_hint}]'
+            self.imports.append(IMPORT_UNION)
+            return f'{LIST}[{UNION}[{type_hint}]]'
         self.imports.append(IMPORT_UNION)
         return f'{UNION}[{type_hint}]'
 

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -221,9 +221,12 @@ class JsonSchemaParser(Parser):
                 )
             ):
                 # trivial item types
+                types = [t.type_hint for t in self.get_data_type(any_of_item.items)]
                 any_of_data_types.append(
                     self.data_type(
-                        type=f"List[{', '.join([t.type_hint for t in self.get_data_type(any_of_item.items)])}]",
+                        type=f"List[Union[{', '.join(types)}]]"
+                        if len(types) > 1
+                        else f"List[{types[0]}]",
                         imports_=[Import(from_='typing', import_='List')],
                     )
                 )

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -239,7 +239,7 @@ def test_data_field():
         is_list=True,
         is_union=False,
     )
-    assert field.type_hint == 'List[str, int]'
+    assert field.type_hint == 'List[Union[str, int]]'
     field = DataModelFieldBase(
         name='a',
         data_types=[DataType(type='str'), DataType(type='int')],
@@ -277,7 +277,7 @@ def test_data_field():
         is_list=True,
         is_union=False,
     )
-    assert field.type_hint == 'Optional[List[str, int]]'
+    assert field.type_hint == 'Optional[List[Union[str, int]]]'
 
     field = DataModelFieldBase(
         name='a', data_types=[], required=False, is_list=True, is_union=False


### PR DESCRIPTION
This PR fixes multiple sub-type in List

before:
```python
List[str, int, float]
```

after:
```python
List[Union[str, int, float]]
```