### PR TITLE
Support remote ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [documentation](https://koxudaxi.github.io/datamodel-code-generator) for mor
 - allOf (as Multiple inheritance)
 - anyOf (as Union)
 - oneOf (as Union)
-- $ref (exclude URL Reference)
+- $ref (http extra is required. `$ pip install datamodel_code_generator[http]`)
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [documentation](https://koxudaxi.github.io/datamodel-code-generator) for mor
 - allOf (as Multiple inheritance)
 - anyOf (as Union)
 - oneOf (as Union)
-- $ref (http extra is required when resolving $ref for remote files. `$ pip install datamodel-code-generator[http]`)
+- $ref ([http extra](#http-extra-option) is required when resolving $ref for remote files.)
 
 
 ## Installation
@@ -55,6 +55,7 @@ To install `datamodel-code-generator`:
 $ pip install datamodel-code-generator
 ```
 
+### `http` extra option
 If you want to resolve `$ref` for remote files then you should specify `http` extra option.
 ```bash
 $ pip install datamodel-code-generator[http]

--- a/README.md
+++ b/README.md
@@ -45,14 +45,19 @@ See [documentation](https://koxudaxi.github.io/datamodel-code-generator) for mor
 - allOf (as Multiple inheritance)
 - anyOf (as Union)
 - oneOf (as Union)
-- $ref (http extra is required. `$ pip install datamodel_code_generator[http]`)
+- $ref (http extra is required when resolving $ref for remote files. `$ pip install datamodel-code-generator[http]`)
 
 
 ## Installation
 
 To install `datamodel-code-generator`:
-```sh
+```bash
 $ pip install datamodel-code-generator
+```
+
+If you want to resolve `$ref` for remote files then you should specify `http` extra option.
+```bash
+$ pip install datamodel-code-generator[http]
 ```
 
 ## Usage

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -190,11 +190,10 @@ class ModelResolver:
         self.references[joined_path] = reference
         return reference
 
-    def get(self, path: List[str]) -> Reference:  # pragma: no cover
+    def get(self, path: Union[List[str], str]) -> Reference:  # pragma: no cover
+        if isinstance(path, str):
+            return self.references.get(path)
         return self.references[self._get_path(path)]
-
-    def get_by_path(self, path: str) -> Optional[Reference]:
-        return self.references.get(path)
 
     def get_class_name(self, field_name: str, unique: bool = True) -> str:
         if '.' in field_name:

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -140,11 +140,11 @@ class ModelResolver:
         self.aliases = {**aliases} if aliases is not None else {}
 
     @staticmethod
-    def _get_path(path: List[str], name: str) -> str:
+    def _get_path(path: List[str]) -> str:
         if '#' in path:  # remote
             delimiter = path.index('#')
-            return f"{''.join(path[:delimiter])}#/{''.join(path[delimiter + 1:])}/{name}"
-        return '/'.join([*path, name])
+            return f"{''.join(path[:delimiter])}#/{''.join(path[delimiter + 1:])}"
+        return '/'.join(path)
 
     def add_ref(self, ref: str) -> Reference:
         if ref in self.references:
@@ -153,7 +153,7 @@ class ModelResolver:
 
         name = self.get_class_name(original_name, unique=False)
         reference = Reference(
-            path=parents.split('/'),
+            path=ref.split('/'),
             original_name=original_name,
             name=name,
             loaded=not (ref.startswith('https://') or ref.startswith('http://'))
@@ -171,7 +171,7 @@ class ModelResolver:
         unique: bool = False,
         singular_name_suffix: str = 'Item',
     ) -> Reference:
-        joined_path: str = self._get_path(path, original_name)
+        joined_path: str = self._get_path(path)
         if joined_path in self.references:
             return self.references[joined_path]
         if class_name:

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -190,7 +190,9 @@ class ModelResolver:
         self.references[joined_path] = reference
         return reference
 
-    def get(self, path: Union[List[str], str]) -> Reference:  # pragma: no cover
+    def get(
+        self, path: Union[List[str], str]
+    ) -> Optional[Reference]:  # pragma: no cover
         if isinstance(path, str):
             return self.references.get(path)
         return self.references[self._get_path(path)]

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -187,6 +187,9 @@ class ModelResolver:
     def get(self, path: List[str]) -> Reference:  # pragma: no cover
         return self.references[self._get_path(path)]
 
+    def get_by_path(self, path: str) -> Optional[Reference]:
+        return self.references.get(path)
+
     def get_class_name(self, field_name: str, unique: bool = True) -> str:
         if '.' in field_name:
             split_name = [self.get_valid_name(n) for n in field_name.split('.')]
@@ -275,7 +278,6 @@ class Parser(ABC):
         #     self.base_path: Path = Path(filename).absolute().parent
         # else:
         self.base_path = Path.cwd()
-        self.excludes_ref_path: Set[str] = set()
 
         self.custom_template_dir = (
             Path(custom_template_dir).expanduser().resolve()

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -156,7 +156,7 @@ class ModelResolver:
             path=ref.split('/'),
             original_name=original_name,
             name=name,
-            loaded=not (ref.startswith('https://') or ref.startswith('http://'))
+            loaded=not ref.startswith(('https://', 'http://')),
         )
         self.references[ref] = reference
         return reference

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -551,7 +551,7 @@ class JsonSchemaParser(Parser):
 
     def parse_ref(self, obj: JsonSchemaObject, path: List[str]) -> None:
         if obj.ref:
-            reference = self.model_resolver.get_by_path(obj.ref)
+            reference = self.model_resolver.get(obj.ref)
             if not reference or not reference.loaded:
                 # https://swagger.io/docs/specification/using-ref/
                 if obj.ref.startswith('#'):

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -549,54 +549,60 @@ class JsonSchemaParser(Parser):
         return enum
 
     def parse_ref(self, obj: JsonSchemaObject, path: List[str]) -> None:
-        if obj.ref and not self.model_resolver.get_by_path(obj.ref):
-            ref: str = obj.ref
-            # https://swagger.io/docs/specification/using-ref/
-            if ref.startswith('#'):
-                # Local Reference – $ref: '#/definitions/myElement'
-                pass
-            else:
-                relative_path, object_path = ref.split('#/')
-                if ref.startswith('https://') or ref.startswith('http://'):
-                    # URL Reference – $ref: 'http://path/to/your/resource' Uses the whole document located on the different server.
-                    try:
-                        import httpx
-                    except ImportError:  # pragma: no cover
-                        raise Exception(
-                            f'Please run $pip install datamodel-code-generator[http] to resolve URL Reference ref={ref}'
-                        )
-                    raw_body: str = httpx.get(relative_path).text
-                    if relative_path.lower().endswith('.json'):
-                        import json
+        if obj.ref:
+            reference = self.model_resolver.get_by_path(obj.ref)
+            if not reference or not reference.loaded:
 
-                        ref_body: Dict[str, Any] = json.loads(raw_body)
-                    else:
-                        # expect yaml
-                        import yaml
-
-                        ref_body = yaml.safe_load(raw_body)
-                    full_path = relative_path
+                # https://swagger.io/docs/specification/using-ref/
+                if obj.ref.startswith('#'):
+                    # Local Reference – $ref: '#/definitions/myElement'
+                    pass
                 else:
-                    # Remote Reference – $ref: 'document.json' Uses the whole document located on the same server and in
-                    # the same location. TODO treat edge case
-                    full_path = self.base_path / relative_path
-                    with full_path.open() as f:
-                        if full_path.suffix.lower() == '.json':
+                    relative_path, object_path = obj.ref.split('#/')
+                    if obj.ref.startswith('https://') or obj.ref.startswith('http://'):
+                        # URL Reference – $ref: 'http://path/to/your/resource' Uses the whole document located on the different server.
+                        try:
+                            import httpx
+                        except ImportError:  # pragma: no cover
+                            raise Exception(
+                                f'Please run $pip install datamodel-code-generator[http] to resolve URL Reference ref={ref}'
+                            )
+                        raw_body: str = httpx.get(relative_path).text
+                        if relative_path.lower().endswith('.json'):
                             import json
 
-                            ref_body: Dict[str, Any] = json.load(f)
+                            ref_body: Dict[str, Any] = json.loads(raw_body)
                         else:
                             # expect yaml
                             import yaml
 
-                            ref_body = yaml.safe_load(f)
-                object_parents = object_path.split('/')
-                self.model_resolver.add_ref(ref)
-                models = get_model_by_path(ref_body, object_parents[:-1])
-                for model_name, model in models.items():
-                    self.parse_raw_obj(
-                        model_name, model, [str(full_path), '#/', *object_parents[:-1]],
-                    )
+                            ref_body = yaml.safe_load(raw_body)
+                        full_path = relative_path
+                    else:
+                        # Remote Reference – $ref: 'document.json' Uses the whole document located on the same server and in
+                        # the same location. TODO treat edge case
+                        full_path = self.base_path / relative_path
+                        with full_path.open() as f:
+                            if full_path.suffix.lower() == '.json':
+                                import json
+
+                                ref_body: Dict[str, Any] = json.load(f)
+                            else:
+                                # expect yaml
+                                import yaml
+
+                                ref_body = yaml.safe_load(f)
+                    object_parents = object_path.split('/')
+                    # self.model_resolver.add_ref(ref)
+                    models = get_model_by_path(ref_body, object_parents[:-1])
+                    for model_name, model in models.items():
+                        self.parse_raw_obj(
+                            model_name,
+                            model,
+                            [str(full_path), '#', *object_parents[:-1]],
+                        )
+                        if reference:
+                            reference.loaded = True
 
         if obj.items:
             if isinstance(obj.items, JsonSchemaObject):

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -552,7 +552,6 @@ class JsonSchemaParser(Parser):
         if obj.ref:
             reference = self.model_resolver.get_by_path(obj.ref)
             if not reference or not reference.loaded:
-
                 # https://swagger.io/docs/specification/using-ref/
                 if obj.ref.startswith('#'):
                     # Local Reference – $ref: '#/definitions/myElement'
@@ -592,17 +591,16 @@ class JsonSchemaParser(Parser):
                                 import yaml
 
                                 ref_body = yaml.safe_load(f)
-                    object_parents = object_path.split('/')
-                    # self.model_resolver.add_ref(ref)
-                    models = get_model_by_path(ref_body, object_parents[:-1])
-                    for model_name, model in models.items():
-                        self.parse_raw_obj(
-                            model_name,
-                            model,
-                            [str(full_path), '#', *object_parents[:-1]],
-                        )
-                        if reference:
-                            reference.loaded = True
+                    object_paths = object_path.split('/')
+                    models = get_model_by_path(ref_body, object_paths)
+                    self.parse_raw_obj(
+                        object_paths[-1],
+                        models,
+                        [str(full_path), '#', *object_paths],
+                    )
+                    self.model_resolver.add_ref(obj.ref)
+                    self.model_resolver.get_by_path(obj.ref).loaded = True
+
 
         if obj.items:
             if isinstance(obj.items, JsonSchemaObject):

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ To install `datamodel-code-generator`:
 $ pip install datamodel-code-generator
 ```
 
+### `http` extra option
 If you want to resolve `$ref` for remote files then you should specify `http` extra option.
 ```bash
 $ pip install datamodel-code-generator[http]

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,13 @@ This code generator creates pydantic model from an openapi file and others.
 ## Installation
 
 To install `datamodel-code-generator`:
-```sh
+```bash
 $ pip install datamodel-code-generator
+```
+
+If you want to resolve `$ref` for remote files then you should specify `http` extra option.
+```bash
+$ pip install datamodel-code-generator[http]
 ```
 
 ## Usage

--- a/docs/support-data-types.md
+++ b/docs/support-data-types.md
@@ -27,4 +27,4 @@ This codegen supports major data types to OpenAPI/JSON Schema
 - allOf (as Multiple inheritance)
 - anyOf (as Union)
 - oneOf (as Union)
-- $ref (http extra is required when resolving $ref for remote files. `$ pip install datamodel-code-generator[http]`)
+- $ref ([http extra](../#http-extra-option) is required when resolving $ref for remote files.)

--- a/docs/support-data-types.md
+++ b/docs/support-data-types.md
@@ -27,4 +27,4 @@ This codegen supports major data types to OpenAPI/JSON Schema
 - allOf (as Multiple inheritance)
 - anyOf (as Union)
 - oneOf (as Union)
-- $ref (http extra is required. `$ pip install datamodel_code_generator[http]`)
+- $ref (http extra is required when resolving $ref for remote files. `$ pip install datamodel-code-generator[http]`)

--- a/docs/support-data-types.md
+++ b/docs/support-data-types.md
@@ -27,4 +27,4 @@ This codegen supports major data types to OpenAPI/JSON Schema
 - allOf (as Multiple inheritance)
 - anyOf (as Union)
 - oneOf (as Union)
-- $ref (exclude URL Reference)
+- $ref (http extra is required. `$ pip install datamodel_code_generator[http]`)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ tests_require =
     freezegun
 
 [options.extras_require]
+http =
+    httpx
 docs =
     mkdocs
     mkdocs-material

--- a/tests/data/jsonschema/user.json
+++ b/tests/data/jsonschema/user.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/data/jsonschema/user.json
+++ b/tests/data/jsonschema/user.json
@@ -9,6 +9,14 @@
           "type": "string"
         }
       }
+    },
+    "Pet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -75,13 +75,13 @@ def test_json_schema_object_ref_url_json(mocker):
         },
     )
 
-    parser.parse_ref(obj, [])
+    parser.parse_ref(obj, ['Model'])
     assert (
         dump_templates(list(parser.results))
         == '''class User(BaseModel):
     name: Optional[str] = None'''
     )
-    parser.parse_ref(obj, [])
+    parser.parse_ref(obj, ['Model'])
     mock_get.assert_called_once_with('https://example.org/schema.json',)
 
 
@@ -103,7 +103,7 @@ def test_json_schema_object_ref_url_yaml(mocker):
         },
     )
 
-    parser.parse_ref(obj, [])
+    parser.parse_ref(obj, ['User'])
     assert (
         dump_templates(list(parser.results))
         == '''class User(BaseModel):
@@ -134,7 +134,7 @@ def test_json_schema_ref_url_json(mocker):
         },
     )
 
-    parser.parse_raw_obj('Model', obj, [])
+    parser.parse_raw_obj('Model', obj, ['Model'])
     assert (
         dump_templates(list(parser.results))
         == '''class Model(BaseModel):

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -95,7 +95,7 @@ def test_json_schema_object_ref_url_yaml(mocker):
     )
     mock_get = mocker.patch('httpx.get')
     mock_get.return_value.text = yaml.safe_dump(
-       json.load((DATA_PATH / 'user.json').open())
+        json.load((DATA_PATH / 'user.json').open())
     )
 
     parser.parse_ref(obj, ['User'])
@@ -119,9 +119,7 @@ def test_json_schema_ref_url_json(mocker):
         },
     }
     mock_get = mocker.patch('httpx.get')
-    mock_get.return_value.text = json.dumps(
-        json.load((DATA_PATH / 'user.json').open())
-    )
+    mock_get.return_value.text = json.dumps(json.load((DATA_PATH / 'user.json').open()))
 
     parser.parse_raw_obj('Model', obj, ['Model'])
     assert (

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -95,13 +95,7 @@ def test_json_schema_object_ref_url_yaml(mocker):
     )
     mock_get = mocker.patch('httpx.get')
     mock_get.return_value.text = yaml.safe_dump(
-        {
-            "$id": "https://example.com/person.schema.json",
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "definitions": {
-                "User": {"type": "object", "properties": {"name": {"type": "string",}},}
-            },
-        },
+       json.load((DATA_PATH / 'user.json').open())
     )
 
     parser.parse_ref(obj, ['User'])
@@ -126,13 +120,7 @@ def test_json_schema_ref_url_json(mocker):
     }
     mock_get = mocker.patch('httpx.get')
     mock_get.return_value.text = json.dumps(
-        {
-            "$id": "https://example.com/person.schema.json",
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "definitions": {
-                "User": {"type": "object", "properties": {"name": {"type": "string",}},}
-            },
-        },
+        json.load((DATA_PATH / 'user.json').open())
     )
 
     parser.parse_raw_obj('Model', obj, ['Model'])

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -21,6 +21,7 @@ DATA_PATH: Path = Path(__file__).parents[1] / 'data' / 'jsonschema'
 @pytest.mark.parametrize(
     'schema,path,model',
     [
+        ({'foo': 'bar'}, None, {'foo': 'bar'}),
         ({'a': {'foo': 'bar'}}, 'a', {'foo': 'bar'}),
         ({'a': {'b': {'foo': 'bar'}}}, 'a/b', {'foo': 'bar'}),
         ({'a': {'b': {'c': {'foo': 'bar'}}}}, 'a/b', {'c': {'foo': 'bar'}}),
@@ -28,7 +29,7 @@ DATA_PATH: Path = Path(__file__).parents[1] / 'data' / 'jsonschema'
     ],
 )
 def test_get_model_by_path(schema: Dict, path: str, model: Dict):
-    assert get_model_by_path(schema, path.split('/')) == model
+    assert get_model_by_path(schema, path.split('/') if path else []) == model
 
 
 def test_json_schema_parser_parse_ref():


### PR DESCRIPTION
This PR adds supporting remote `$ref`.
The feature is optional.  Users have to install http extra blow.
```bash
$ pip install datamodel_code_generator[http]
```
# Realted issue 

https://github.com/koxudaxi/datamodel-code-generator/issues/156