### PR TITLE
Fix nested refs and subclasses

### DIFF
--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -104,6 +104,7 @@ def sort_data_models(
             if model.name in model.reference_classes:
                 require_update_action_models.append(model.name)
         else:
+            sorted_data_models[model.name] = model
             unresolved_references.append(model)
     if unresolved_references:
         try:


### PR DESCRIPTION
This fixes model generation for openapi specs with nested references or with parent classes different than the base_model.

Attached is the Jetbrain's youtrack openapi.json that I used.

[openapi.zip](https://github.com/koxudaxi/datamodel-code-generator/files/5138984/openapi.zip)

