### PR TITLE
Fix get_relative_path subfolders with same names

### DIFF
--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -169,7 +169,7 @@ def get_relative_path(base_path: PurePath, target_path: PurePath) -> PurePath:
     parent_count: int = 0
     children: List[str] = []
     for base_part, target_part in zip_longest(base_path.parts, target_path.parts):
-        if base_part == target_part:
+        if base_part == target_part and not parent_count:
             continue
         if base_part or not target_part:
             parent_count += 1

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -16,6 +16,7 @@ from datamodel_code_generator.reference import get_relative_path
         ('/a/b/c/d', '/a', '../../..'),
         ('/a/b/c/d', '/a/x/y/z', '../../../x/y/z'),
         ('/a/b/c/d', 'a/x/y/z', 'a/x/y/z'),
+        ('/a/b/c/d', '/a/b/e/d', '../../e/d'),
     ],
 )
 def test_get_relative_path_posix(
@@ -37,6 +38,7 @@ def test_get_relative_path_posix(
         ('c:/a/b/c/d', 'c:/a', '../../..'),
         ('c:/a/b/c/d', 'c:/a/x/y/z', '../../../x/y/z'),
         ('c:/a/b/c/d', 'a/x/y/z', 'a/x/y/z'),
+        ('c:/a/b/c/d', 'c:/a/b/e/d', '../../e/d'),
     ],
 )
 def test_get_relative_path_windows(


### PR DESCRIPTION
Whilst calculating relative paths, the current implementation has an
issue where if a subfolder beyond the point of divergence has the same
name in the base_path and the target_path, this doesn't increment the
parent_count, and doesn't properly append to the children.

Example:

>   base_path: /a/b/c/d
>   target_path: /a/b/e/d
> 
>   To get from the base path to the target path, we'd need to go up 2
>   directories from d to b, then back down through e and into d, so we
>   expect the function to return "../../e/d"
> 
>   In the current implementation of get_relative_path, we successfully
>   `continue` through `a` and `b`, as these match the condition
>   `if base_part == target_part`.
> 
>   Once we get to the comparison between `c` and `e`, we increment the
>   parent_count, showing that we've now diverged between the two absolute
>   paths, and add the target_part of `e` to the children.
> 
>   This next iteration is where the issue is seen. When comparing `d` in
>   the base_part to `d` in the target part, we match on the condition
>   `if base_part == target_part`, causing us to `continue`, which causes
>   us to not increment parent_count as we should, and not add the
>   target_part of `d` to the children as well.
> 
>   This actually returns "../e"

In order to fix this, we add another check to the initial
`if base_part == target_part`. If `parent_count != 0`, we know that the
paths have diverged between base_path and target_path, and any further
subfolders should therefore not be compared against for matching names.