### PR TITLE
Pass custom template dir when creating enums

### DIFF
--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -877,6 +877,7 @@ class JsonSchemaParser(Parser):
                 fields=enum_fields,
                 path=self.current_source_path,
                 description=obj.description if self.use_schema_description else None,
+                custom_template_dir=self.custom_template_dir,
             )
             self.results.append(enum)
             return self.data_type(reference=reference_)


### PR DESCRIPTION
This way, user can provide a customized jinja template specific to enum

Fixes #428 