### PR TITLE
Fix inline enum only string literal

### DIFF
--- a/datamodel_code_generator/types.py
+++ b/datamodel_code_generator/types.py
@@ -16,6 +16,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    Union,
 )
 
 from pydantic import create_model
@@ -71,7 +72,7 @@ class DataType(_BaseModel):
     is_dict: bool = False
     is_list: bool = False
     is_custom_type: bool = False
-    literals: List[str] = []
+    literals: List[Union[int, str]] = []
     use_standard_collections: bool = False
     use_generic_container: bool = False
     alias: Optional[str] = None


### PR DESCRIPTION
This change adds support for `integer` inline enums. It fixes #440.

The following schema:

```yml
Foo:
  type: object
  properties:
    bar:
      type: integer
      enum: [1]
```

Becomes the following model:

```py
class Foo(BaseModel):
    bar: Optional[Literal[1]] = None
```

And the following schema:

```yml
Foo:
  type: object
  properties:
    bar:
      type: string
      enum: ["a"]
```

Becomes the following model:

```py
class Foo(BaseModel):
    bar: Optional[Literal['a']] = None