### PR TITLE
Fix handling of absolute ref

### DIFF
--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -359,6 +359,9 @@ class ModelResolver:
         ):
             if Path(self._base_path, joined_path).is_file():
                 ref = f'{joined_path}#'
+            elif is_url(joined_path):
+                # Handle when the joined_path is already an absolute URL
+                ref = f'{joined_path}#'
             else:
                 ref = f'{self.root_id_base_path}/{joined_path}#'
         else:


### PR DESCRIPTION
Closes https://github.com/koxudaxi/datamodel-code-generator/issues/564

If the ref is already an absolute URL (i.e. starts with `https://` or `http://`) then don't append it to `root_id_base_path`. 

The previous behavior for a schema like:
```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "$id": "https://example.com/list-of-features.schema.json",
  "title": "ListOfFeatures",
  "type": "object",
  "required": ["features"],
  "additionalProperties": false,
  "properties": {
    "features": {
      "type": "array",
      "items": {
        "$ref": "https://geojson.org/schema/Feature.json"
      }
    }
  }
}
```
was that the resolved ref was actually

```
https://example.com/https://geojson.org/schema/Feature.json#
```