### PR TITLE
WIP: Differentiate "nullable" and "not-required" properties

### DIFF
--- a/datamodel_code_generator/model/base.py
+++ b/datamodel_code_generator/model/base.py
@@ -28,6 +28,7 @@ from datamodel_code_generator.types import DataType, chain_as_tuple
 TEMPLATE_DIR: Path = Path(__file__).parents[0] / 'template'
 
 OPTIONAL: str = 'Optional'
+UNION: str = 'Union'
 
 ALL_MODEL: str = '#all#'
 
@@ -64,6 +65,8 @@ class DataModelFieldBase(_BaseModel):
 
         if not type_hint:
             return OPTIONAL
+        elif self.required is False:
+            return f'{UNION}[{type_hint}, Unset]'
         elif self.nullable is not None:
             if self.nullable:
                 return f'{OPTIONAL}[{type_hint}]'

--- a/datamodel_code_generator/model/template/pydantic/BaseModel.jinja2
+++ b/datamodel_code_generator/model/template/pydantic/BaseModel.jinja2
@@ -24,7 +24,9 @@ class {{ class_name }}({{ base_class }}):
     {%- else %}
     {{ field.name }}: {{ field.type_hint }}
     {%- endif %}
-    {%- if not (field.required or (field.represented_default == 'None' and field.strip_default_none))
+    {%- if not field.required
+            %} = unset
+    {%- elif not (field.required or (field.represented_default == 'None' and field.strip_default_none))
             %} = {{ field.represented_default }}
     {%- endif -%}
     {%- endif %}

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -629,6 +629,7 @@ class Parser(ABC):
                 result += [str(self.imports), str(imports), '\n']
 
             code = dump_templates(models)
+            result += ["class Unset:", "    pass", "\n", "unset = Unset()"]
             result += [code]
 
             if self.dump_resolve_reference_action is not None:


### PR DESCRIPTION
> :warning: This PR isn't done yet. I'm creating it to get some feedback and help.

## Definition of Done

Add support for differentiating between "nullable" and "not-required" properties. For example, the following spec generates the following model:

```yaml
components:
  schemas:
    Pet:
      type: object
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
```

```py
from __future__ import annotations

from typing import Optional, Union

from pydantic import BaseModel


class Unset:
    pass


unset = Unset()


class Pet(BaseModel):
    id: int
    name: str
    tag: Union[str, Unset] = unset
```

## Missing Stuff

- CLI argument for opting into this new behavior.
- Adding the `typing.Union` import.