### PR TITLE
do not convert literal int to string

### DIFF
--- a/datamodel_code_generator/types.py
+++ b/datamodel_code_generator/types.py
@@ -75,7 +75,7 @@ class DataType(_BaseModel):
     is_dict: bool = False
     is_list: bool = False
     is_custom_type: bool = False
-    literals: List[Union[int, str]] = []
+    literals: 'List[Union[int, str]]' = []
     use_standard_collections: bool = False
     use_generic_container: bool = False
     alias: Optional[str] = None

--- a/tests/data/expected/main/main_openapi_enum_models_all/output.py
+++ b/tests/data/expected/main/main_openapi_enum_models_all/output.py
@@ -16,6 +16,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
     kind: Optional[Literal['dog', 'cat']] = None
     type: Optional[Literal['animal']] = None
+    number: Literal[1]
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/main/main_openapi_enum_models_as_literal_py37/output.py
+++ b/tests/data/expected/main/main_openapi_enum_models_as_literal_py37/output.py
@@ -17,6 +17,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
     kind: Optional[Literal['dog', 'cat']] = None
     type: Optional[Literal['animal']] = None
+    number: Literal[1]
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/main/main_openapi_enum_models_one/output.py
+++ b/tests/data/expected/main/main_openapi_enum_models_one/output.py
@@ -21,6 +21,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
     kind: Optional[Kind] = None
     type: Optional[Literal['animal']] = None
+    number: Literal[1]
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py36.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py36.py
@@ -13,12 +13,17 @@ class Type(Enum):
     animal = 'animal'
 
 
+class Number(Enum):
+    integer_1 = 1
+
+
 class Pet(BaseModel):
     id: int
     name: str
     tag: Optional[str] = None
     kind: Optional['Kind'] = None
     type: Optional['Type'] = None
+    number: 'Number'
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py37.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py37.py
@@ -15,12 +15,17 @@ class Type(Enum):
     animal = 'animal'
 
 
+class Number(Enum):
+    integer_1 = 1
+
+
 class Pet(BaseModel):
     id: int
     name: str
     tag: Optional[str] = None
     kind: Optional[Kind] = None
     type: Optional[Type] = None
+    number: Number
 
 
 class Pets(BaseModel):

--- a/tests/data/openapi/enum_models.yaml
+++ b/tests/data/openapi/enum_models.yaml
@@ -51,6 +51,7 @@ components:
       required:
         - id
         - name
+        - number
       properties:
         id:
           type: integer
@@ -65,6 +66,10 @@ components:
         type:
           type: string
           enum: [ 'animal' ]
+        number:
+          type: integer
+          enum: [ 1 ]
+
     Pets:
       type: array
       items:

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -2,6 +2,7 @@ import platform
 from pathlib import Path
 from typing import List, Optional
 
+import pydantic
 import pytest
 
 from datamodel_code_generator import PythonVersion
@@ -378,6 +379,9 @@ class UnknownTypeNumber(Enum):
     )
 
 
+@pytest.mark.skipif(
+    pydantic.VERSION < '1.9.0', reason='Require Pydantic version 1.9.0 or later '
+)
 def test_openapi_parser_parse_enum_models():
     parser = OpenAPIParser(
         Path(DATA_PATH / 'enum_models.yaml').read_text(),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import call
 
 import isort
+import pydantic
 import pytest
 from _pytest.capture import CaptureFixture
 from _pytest.tmpdir import TempdirFactory
@@ -1824,6 +1825,9 @@ def test_main_jsonschema_multiple_files_json_pointer():
         main()
 
 
+@pytest.mark.skipif(
+    pydantic.VERSION < '1.9.0', reason='Require Pydantic version 1.9.0 or later '
+)
 @freeze_time('2019-07-26')
 def test_main_openapi_enum_models_as_literal_one():
     with TemporaryDirectory() as output_dir:
@@ -1853,6 +1857,9 @@ def test_main_openapi_enum_models_as_literal_one():
         main()
 
 
+@pytest.mark.skipif(
+    pydantic.VERSION < '1.9.0', reason='Require Pydantic version 1.9.0 or later '
+)
 @freeze_time('2019-07-26')
 def test_main_openapi_enum_models_as_literal_all():
     with TemporaryDirectory() as output_dir:
@@ -1882,6 +1889,9 @@ def test_main_openapi_enum_models_as_literal_all():
         main()
 
 
+@pytest.mark.skipif(
+    pydantic.VERSION < '1.9.0', reason='Require Pydantic version 1.9.0 or later '
+)
 @freeze_time('2019-07-26')
 def test_main_openapi_enum_models_as_literal_py37(capsys):
     with TemporaryDirectory() as output_dir:


### PR DESCRIPTION
Fixes #688

Before, dependening on the exact version of libraries imported before
parsing `types.py`, literal integers would get converted to strings,
as python caches specified generics and considers
`Union[int, str] == Union[str, int]` to be true.