### PR TITLE
fix booleans literals being converted to int

### DIFF
--- a/datamodel_code_generator/types.py
+++ b/datamodel_code_generator/types.py
@@ -19,7 +19,7 @@ from typing import (
     Union,
 )
 
-from pydantic import create_model
+from pydantic import create_model, StrictBool
 
 from datamodel_code_generator import Protocol, runtime_checkable
 from datamodel_code_generator.format import PythonVersion
@@ -75,7 +75,7 @@ class DataType(_BaseModel):
     is_dict: bool = False
     is_list: bool = False
     is_custom_type: bool = False
-    literals: 'List[Union[int, str]]' = []
+    literals: 'List[Union[StrictBool, int, str]]' = []
     use_standard_collections: bool = False
     use_generic_container: bool = False
     alias: Optional[str] = None

--- a/tests/data/expected/main/main_openapi_enum_models_all/output.py
+++ b/tests/data/expected/main/main_openapi_enum_models_all/output.py
@@ -17,6 +17,7 @@ class Pet(BaseModel):
     kind: Optional[Literal['dog', 'cat']] = None
     type: Optional[Literal['animal']] = None
     number: Literal[1]
+    boolean: Literal[True]
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/main/main_openapi_enum_models_as_literal_py37/output.py
+++ b/tests/data/expected/main/main_openapi_enum_models_as_literal_py37/output.py
@@ -18,6 +18,7 @@ class Pet(BaseModel):
     kind: Optional[Literal['dog', 'cat']] = None
     type: Optional[Literal['animal']] = None
     number: Literal[1]
+    boolean: Literal[True]
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/main/main_openapi_enum_models_one/output.py
+++ b/tests/data/expected/main/main_openapi_enum_models_one/output.py
@@ -22,6 +22,7 @@ class Pet(BaseModel):
     kind: Optional[Kind] = None
     type: Optional[Literal['animal']] = None
     number: Literal[1]
+    boolean: Literal[True]
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py36.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py36.py
@@ -17,6 +17,10 @@ class Number(Enum):
     integer_1 = 1
 
 
+class Boolean(Enum):
+    boolean_True = True
+
+
 class Pet(BaseModel):
     id: int
     name: str
@@ -24,6 +28,7 @@ class Pet(BaseModel):
     kind: Optional['Kind'] = None
     type: Optional['Type'] = None
     number: 'Number'
+    boolean: 'Boolean'
 
 
 class Pets(BaseModel):

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py37.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_enum_models/output_py37.py
@@ -19,6 +19,10 @@ class Number(Enum):
     integer_1 = 1
 
 
+class Boolean(Enum):
+    boolean_True = True
+
+
 class Pet(BaseModel):
     id: int
     name: str
@@ -26,6 +30,7 @@ class Pet(BaseModel):
     kind: Optional[Kind] = None
     type: Optional[Type] = None
     number: Number
+    boolean: Boolean
 
 
 class Pets(BaseModel):

--- a/tests/data/openapi/enum_models.yaml
+++ b/tests/data/openapi/enum_models.yaml
@@ -52,6 +52,7 @@ components:
         - id
         - name
         - number
+        - boolean
       properties:
         id:
           type: integer
@@ -69,6 +70,9 @@ components:
         number:
           type: integer
           enum: [ 1 ]
+        boolean:
+          type: boolean
+          enum: [ true ]
 
     Pets:
       type: array


### PR DESCRIPTION
### Bug fix

When using `--enum-field-as-literal`, a boolean enum is being converted to a `Literal[1]` instead of a `Literal[True]`. The cause of the bug is because the literals field does not specify bool as a valid type https://github.com/koxudaxi/datamodel-code-generator/blob/eb8210e9ea5bbb1a9dc56fb5b200b3a6a4387903/datamodel_code_generator/types.py#L78

The fix is to simply add `StrictBool` to the union, `StrictBool` is used because pydantic automatically converts data type whenever possible, putting `List[Union[bool, int, str]]` would cause integer enums of 0 or 1 to be converted to boolean, and `List[Union[int, bool, str]]` would cause the opposite.

