### PR TITLE
Fix dict key for field-constraint

### DIFF
--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -670,12 +670,8 @@ class JsonSchemaParser(Parser):
                             is_dict=True,
                             dict_key=self.parse_item(
                                 f"{name}Key",
-                                JsonSchemaObject(
-                                    type="string",
-                                    pattern=k,
-                                    example=None,
-                                    examples=None,
-                                    default=None,
+                                JsonSchemaObject.parse_obj(
+                                    {"type": "string", "pattern": k}
                                 ),
                                 object_path,
                                 parent=item,

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -670,9 +670,15 @@ class JsonSchemaParser(Parser):
                             is_dict=True,
                             dict_key=self.parse_item(
                                 f"{name}Key",
-                                JsonSchemaObject(type="string", pattern=k),
+                                JsonSchemaObject(
+                                    type="string",
+                                    pattern=k,
+                                    example=None,
+                                    examples=None,
+                                    default=None,
+                                ),
                                 object_path,
-                                parent=item
+                                parent=item,
                             ),
                         )
                         for k, v in item.patternProperties.items()

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -668,9 +668,11 @@ class JsonSchemaParser(Parser):
                         self.data_type(
                             data_types=[self.parse_item(name, v, object_path)],
                             is_dict=True,
-                            dict_key=self.data_type_manager.get_data_type(
-                                Types.string,
-                                pattern=k,
+                            dict_key=self.parse_item(
+                                f"{name}Key",
+                                JsonSchemaObject(type="string", pattern=k),
+                                object_path,
+                                parent=item
                             ),
                         )
                         for k, v in item.patternProperties.items()


### PR DESCRIPTION
close #724 

Attempted to correct that constr was left in the key type of dictionary-style schemas when using the `--field-constraints` option command, so that it is properly represented in Field Constraints.