### PR TITLE
Add Python 3.10 to PythonVersion

### DIFF
--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -13,6 +13,7 @@ class PythonVersion(Enum):
     PY_37 = '3.7'
     PY_38 = '3.8'
     PY_39 = '3.9'
+    PY_310 = '3.10'
 
     @property
     def has_literal_type(self) -> bool:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,9 @@
+import sys
+
+from datamodel_code_generator.format import PythonVersion
+
+
+def test_python_version():
+    """Ensure that the python version used for the tests is properly listed"""
+
+    _ = PythonVersion("{}.{}".format(*sys.version_info[:2]))


### PR DESCRIPTION
This pull request adds Python 3.10 to the PythonVersion enum so that it can also be constructed for it.

There's also a simple test that has been added to ensure the enum covers the version of Python being tested.

The test has been put in its own file following the model of `test_imports.py`.

The test is not parametrized as it goals is to fail if a new version of Python is tested but has not yet been added to the enum.