### PR TITLE
Fix none related issues

### DIFF
--- a/datamodel_code_generator/model/base.py
+++ b/datamodel_code_generator/model/base.py
@@ -68,19 +68,19 @@ class DataModelFieldBase(_BaseModel):
 
         if not type_hint:
             return OPTIONAL
-        elif self.nullable is not None:
-            if self.nullable:
+        if self.nullable is not None:
+            if self.nullable and not type_hint.startswith('Optional'):
                 if self.data_type.use_union_operator:
                     return f'{type_hint} | None'
-                else:
-                    return f'{OPTIONAL}[{type_hint}]'
+                return f'{OPTIONAL}[{type_hint}]'
             return type_hint
-        elif self.required:
+        if self.required:
+            return type_hint
+        if type_hint.startswith('Optional'):
             return type_hint
         if self.data_type.use_union_operator:
             return f'{type_hint} | None'
-        else:
-            return f'{OPTIONAL}[{type_hint}]'
+        return f'{OPTIONAL}[{type_hint}]'
 
     @property
     def imports(self) -> Tuple[Import, ...]:

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -163,6 +163,12 @@ class JsonSchemaObject(BaseModel):
             return value.replace('#', '#/')
         return value
 
+    @validator('default')
+    def validate_default(cls, value: Any) -> Any:
+        if value == 'null':
+            return None
+        return value
+
     items: Union[List[JsonSchemaObject], JsonSchemaObject, None]
     uniqueItems: Optional[bool]
     type: Union[str, List[str], None]

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -324,6 +324,7 @@ def test_parse_one_of_object(source_obj, generated_classes):
                     "number_array": {"type": "array", "default": [1, 2, 3]},
                     "string_array": {"type": "array", "default": ["a", "b", "c"]},
                     "object": {"type": "object", "default": {"key": "value"}},
+                    "optional": {"type": ["number", "null"], "default": "null"},
                 },
             },
             """class Defaults(BaseModel):
@@ -333,7 +334,8 @@ def test_parse_one_of_object(source_obj, generated_classes):
     number_on_field: Optional[float] = Field(123, description='description')
     number_array: Optional[List] = [1, 2, 3]
     string_array: Optional[List] = ['a', 'b', 'c']
-    object: Optional[Dict[str, Any]] = {'key': 'value'}""",
+    object: Optional[Dict[str, Any]] = {'key': 'value'}
+    optional: Optional[float] = None""",
         )
     ],
 )


### PR DESCRIPTION
For a schema with a property that can be null and has a null default value, the pydantic model is not correctly generated.
For instance:
```json
{
  "properties": {
    "name": {
      "type": ["null", "string"],
      "default": "null"
    },
  },
  "type": "object"
}
```
is converted to
```python
class Model(BaseModel):
    name: Optional[Optional[str]] = 'null'
```
instead of
```python
class Model(BaseModel):
    name: Optional[str] = None
```

This PR addresses the default value conversion and the duplicated `Optional`.