### PR TITLE
fix(format): Fix PythonVersion.has_literal_type for Python 3.10.

### DIFF
--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -17,7 +17,7 @@ class PythonVersion(Enum):
 
     @property
     def has_literal_type(self) -> bool:
-        return self.value >= self.PY_38.value  # type: ignore
+        return self.value not in {self.PY_36.value, self.PY_37.value}  # type: ignore
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Since `PythonVersion` members are `str`, for `PythonVersion.PY_310` - `"3.10"`, the comparison `PY_310 >= self.PY_38.value` evaluated to `False`