### PR TITLE
Use format of object if provided

### DIFF
--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -430,7 +430,7 @@ class JsonSchemaParser(Parser):
         if isinstance(obj.type, list):
             return self.data_type(
                 data_types=[
-                    _get_data_type(t, 'default') for t in obj.type if t != 'null'
+                    _get_data_type(t, obj.format or 'default') for t in obj.type if t != 'null'
                 ],
                 is_optional='null' in obj.type,
             )

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -430,7 +430,9 @@ class JsonSchemaParser(Parser):
         if isinstance(obj.type, list):
             return self.data_type(
                 data_types=[
-                    _get_data_type(t, obj.format or 'default') for t in obj.type if t != 'null'
+                    _get_data_type(t, obj.format or 'default')
+                    for t in obj.type
+                    if t != 'null'
                 ],
                 is_optional='null' in obj.type,
             )


### PR DESCRIPTION
For example it fixes generating fields of type `Decimal` if format is set to `decimal` in JSON schema.

Following example
```json
{
  "properties": {
    "rate": {
      "type": "number",
      "format": "decimal"
    }
  }
}
```

will produce following field within pydantic model (after the fix):
```python
rate: Optional[Decimal] = None
```

previously it produced:
```python
rate: Optional[float] = None
```