### PR TITLE
Fix generating import statement code

### DIFF
--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -596,7 +596,7 @@ class Parser(ABC):
                         data_type.alias = f'{alias}.{name}'
 
                     if init:
-                        from_ += "."
+                        from_ = "." + from_
                     imports.append(Import(from_=from_, import_=import_, alias=alias))
 
             # extract inherited enum


### PR DESCRIPTION
Reference: #892

Code generator is appending a dot at end of module name in import statement, which is throwing an error with black. Maybe the dot can be prepended since it is indicating path heirarchy levels?