### PR TITLE
Add `$ref` support to schemas

### DIFF
--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -431,6 +431,8 @@ class OpenAPIParser(JsonSchemaParser):
                 path_parts = list(source.path.parts)
             with self.model_resolver.current_root_context(path_parts):
                 if OpenAPIScope.Schemas in self.open_api_scopes:
+                    if "$ref" in schemas:
+                        schemas = self._get_ref_body(schemas["$ref"])
                     for (
                         obj_name,
                         raw_obj,


### PR DESCRIPTION
Hi, I'm a newbie to OpenAPI and this generator.
This generator doesn't seem to have `$ref` resolving at `schemas`, thus I added.
I would help us keep Yamls separated and easier to manage.
