### PR TITLE
Remove union operator error when target-python is 3.9 or early version

### DIFF
--- a/datamodel_code_generator/__main__.py
+++ b/datamodel_code_generator/__main__.py
@@ -493,28 +493,12 @@ class Config(BaseModel):
     @root_validator()
     def validate_root(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values = cls._validate_use_annotated(values)
-        values = cls._validate_use_union_operator(values)
         return cls._validate_base_class(values)
 
     @classmethod
     def _validate_use_annotated(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if values.get('use_annotated'):
             values['field_constraints'] = True
-        return values
-
-    @classmethod
-    def _validate_use_union_operator(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if values.get('use_union_operator'):
-            target_python_version: PythonVersion = PythonVersion(
-                values.get('target_python_version', PythonVersion.PY_37.value)
-            )
-            if not target_python_version.has_union_operator:
-                if not values.get('disable_warnings'):
-                    warn(
-                        f"`--use-union-operator` can not be used with `--target-python_version` {target_python_version.value}.\n"
-                        f"`--target-python_version` {PythonVersion.PY_310.value} will be used."
-                    )
-                values['target_python_version'] = PythonVersion.PY_310
         return values
 
     @classmethod
@@ -586,7 +570,6 @@ class Config(BaseModel):
             f: getattr(args, f) for f in self.__fields__ if getattr(args, f) is not None
         }
         set_args = self._validate_use_annotated(set_args)
-        set_args = self._validate_use_union_operator(set_args)
         set_args = self._validate_base_class(set_args)
         parsed_args = self.parse_obj(set_args)
         for field_name in set_args:

--- a/datamodel_code_generator/__main__.py
+++ b/datamodel_code_generator/__main__.py
@@ -29,7 +29,6 @@ from typing import (
     cast,
 )
 from urllib.parse import ParseResult, urlparse
-from warnings import warn
 
 import argcomplete
 import black

--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -23,7 +23,7 @@ class PythonVersion(Enum):
         return self.value not in {self.PY_36.value, self.PY_37.value}  # type: ignore
 
     @property
-    def has_union_operator(self) -> bool:
+    def has_union_operator(self) -> bool:  # pragma: no cover
         return self.value not in {self.PY_36.value, self.PY_37.value, self.PY_38.value, self.PY_39.value}  # type: ignore
 
 

--- a/datamodel_code_generator/types.py
+++ b/datamodel_code_generator/types.py
@@ -385,13 +385,6 @@ class DataTypeManager(ABC):
                 " The version will be not supported in a future version"
             )
 
-        if (
-            use_union_operator and not python_version.has_union_operator
-        ):  # pragma: no cover
-            raise Exception(
-                "use_union_operator can not be used with target_python_version 3.9 or earlier.\n"
-                " The version will be not supported in a future version"
-            )
         if TYPE_CHECKING:
             self.data_type: Type[DataType]
         else:


### PR DESCRIPTION
`from __future__ import annotations` works fine for union operator.
target python 3.6 don't add `from __future__ import annotations` . But 3.6 is EOL, we can ignore the verison.