### PR TITLE
Exclude fields with default_factory from --use-default-kwarg

### DIFF
--- a/datamodel_code_generator/model/pydantic/base_model.py
+++ b/datamodel_code_generator/model/pydantic/base_model.py
@@ -69,7 +69,11 @@ class DataModelField(DataModelFieldBase):
     def field(self) -> Optional[str]:
         """for backwards compatibility"""
         result = str(self)
-        if self.use_default_kwarg and not result.startswith('Field(...'):
+        if (
+            self.use_default_kwarg
+            and not result.startswith('Field(...')
+            and not result.startswith('Field(default_factory=')
+        ):
             # Use `default=` for fields that have a default value so that type
             # checkers using @dataclass_transform can infer the field as
             # optional in __init__.


### PR DESCRIPTION
@dataclass_transform supports both default_factory and default on fields, so if default_factory is present no need to add default

Fixes #1146 