### PR TITLE
Update __all__ to expose needed types

### DIFF
--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -478,4 +478,12 @@ def generate(
             file.close()
 
 
-__all__ = ['DefaultPutDict', 'LiteralType', 'PythonVersion']
+__all__ = [
+    'DefaultPutDict',
+    'Error',
+    'InputFileType',
+    'InvalidClassNameError',
+    'LiteralType',
+    'PythonVersion',
+    'generate',
+]


### PR DESCRIPTION
The [docs](https://koxudaxi.github.io/datamodel-code-generator/using_as_module/) mention importing generate and InputFileType, so those should be listed in __all__. While we're here, also expose error types so users can write proper exception handlers.