### PR TITLE
(🎁) remove typed-ast dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1449,4 +1449,4 @@ http = ["httpx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "678e87f0717456439bed0c884b9d0a57baa08bf9de3e1b0e779e10992eeafff2"
+content-hash = "1cd7128d08b561c7f6d9b416b70fa3023c46250586c21d719af50aa59c7f6f47"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,6 @@ PySnooper = ">=0.4.1,<2.0.0"
 toml = ">=0.10.0,<1.0.0"
 genson = ">=1.2.1,<2.0"
 httpx = { version = "*", optional = true }
-typed-ast = [
-    {version = ">=1.4.2", python = "<3.9.8", optional = true},
-    {version = ">=1.5.0", python = ">=3.9.8", optional = true},
-]
 packaging = "*"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This is a follow up to #1222.

Typed-ast is a very painful dependency, I'm not sure why it is included in the dependencies to begin with. Modern versions of black and mypy no longer use typed-ast.