### PR TITLE
(🎁) reference config option to specify input type

### DIFF
--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -310,7 +310,7 @@ def generate(
                 else InputFileType.JsonSchema
             )
             print(
-                f'The input file type was determined to be: {input_file_type.value}',
+                inferred_message.format(input_file_type.value),
                 file=sys.stderr,
             )
         except:  # noqa
@@ -482,6 +482,11 @@ def generate(
         if file is not None:
             file.close()
 
+
+inferred_message = (
+    'The input file type was determined to be: {}\nThis can be specificied explicitly with the '
+    '`--input-file-type` option.'
+)
 
 __all__ = [
     'DefaultPutDict',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ from _pytest.capture import CaptureFixture
 from freezegun import freeze_time
 from packaging import version
 
-from datamodel_code_generator import InputFileType, chdir, generate
+from datamodel_code_generator import InputFileType, chdir, generate, inferred_message
 from datamodel_code_generator.__main__ import Exit, main
 
 try:
@@ -588,7 +588,7 @@ def test_main_no_file(capsys: CaptureFixture) -> None:
     assert (
         captured.out == (EXPECTED_MAIN_PATH / 'main_no_file' / 'output.py').read_text()
     )
-    assert captured.err == 'The input file type was determined to be: openapi\n'
+    assert captured.err == inferred_message.format('openapi') + '\n'
 
 
 def test_main_extra_template_data_config(capsys: CaptureFixture) -> None:
@@ -614,7 +614,7 @@ def test_main_extra_template_data_config(capsys: CaptureFixture) -> None:
             EXPECTED_MAIN_PATH / 'main_extra_template_data_config' / 'output.py'
         ).read_text()
     )
-    assert captured.err == 'The input file type was determined to be: openapi\n'
+    assert captured.err == inferred_message.format('openapi') + '\n'
 
 
 def test_main_custom_template_dir_old_style(capsys: CaptureFixture) -> None:
@@ -641,7 +641,7 @@ def test_main_custom_template_dir_old_style(capsys: CaptureFixture) -> None:
         captured.out
         == (EXPECTED_MAIN_PATH / 'main_custom_template_dir' / 'output.py').read_text()
     )
-    assert captured.err == 'The input file type was determined to be: openapi\n'
+    assert captured.err == inferred_message.format('openapi') + '\n'
 
 
 def test_main_custom_template_dir(capsys: CaptureFixture) -> None:
@@ -668,7 +668,7 @@ def test_main_custom_template_dir(capsys: CaptureFixture) -> None:
         captured.out
         == (EXPECTED_MAIN_PATH / 'main_custom_template_dir' / 'output.py').read_text()
     )
-    assert captured.err == 'The input file type was determined to be: openapi\n'
+    assert captured.err == inferred_message.format('openapi') + '\n'
 
 
 @freeze_time('2019-07-26')

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -6,6 +6,7 @@ import pytest
 from _pytest.capture import CaptureFixture
 from freezegun import freeze_time
 
+from datamodel_code_generator import inferred_message
 from datamodel_code_generator.__main__ import Exit, main
 
 try:
@@ -146,7 +147,7 @@ def test_main_no_file(capsys: CaptureFixture) -> None:
         == (EXPECTED_MAIN_KR_PATH / 'main_no_file' / 'output.py').read_text()
     )
 
-    assert captured.err == 'The input file type was determined to be: openapi\n'
+    assert captured.err == inferred_message.format('openapi') + '\n'
 
 
 def test_main_custom_template_dir(capsys: CaptureFixture) -> None:
@@ -175,7 +176,7 @@ def test_main_custom_template_dir(capsys: CaptureFixture) -> None:
             EXPECTED_MAIN_KR_PATH / 'main_custom_template_dir' / 'output.py'
         ).read_text()
     )
-    assert captured.err == 'The input file type was determined to be: openapi\n'
+    assert captured.err == inferred_message.format('openapi') + '\n'
 
 
 @freeze_time('2019-07-26')


### PR DESCRIPTION
As a follow up to #1248, this change improves the message to include the relevant config option