### PR TITLE
Eliminate the naming differences of model names and field names by the OS

### DIFF
--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -485,11 +485,7 @@ class Parser(ABC):
             yield Source(path=Path(), text=self.source)
         elif isinstance(self.source, Path):  # pragma: no cover
             if self.source.is_dir():
-                paths = (
-                    sorted(self.source.rglob('*'))
-                    if self.keep_model_order
-                    else self.source.rglob('*')
-                )
+                paths = sorted(self.source.rglob('*'), key=lambda x: x.name)
                 for path in paths:
                     if path.is_file():
                         yield Source.from_path(path, self.base_path, self.encoding)

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -485,8 +485,7 @@ class Parser(ABC):
             yield Source(path=Path(), text=self.source)
         elif isinstance(self.source, Path):  # pragma: no cover
             if self.source.is_dir():
-                paths = sorted(self.source.rglob('*'), key=lambda x: x.name)
-                for path in paths:
+                for path in sorted(self.source.rglob('*'), key=lambda p: p.name):
                     if path.is_file():
                         yield Source.from_path(path, self.base_path, self.encoding)
             else:


### PR DESCRIPTION
Resolve the differences in file loading caused by different operating systems, ensuring that files are loaded in the same order regardless of the OS, and making model names and field names idempotent.