### PR TITLE
Relax version constraint of prance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ pydantic =  [
     {extras = ["email"], version = ">=1.10.0,<3.0", python = "^3.11"}
 ]
 argcomplete = ">=1.10,<4.0"
-prance = ">=0.18.2,<1.0"
+prance = ">=0.18.2"
 openapi-spec-validator = ">=0.2.8,<=0.5.2"
 jinja2 = ">=2.10.1,<4.0"
 inflect = ">=4.1.0,<6.0"


### PR DESCRIPTION
This PR proposes relaxing the version constraint of prance (https://pypi.org/project/prance/). This is to avoid transitive dependency issues caused by prance: Currently, users can't use this fantastic datamodel-code-generator along with Python packages that require [packaging](https://pypi.org/project/packaging/) 22.0 or newer. 

One example of such packages is Black: Black 23.1.0 or newer require packaging 22.0 or newer ([commit](https://github.com/psf/black/commit/69ca0a4c7a365c5f5eea519a90980bab72cab764)) (NOTE: in organizations that adopt [monorepo](https://en.wikipedia.org/wiki/Monorepo), they often need to use a single centralized requirements file that contain Black and datamodel-code-generator that require different versions of packaging).

There are two reasons why the dependency issue happens:
- prance used a stricter version constraint of packaging: prance specified `packaging~=21.3` until prance 0.22.11.4.0. [This version constraint was relaxed for prance 23.06.21.0](https://github.com/RonnyPfannschmidt/prance/commit/0d8b32ad3b94f6ee5479dbe85390465452be4f1d#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R35). Note that [prance changed the versioning scheme recently](https://github.com/RonnyPfannschmidt/prance/commit/d96e9fc554797ac60c50cb31a59be95f1d07e8dd).
- Users of datamodel-code-generator can't install prance 23.06.21.0 because datamodel-code-generator doesn't allow to install prance 1.0 or newer.

A solution to the issues would be to relax the version constraint of prance so that users can install prance 23.06.21.0.