### PR TITLE
fix: Fix regex expression of hostname in pydantic v2

### DIFF
--- a/datamodel_code_generator/model/pydantic/types.py
+++ b/datamodel_code_generator/model/pydantic/types.py
@@ -84,7 +84,7 @@ def type_map_factory(
             strict=StrictTypes.str in strict_types,
             # https://github.com/horejsek/python-fastjsonschema/blob/61c6997a8348b8df9b22e029ca2ba35ef441fbb8/fastjsonschema/draft04.py#L31
             kwargs={
-                pattern_key: r"r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$'",
+                pattern_key: r"r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])\Z'",
                 **({'strict': True} if StrictTypes.str in strict_types else {}),
             },
         ),
@@ -155,7 +155,7 @@ class DataTypeManager(_DataTypeManager):
             use_union_operator,
         )
 
-        self.type_map: Dict[Types, DataType] = type_map_factory(
+        self.type_map: Dict[Types, DataType] = self.type_map_factory(
             self.data_type,
             strict_types=self.strict_types,
             pattern_key=self.PATTERN_KEY,
@@ -176,6 +176,14 @@ class DataTypeManager(_DataTypeManager):
             'maxLength': 'max_length',
             'pattern': self.PATTERN_KEY,
         }
+
+    def type_map_factory(
+        self,
+        data_type: Type[DataType],
+        strict_types: Sequence[StrictTypes],
+        pattern_key: str,
+    ) -> Dict[Types, DataType]:
+        return type_map_factory(data_type, strict_types, pattern_key)
 
     def transform_kwargs(
         self, kwargs: Dict[str, Any], filter_: Set[str]

--- a/datamodel_code_generator/model/pydantic/types.py
+++ b/datamodel_code_generator/model/pydantic/types.py
@@ -84,7 +84,7 @@ def type_map_factory(
             strict=StrictTypes.str in strict_types,
             # https://github.com/horejsek/python-fastjsonschema/blob/61c6997a8348b8df9b22e029ca2ba35ef441fbb8/fastjsonschema/draft04.py#L31
             kwargs={
-                pattern_key: r"r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])\Z'",
+                pattern_key: r"r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$'",
                 **({'strict': True} if StrictTypes.str in strict_types else {}),
             },
         ),

--- a/datamodel_code_generator/model/pydantic_v2/types.py
+++ b/datamodel_code_generator/model/pydantic_v2/types.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import ClassVar, Dict, Sequence, Type
 
 from datamodel_code_generator.model.pydantic import DataTypeManager as _DataTypeManager
+from datamodel_code_generator.model.pydantic.imports import IMPORT_CONSTR
+from datamodel_code_generator.types import DataType, StrictTypes, Types
 
 
 class DataTypeManager(_DataTypeManager):
     PATTERN_KEY: ClassVar[str] = 'pattern'
+
+    def type_map_factory(
+        self,
+        data_type: Type[DataType],
+        strict_types: Sequence[StrictTypes],
+        pattern_key: str,
+    ) -> Dict[Types, DataType]:
+        return {
+            **super().type_map_factory(data_type, strict_types, pattern_key),
+            Types.hostname: self.data_type.from_import(
+                IMPORT_CONSTR,
+                strict=StrictTypes.str in strict_types,
+                # https://github.com/horejsek/python-fastjsonschema/blob/61c6997a8348b8df9b22e029ca2ba35ef441fbb8/fastjsonschema/draft04.py#L31
+                kwargs={
+                    pattern_key: r"r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$'",
+                    **({'strict': True} if StrictTypes.str in strict_types else {}),
+                },
+            ),
+        }

--- a/tests/data/expected/main/main_pattern/output.py
+++ b/tests/data/expected/main/main_pattern/output.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, constr
 class Info(BaseModel):
     hostName: Optional[
         constr(
-            regex=r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])\Z'
+            regex=r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$'
         )
     ] = None
     arn: Optional[

--- a/tests/data/expected/main/main_pattern/output.py
+++ b/tests/data/expected/main/main_pattern/output.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, constr
 class Info(BaseModel):
     hostName: Optional[
         constr(
-            regex=r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$'
+            regex=r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])\Z'
         )
     ] = None
     arn: Optional[

--- a/tests/data/expected/main/main_pattern_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_pattern_pydantic_v2/output.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, constr
 class Info(BaseModel):
     hostName: Optional[
         constr(
-            pattern=r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])\Z'
+            pattern=r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])$'
         )
     ] = None
     arn: Optional[


### PR DESCRIPTION
The original regex causes errors when loading the generated model.

**To Reproduce**

Example schema:
```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Example",
  "type": "object",
  "properties": {
    "data": {
      "type": "string",
      "format": "hostname"
    }
  }
}
```

Used commandline:
```
$ datamodel-codegen --output-model-type pydantic_v2.BaseModel --input schema.json --output model.py
$ python3 -m model
```

Output:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/private/tmp/test/model.py", line 12, in <module>
    class Example(BaseModel):
  File "/private/tmp/test/env/lib/python3.11/site-packages/pydantic/_internal/_model_construction.py", line 174, in __new__
    complete_model_class(
  File "/private/tmp/test/env/lib/python3.11/site-packages/pydantic/_internal/_model_construction.py", line 449, in complete_model_class
    cls.__pydantic_validator__ = SchemaValidator(simplified_core_schema, core_config)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.SchemaError: Error building "model" validator:
  SchemaError: Error building "model-fields" validator:
  SchemaError: Field "data":
  SchemaError: Error building "default" validator:
  SchemaError: Error building "nullable" validator:
  SchemaError: Error building "str" validator:
  SchemaError: regex parse error:
    ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{0,61}[A-Za-z0-9])\Z
                                                                                                                        ^^
error: unrecognized escape sequence
```

