### PR TITLE
Fix issue #1461: Open API parameter models use base class if set

### DIFF
--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -479,7 +479,7 @@ class OpenAPIParser(JsonSchemaParser):
 
         if OpenAPIScope.Parameters in self.open_api_scopes and fields:
             self.results.append(
-                self.data_model_type(fields=fields, reference=reference)
+                self.data_model_type(fields=fields, reference=reference,custom_base_class=self.base_class)
             )
 
     def parse_operation(


### PR DESCRIPTION
As per #1461 this sets the base class for Open API parameter scopes to the base class supplied.