### PR TITLE
Give Pydantic V2 its own `dump_resolve_reference_action` to use `model_rebuild` not `update_forward_refs`

### DIFF
--- a/datamodel_code_generator/model/__init__.py
+++ b/datamodel_code_generator/model/__init__.py
@@ -38,7 +38,7 @@ def get_data_model_types(
             root_model=pydantic_v2.RootModel,
             field_model=pydantic_v2.DataModelField,
             data_type_manager=pydantic_v2.DataTypeManager,
-            dump_resolve_reference_action=pydantic.dump_resolve_reference_action,
+            dump_resolve_reference_action=pydantic_v2.dump_resolve_reference_action,
         )
     elif data_model_type == DataModelType.DataclassesDataclass:
         return DataModelSet(

--- a/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -9,11 +9,8 @@ from .root_model import RootModel
 from .types import DataTypeManager
 
 
-
 def dump_resolve_reference_action(class_names: Iterable[str]) -> str:
-    return '\n'.join(
-        f'{class_name}.model_rebuild()' for class_name in class_names
-    )
+    return '\n'.join(f'{class_name}.model_rebuild()' for class_name in class_names)
 
 
 class ConfigDict(_BaseModel):
@@ -25,4 +22,10 @@ class ConfigDict(_BaseModel):
     arbitrary_types_allowed: Optional[bool] = None
 
 
-__all__ = ['BaseModel', 'DataModelField', 'RootModel', 'dump_resolve_reference_action', 'DataTypeManager']
+__all__ = [
+    'BaseModel',
+    'DataModelField',
+    'RootModel',
+    'dump_resolve_reference_action',
+    'DataTypeManager',
+]

--- a/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Iterable, Optional
 
 from pydantic import BaseModel as _BaseModel
 
 from .base_model import BaseModel, DataModelField
 from .root_model import RootModel
 from .types import DataTypeManager
+
+
+
+def dump_resolve_reference_action(class_names: Iterable[str]) -> str:
+    return '\n'.join(
+        f'{class_name}.model_rebuild()' for class_name in class_names
+    )
 
 
 class ConfigDict(_BaseModel):
@@ -18,4 +25,4 @@ class ConfigDict(_BaseModel):
     arbitrary_types_allowed: Optional[bool] = None
 
 
-__all__ = ['BaseModel', 'DataModelField', 'RootModel', 'DataTypeManager']
+__all__ = ['BaseModel', 'DataModelField', 'RootModel', 'dump_resolve_reference_action', 'DataTypeManager']


### PR DESCRIPTION
- #1440
  - Explained here https://github.com/koxudaxi/datamodel-code-generator/issues/1440#issuecomment-1660077870
- Give Pydantic V2 its own `dump_resolve_reference_action`
- change it from 'update_forward_refs' to 'model_rebuild' to eliminate warning