### PR TITLE
Update openapi-spec-validator to 0.5.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ pydantic =  [
 ]
 argcomplete = ">=1.10,<4.0"
 prance = ">=0.18.2"
-openapi-spec-validator = ">=0.2.8,<=0.5.2"
+openapi-spec-validator = ">=0.2.8,<=0.5.7"
 jinja2 = ">=2.10.1,<4.0"
 inflect = ">=4.1.0,<6.0"
 black = ">=19.10b0"


### PR DESCRIPTION
This is causing a whole rat tail of transitive dependency issues for us. We can't install `data-diff` with [Apache Airflow 2.6.3 constraints](https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt), because it requires dbt-artifacts-parser, which requires datamodel-code-generator, which requires openapi-spec-validator, however aforementioned constraints pin this project to 0.5.7. Would be great if this dependency could be loosened up a bit.
Analogue to #1343.