### PR TITLE
Fix Pydantic V2 RootModel inheritance

### DIFF
--- a/datamodel_code_generator/model/pydantic_v2/root_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/root_model.py
@@ -8,3 +8,13 @@ from datamodel_code_generator.model.pydantic_v2.base_model import BaseModel
 class RootModel(BaseModel):
     TEMPLATE_FILE_PATH: ClassVar[str] = 'pydantic_v2/RootModel.jinja2'
     BASE_CLASS: ClassVar[str] = 'pydantic.RootModel'
+
+    def __init__(
+            self,
+            **kwargs,
+    ):
+        # Remove custom_base_class for Pydantic V2 models; behaviour is different from Pydantic V1 as it will not
+        # be treated as a root model. custom_base_class cannot both implement BaseModel and RootModel!
+        kwargs.pop("custom_base_class")
+
+        super().__init__(**kwargs)


### PR DESCRIPTION
In Pydantic V2, root models are defined by inheriting `RootModel` class and defining the `root` field. However, in Pydantic V1, root models were defined by inheriting the same `BaseModel` and declaring a `__root__` field.

Developers can set the `base_class` parameter to override the inherited class in the generated models. For Pydantic V1, this works fine in all cases as both Normal Models and Root Models were inheriting the same class. But for Pydantic V2 Root Models need to inherit a different class, so having the same `base_class` for both Normal Models and Root Models no longer works (as Root Models will be detected as Normal Models with a literal `root` field).

Considering how Enum's are being generated (by ignoring `base_class`), it seems like the best approach is the same one: for Pydantic V2 Root Models, ignore if `base_class` is set and always inherit `RootModel`. This PR applies this change for Pydantic V2 Root Models only.

Fixes #1435 (kinda)