### PR TITLE
Added protect namespace to Pydantic v2 ConfigDict

### DIFF
--- a/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -20,6 +20,7 @@ class ConfigDict(_BaseModel):
     allow_extra_fields: Optional[bool] = None
     frozen: Optional[bool] = None
     arbitrary_types_allowed: Optional[bool] = None
+    protected_namespaces: Optional[tuple[str, ...]] = None
 
 
 __all__ = [

--- a/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Tuple
 
 from pydantic import BaseModel as _BaseModel
 
@@ -20,7 +20,7 @@ class ConfigDict(_BaseModel):
     allow_extra_fields: Optional[bool] = None
     frozen: Optional[bool] = None
     arbitrary_types_allowed: Optional[bool] = None
-    protected_namespaces: Optional[tuple[str, ...]] = None
+    protected_namespaces: Optional[Tuple[str, ...]] = None
 
 
 __all__ = [


### PR DESCRIPTION
In Pydantic v2, a new "feature" was introduced that warned you if your field keys began with `model_`. However we have several fields that need to be named as such. So per [Pydantic docs](https://docs.pydantic.dev/2.1/usage/model_config/#protected-namespaces), this warning can be removed by setting `protected_namespaces = ()` to remove the default protected namespace `model_`.

This PR allows an `extra_data_template` JSON file such as the following to be passed into the datamodel-codgen tool and have the `protected_namespace` change actually take affect. I verified that the warnings disappear on my project after this change.

```
{
    "MyModelThatIsCausingWarnings": {
        "config": {
            "protected_namespaces": []
        }
    }
}
```