### PR TITLE
Add missing default=None

### DIFF
--- a/datamodel_code_generator/__main__.py
+++ b/datamodel_code_generator/__main__.py
@@ -291,6 +291,7 @@ arg_parser.add_argument(
     '--use-default-kwarg',
     action='store_true',
     help='Use `default=` instead of a positional argument for Fields that have default values.',
+    default=None,
 )
 
 arg_parser.add_argument(

--- a/datamodel_code_generator/__main__.py
+++ b/datamodel_code_generator/__main__.py
@@ -621,7 +621,7 @@ class Config(BaseModel):
     use_standard_collections: bool = False
     use_schema_description: bool = False
     use_field_description: bool = False
-    use_default_kwarg: bool = True
+    use_default_kwarg: bool = False
     reuse_model: bool = False
     encoding: str = DEFAULT_ENCODING
     enum_field_as_literal: Optional[LiteralType] = None


### PR DESCRIPTION
On issue https://github.com/koxudaxi/datamodel-code-generator/issues/1027 there was a problem with CLI option defaults overriding pyproject.toml. Here's another one, `use-default-kwarg`