### PR TITLE
Fix class Field generated when array with name fields with oneOf inside

### DIFF
--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -1035,12 +1035,12 @@ class Parser(ABC):
             for i in import_
         }
         for model in models:
-            if model.class_name not in imported_names:
+            if model.class_name not in imported_names:  # pragma: no cover
                 continue
-            if model in unused_models:
+            if model in unused_models:  # pragma: no cover
                 continue
 
-            model.reference.name = scoped_model_resolver.add(
+            model.reference.name = scoped_model_resolver.add(  # pragma: no cover
                 path=get_special_path('imported_name', model.path.split('/')),
                 original_name=model.reference.name,
                 unique=True,

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -43,6 +43,13 @@ from datamodel_code_generator.reference import ModelResolver, Reference
 from datamodel_code_generator.types import DataType, DataTypeManager, StrictTypes
 from datamodel_code_generator.util import Protocol, runtime_checkable
 
+SPECIAL_PATH_FORMAT: str = '#-datamodel-code-generator-#-{}-#-special-#'
+
+
+def get_special_path(keyword: str, path: List[str]) -> List[str]:
+    return [*path, SPECIAL_PATH_FORMAT.format(keyword)]
+
+
 escape_characters = str.maketrans(
     {
         '\\': r'\\',
@@ -1013,6 +1020,33 @@ class Parser(ABC):
                 if model_field.nullable is not True:  # pragma: no cover
                     model_field.nullable = False
 
+    def __change_imported_model_name(
+        self,
+        models: List[DataModel],
+        unused_models: List[DataModel],
+        imports: Imports,
+        scoped_model_resolver: ModelResolver,
+    ) -> None:
+        imported_names = {
+            imports.alias[from_][i]
+            if i in imports.alias[from_] and i != imports.alias[from_][i]
+            else i
+            for from_, import_ in imports.items()
+            for i in import_
+        }
+        for model in models:
+            if model.class_name not in imported_names:
+                continue
+            if model in unused_models:
+                continue
+
+            model.reference.name = scoped_model_resolver.add(
+                path=get_special_path('imported_name', model.path),
+                original_name=model.reference.name,
+                unique=True,
+                class_name=True,
+            ).name
+
     def parse(
         self,
         with_import: Optional[bool] = True,
@@ -1112,6 +1146,9 @@ class Parser(ABC):
             self.__override_required_field(models)
             self.__sort_models(models, imports)
             self.__set_one_literal_on_default(models)
+            self.__change_imported_model_name(
+                models, unused_models, imports, scoped_model_resolver
+            )
 
             processed_models.append(Processed(module, models, init, imports))
 

--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -1041,7 +1041,7 @@ class Parser(ABC):
                 continue
 
             model.reference.name = scoped_model_resolver.add(
-                path=get_special_path('imported_name', model.path),
+                path=get_special_path('imported_name', model.path.split('/')),
                 original_name=model.reference.name,
                 unique=True,
                 class_name=True,

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -44,9 +44,11 @@ from datamodel_code_generator.model.base import UNDEFINED, get_module_name
 from datamodel_code_generator.model.enum import Enum
 from datamodel_code_generator.parser import DefaultPutDict, LiteralType
 from datamodel_code_generator.parser.base import (
+    SPECIAL_PATH_FORMAT,
     Parser,
     Source,
     escape_characters,
+    get_special_path,
     title_to_class_name,
 )
 from datamodel_code_generator.reference import ModelType, Reference, is_url
@@ -90,13 +92,6 @@ def get_model_by_path(
     raise NotImplementedError(  # pragma: no cover
         f'Does not support json pointer to array. schema={schema}, key={keys}'
     )
-
-
-SPECIAL_PATH_FORMAT: str = '#-datamodel-code-generator-#-{}-#-special-#'
-
-
-def get_special_path(keyword: str, path: List[str]) -> List[str]:
-    return [*path, SPECIAL_PATH_FORMAT.format(keyword)]
 
 
 json_schema_data_formats: Dict[str, Dict[str, Types]] = {

--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -37,11 +37,11 @@ from datamodel_code_generator import (
 )
 from datamodel_code_generator.model import DataModel, DataModelFieldBase
 from datamodel_code_generator.model import pydantic as pydantic_model
+from datamodel_code_generator.parser.base import get_special_path
 from datamodel_code_generator.parser.jsonschema import (
     JsonSchemaObject,
     JsonSchemaParser,
     get_model_by_path,
-    get_special_path,
 )
 from datamodel_code_generator.reference import snake_to_upper_camel
 from datamodel_code_generator.types import (

--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -277,6 +277,7 @@ class FieldNameResolver:
 class PydanticFieldNameResolver(FieldNameResolver):
     @classmethod
     def _validate_field_name(cls, field_name: str) -> bool:
+        # TODO: Support Pydantic V2
         return not hasattr(BaseModel, field_name)
 
 

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_array_called_fields_with_oneOf_items/output.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_array_called_fields_with_oneOf_items/output.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class FieldItem(BaseModel):
+    a: Optional[str] = None
+
+
+class FieldItem1(BaseModel):
+    b: Optional[str] = Field(None, regex='^[a-zA-Z_]+$')
+
+
+class BadSchema(BaseModel):
+    fields: Optional[List[Union[FieldItem, FieldItem1]]] = None

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_array_called_fields_with_oneOf_items/output.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_array_called_fields_with_oneOf_items/output.py
@@ -5,13 +5,13 @@ from typing import List, Optional, Union
 from pydantic import BaseModel, Field
 
 
-class FieldItem(BaseModel):
+class FieldModel(BaseModel):
     a: Optional[str] = None
 
 
-class FieldItem1(BaseModel):
+class Field1(BaseModel):
     b: Optional[str] = Field(None, regex='^[a-zA-Z_]+$')
 
 
 class BadSchema(BaseModel):
-    fields: Optional[List[Union[FieldItem, FieldItem1]]] = None
+    fields: Optional[List[Union[FieldModel, Field1]]] = None

--- a/tests/data/openapi/array_called_fields_with_oneOf_items.yaml
+++ b/tests/data/openapi/array_called_fields_with_oneOf_items.yaml
@@ -1,0 +1,19 @@
+# input.yaml
+components:
+  schemas:
+    BadSchema:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            oneOf:
+            - type: object
+              properties:
+                a:
+                  type: string
+            - type: object
+              properties:
+                b:
+                  type: string
+                  pattern: "^[a-zA-Z_]+$"

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -730,6 +730,26 @@ def test_openapi_parser_with_query_parameters():
         ).read_text()
     )
 
+def test_openapi_parser_array_called_fields_with_oneOf_items():
+    parser = OpenAPIParser(
+        data_model_field_type=DataModelFieldBase,
+        source=Path(DATA_PATH / 'array_called_fields_with_oneOf_items.yaml'),
+        openapi_scopes=[
+            OpenAPIScope.Parameters,
+            OpenAPIScope.Schemas,
+            OpenAPIScope.Paths,
+        ],
+    )
+    assert (
+        parser.parse()
+        == (
+            EXPECTED_OPEN_API_PATH
+            / 'openapi_parser_parse_array_called_fields_with_oneOf_items'
+            / 'output.py'
+        ).read_text()
+    )
+
+
 
 def test_additional_imports():
     """Test that additional imports are inside imports container."""

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -730,6 +730,7 @@ def test_openapi_parser_with_query_parameters():
         ).read_text()
     )
 
+
 def test_openapi_parser_array_called_fields_with_oneOf_items():
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
@@ -748,7 +749,6 @@ def test_openapi_parser_array_called_fields_with_oneOf_items():
             / 'output.py'
         ).read_text()
     )
-
 
 
 def test_additional_imports():

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -7,6 +7,7 @@ import pytest
 
 from datamodel_code_generator import OpenAPIScope, PythonVersion
 from datamodel_code_generator.model import DataModelFieldBase
+from datamodel_code_generator.model.pydantic import DataModelField
 from datamodel_code_generator.parser.base import dump_templates
 from datamodel_code_generator.parser.jsonschema import JsonSchemaObject
 from datamodel_code_generator.parser.openapi import OpenAPIParser
@@ -733,13 +734,14 @@ def test_openapi_parser_with_query_parameters():
 
 def test_openapi_parser_array_called_fields_with_oneOf_items():
     parser = OpenAPIParser(
-        data_model_field_type=DataModelFieldBase,
+        data_model_field_type=DataModelField,
         source=Path(DATA_PATH / 'array_called_fields_with_oneOf_items.yaml'),
         openapi_scopes=[
             OpenAPIScope.Parameters,
             OpenAPIScope.Schemas,
             OpenAPIScope.Paths,
         ],
+        field_constraints=True,
     )
     assert (
         parser.parse()

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 import pydantic
 import pytest
+from packaging import version
 
 from datamodel_code_generator import OpenAPIScope, PythonVersion
 from datamodel_code_generator.model import DataModelFieldBase
@@ -732,6 +733,10 @@ def test_openapi_parser_with_query_parameters():
     )
 
 
+@pytest.mark.skipif(
+    version.parse(pydantic.VERSION) < version.parse('2.9.0'),
+    reason='Require Pydantic version 2.0.0 or later ',
+)
 def test_openapi_parser_array_called_fields_with_oneOf_items():
     parser = OpenAPIParser(
         data_model_field_type=DataModelField,

--- a/tests/test_infer_input_type.py
+++ b/tests/test_infer_input_type.py
@@ -36,6 +36,7 @@ def test_infer_input_type():
                 'root_model.yaml',
                 'json_pointer.yaml',
                 'const.json',
+                'array_called_fields_with_oneOf_items.yaml',
             )
         ):
             continue


### PR DESCRIPTION
Adds a test to reproduce https://github.com/koxudaxi/datamodel-code-generator/issues/1508

The input yaml is the same as from the issue, and for the output I took a guess at what correct would be based on what the output is when I change the name of `components.schemas.BadSchema.properties.fields` to `fieldz`, which was:

```python
class FieldzItem(BaseModel):
    a: Optional[str] = None


class FieldzItem1(BaseModel):
    b: Optional[str] = Field(None, regex='^[a-zA-Z_]+$')


class BadSchema(BaseModel):
    fieldz: Optional[List[Union[FieldzItem, FieldzItem1]]] = None
```