### PR TITLE
fix: add type parameters to generic RootModel

### DIFF
--- a/datamodel_code_generator/model/template/pydantic_v2/RootModel.jinja2
+++ b/datamodel_code_generator/model/template/pydantic_v2/RootModel.jinja2
@@ -1,7 +1,16 @@
+{%- macro get_type_hint(_fields) -%}
+{%- if _fields -%}
+{#There will only ever be a single field for RootModel#}
+{{- _fields[0].type_hint}}
+{%- endif -%}
+{%- endmacro -%}
+
+
 {% for decorator in decorators -%}
 {{ decorator }}
 {% endfor -%}
-class {{ class_name }}({{ base_class }}):{% if comment is defined %}  # {{ comment }}{% endif %}
+
+class {{ class_name }}({{ base_class }}[{{get_type_hint(fields)}}]):{% if comment is defined %}  # {{ comment }}{% endif %}
 {%- if description %}
     """
     {{ description | indent(4) }}

--- a/tests/data/expected/main/allow_extra_fields_pydantic_v2/output.py
+++ b/tests/data/expected/main/allow_extra_fields_pydantic_v2/output.py
@@ -18,7 +18,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     root: List[Pet]
 
 
@@ -31,15 +31,15 @@ class User(BaseModel):
     tag: Optional[str] = None
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     root: List[str]
 
 
@@ -69,7 +69,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     root: List[Api]
 
 

--- a/tests/data/expected/main/allow_population_by_field_name_pydantic_v2/output.py
+++ b/tests/data/expected/main/allow_population_by_field_name_pydantic_v2/output.py
@@ -18,7 +18,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     model_config = ConfigDict(
         populate_by_name=True,
     )
@@ -34,21 +34,21 @@ class User(BaseModel):
     tag: Optional[str] = None
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     model_config = ConfigDict(
         populate_by_name=True,
     )
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     model_config = ConfigDict(
         populate_by_name=True,
     )
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     model_config = ConfigDict(
         populate_by_name=True,
     )
@@ -81,7 +81,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     model_config = ConfigDict(
         populate_by_name=True,
     )

--- a/tests/data/expected/main/enable_faux_immutability_pydantic_v2/output.py
+++ b/tests/data/expected/main/enable_faux_immutability_pydantic_v2/output.py
@@ -18,7 +18,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     model_config = ConfigDict(
         frozen=True,
     )
@@ -34,21 +34,21 @@ class User(BaseModel):
     tag: Optional[str] = None
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     model_config = ConfigDict(
         frozen=True,
     )
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     model_config = ConfigDict(
         frozen=True,
     )
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     model_config = ConfigDict(
         frozen=True,
     )
@@ -81,7 +81,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     model_config = ConfigDict(
         frozen=True,
     )

--- a/tests/data/expected/main/main_extra_template_data_config_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_extra_template_data_config_pydantic_v2/output.py
@@ -18,7 +18,7 @@ class Pet(BaseModel):  # 1 2, 1 2, this is just a pet
     tag: Optional[str] = None
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     root: List[Pet]
 
 
@@ -28,15 +28,15 @@ class User(BaseModel):
     tag: Optional[str] = None
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     root: List[str]
 
 
@@ -60,7 +60,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     root: List[Api]
 
 

--- a/tests/data/expected/main/main_jsonschema_custom_type_path_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_jsonschema_custom_type_path_pydantic_v2/output.py
@@ -29,7 +29,7 @@ class Person(BaseModel):
     comment: Optional[MultipleLineString] = None
 
 
-class RootedCustomType(RootModel):
+class RootedCustomType(RootModel[SpecialString]):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )

--- a/tests/data/expected/main/main_openapi_custom_id_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_openapi_custom_id_pydantic_v2/output.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, RootModel
 
 
-class CustomId(RootModel):
+class CustomId(RootModel[UUID]):
     root: UUID = Field(..., description='My custom ID')
 
 

--- a/tests/data/expected/main/main_openapi_custom_id_pydantic_v2_custom_base/output.py
+++ b/tests/data/expected/main/main_openapi_custom_id_pydantic_v2_custom_base/output.py
@@ -12,7 +12,7 @@ from pydantic import Field, RootModel
 from custom_base import Base
 
 
-class CustomId(RootModel):
+class CustomId(RootModel[UUID]):
     root: UUID = Field(..., description='My custom ID')
 
 

--- a/tests/data/expected/main/main_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_pydantic_v2/output.py
@@ -15,7 +15,7 @@ class Pet(BaseModel):
     tag: Optional[str] = None
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     root: List[Pet]
 
 
@@ -25,15 +25,15 @@ class User(BaseModel):
     tag: Optional[str] = None
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     root: List[str]
 
 
@@ -57,7 +57,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     root: List[Api]
 
 

--- a/tests/data/expected/main/main_with_field_constraints_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_with_field_constraints_pydantic_v2/output.py
@@ -15,19 +15,19 @@ class Pet(BaseModel):
     tag: Optional[str] = Field(None, max_length=64)
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     root: List[Pet] = Field(..., max_length=10, min_length=1)
 
 
-class UID(RootModel):
+class UID(RootModel[int]):
     root: int = Field(..., ge=0)
 
 
-class Phone(RootModel):
+class Phone(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
-class FaxItem(RootModel):
+class FaxItem(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
@@ -44,15 +44,15 @@ class User(BaseModel):
     rating: Optional[float] = Field(None, gt=0.0, le=5.0)
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     root: List[str]
 
 
@@ -76,7 +76,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     root: List[Api]
 
 

--- a/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_generic_container_types/output.py
+++ b/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_generic_container_types/output.py
@@ -15,19 +15,19 @@ class Pet(BaseModel):
     tag: Optional[str] = Field(None, max_length=64)
 
 
-class Pets(RootModel):
+class Pets(RootModel[Sequence[Pet]]):
     root: Sequence[Pet] = Field(..., max_length=10, min_length=1)
 
 
-class UID(RootModel):
+class UID(RootModel[int]):
     root: int = Field(..., ge=0)
 
 
-class Phone(RootModel):
+class Phone(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
-class FaxItem(RootModel):
+class FaxItem(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
@@ -44,15 +44,15 @@ class User(BaseModel):
     rating: Optional[float] = Field(None, gt=0.0, le=5.0)
 
 
-class Users(RootModel):
+class Users(RootModel[Sequence[User]]):
     root: Sequence[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[Sequence[str]]):
     root: Sequence[str]
 
 
@@ -76,7 +76,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[Sequence[Api]]):
     root: Sequence[Api]
 
 

--- a/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_generic_container_types_set/output.py
+++ b/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_generic_container_types_set/output.py
@@ -15,19 +15,19 @@ class Pet(BaseModel):
     tag: Optional[str] = Field(None, max_length=64)
 
 
-class Pets(RootModel):
+class Pets(RootModel[FrozenSet[Pet]]):
     root: FrozenSet[Pet] = Field(..., max_length=10, min_length=1)
 
 
-class UID(RootModel):
+class UID(RootModel[int]):
     root: int = Field(..., ge=0)
 
 
-class Phone(RootModel):
+class Phone(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
-class FaxItem(RootModel):
+class FaxItem(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
@@ -44,15 +44,15 @@ class User(BaseModel):
     rating: Optional[float] = Field(None, gt=0.0, le=5.0)
 
 
-class Users(RootModel):
+class Users(RootModel[Sequence[User]]):
     root: Sequence[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[Sequence[str]]):
     root: Sequence[str]
 
 
@@ -76,7 +76,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[Sequence[Api]]):
     root: Sequence[Api]
 
 

--- a/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_standard_collections/output.py
+++ b/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_standard_collections/output.py
@@ -15,19 +15,19 @@ class Pet(BaseModel):
     tag: Optional[str] = Field(None, max_length=64)
 
 
-class Pets(RootModel):
+class Pets(RootModel[list[Pet]]):
     root: list[Pet] = Field(..., max_length=10, min_length=1)
 
 
-class UID(RootModel):
+class UID(RootModel[int]):
     root: int = Field(..., ge=0)
 
 
-class Phone(RootModel):
+class Phone(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
-class FaxItem(RootModel):
+class FaxItem(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
@@ -44,15 +44,15 @@ class User(BaseModel):
     rating: Optional[float] = Field(None, gt=0.0, le=5.0)
 
 
-class Users(RootModel):
+class Users(RootModel[list[User]]):
     root: list[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[list[str]]):
     root: list[str]
 
 
@@ -76,7 +76,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[list[Api]]):
     root: list[Api]
 
 

--- a/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_standard_collections_set/output.py
+++ b/tests/data/expected/main/main_with_field_constraints_pydantic_v2_use_standard_collections_set/output.py
@@ -15,19 +15,19 @@ class Pet(BaseModel):
     tag: Optional[str] = Field(None, max_length=64)
 
 
-class Pets(RootModel):
+class Pets(RootModel[set[Pet]]):
     root: set[Pet] = Field(..., max_length=10, min_length=1)
 
 
-class UID(RootModel):
+class UID(RootModel[int]):
     root: int = Field(..., ge=0)
 
 
-class Phone(RootModel):
+class Phone(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
-class FaxItem(RootModel):
+class FaxItem(RootModel[str]):
     root: str = Field(..., min_length=3)
 
 
@@ -44,15 +44,15 @@ class User(BaseModel):
     rating: Optional[float] = Field(None, gt=0.0, le=5.0)
 
 
-class Users(RootModel):
+class Users(RootModel[list[User]]):
     root: list[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[list[str]]):
     root: list[str]
 
 
@@ -76,7 +76,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[list[Api]]):
     root: list[Api]
 
 

--- a/tests/data/expected/main/main_without_field_constraints_pydantic_v2/output.py
+++ b/tests/data/expected/main/main_without_field_constraints_pydantic_v2/output.py
@@ -15,15 +15,15 @@ class Pet(BaseModel):
     tag: Optional[constr(max_length=64)] = None
 
 
-class Pets(RootModel):
+class Pets(RootModel[List[Pet]]):
     root: List[Pet] = Field(..., max_length=10, min_length=1)
 
 
-class UID(RootModel):
+class UID(RootModel[conint(ge=0)]):
     root: conint(ge=0)
 
 
-class Phone(RootModel):
+class Phone(RootModel[constr(min_length=3)]):
     root: constr(min_length=3)
 
 
@@ -40,15 +40,15 @@ class User(BaseModel):
     rating: Optional[confloat(le=5.0, gt=0.0)] = None
 
 
-class Users(RootModel):
+class Users(RootModel[List[User]]):
     root: List[User]
 
 
-class Id(RootModel):
+class Id(RootModel[str]):
     root: str
 
 
-class Rules(RootModel):
+class Rules(RootModel[List[str]]):
     root: List[str]
 
 
@@ -72,7 +72,7 @@ class Api(BaseModel):
     )
 
 
-class Apis(RootModel):
+class Apis(RootModel[List[Api]]):
     root: List[Api]
 
 

--- a/tests/model/pydantic_v2/test_root_model.py
+++ b/tests/model/pydantic_v2/test_root_model.py
@@ -31,11 +31,14 @@ def test_root_model():
     assert root_model.base_class == 'RootModel'
     assert root_model.custom_base_class is None
     assert root_model.render() == (
-        'class TestRootModel(RootModel):\n' "    root: Optional[str] = 'abc'"
+        'class TestRootModel(RootModel[Optional[str]]):\n'
+        "    root: Optional[str] = 'abc'"
     )
 
 
-def test_root_model_custom_base_class():
+def test_root_model_custom_base_class_is_ignored():
+    """Verify that passing a custom_base_class is ignored."""
+
     root_model = RootModel(
         custom_base_class='test.Test',
         fields=[
@@ -61,7 +64,8 @@ def test_root_model_custom_base_class():
     ]
 
     assert root_model.base_class == 'RootModel'
-    assert root_model.custom_base_class is None
+    assert root_model.custom_base_class is None  # make sure it's ignored
     assert root_model.render() == (
-        'class TestRootModel(RootModel):\n' "    root: Optional[str] = 'abc'"
+        'class TestRootModel(RootModel[Optional[str]]):\n'
+        "    root: Optional[str] = 'abc'"
     )


### PR DESCRIPTION

Closes: https://github.com/koxudaxi/datamodel-code-generator/issues/1491

and by extension it fixes mypy's error:

`Missing type parameters for generic type 'RootModel'`

It's not clear from the [pydantic documentation](https://docs.pydantic.dev/dev-v2/usage/models/#rootmodel-and-custom-root-types) whether they force the user to use declare the type twice. They have one example with `Pets(RootModel[List[str]])` and one with  `Pets(RootModel)`. Though `mypy` seems to be in favor of the double type hint style.