### PR TITLE
Ignore broken pydantic version 2.4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1711,4 +1711,4 @@ http = ["httpx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "973b0a0560f4c499c6122a19fc66182628c1b360142244a334b779cea84d041a"
+content-hash = "c4c3b2b6aca921636859f4ee23ef5c301063a3ec85ab5c68f1b15ddb06c81d31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ datamodel-codegen = "datamodel_code_generator.__main__:main"
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic =  [
-    {extras = ["email"], version = ">=1.5.1,<3.0", python = "<3.10"},
-    {extras = ["email"], version = ">=1.9.0,<3.0", python = "~3.10"},
-    {extras = ["email"], version = ">=1.10.0,<3.0", python = "^3.11"}
+    {extras = ["email"], version = ">=1.5.1,<3.0,!=2.4.0", python = "<3.10"},
+    {extras = ["email"], version = ">=1.9.0,<3.0,!=2.4.0", python = "~3.10"},
+    {extras = ["email"], version = ">=1.10.0,<3.0,!=2.4.0", python = "^3.11"}
 ]
 argcomplete = ">=1.10,<4.0"
 prance = ">=0.18.2"


### PR DESCRIPTION
Changed to exclude pydantic 2.4.0 from dependencies because it has bugs

Release:
- https://github.com/pydantic/pydantic/releases/tag/v2.4.1

PR: 
-  https://github.com/pydantic/pydantic/pull/7624
Issue:
-  https://github.com/pydantic/pydantic/issues/7611

# Related Issues
https://github.com/koxudaxi/datamodel-code-generator/issues/1570
https://github.com/koxudaxi/datamodel-code-generator/issues/1571