### PR TITLE
Fix generation of nullable array items

### DIFF
--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -590,6 +590,12 @@ class JsonSchemaParser(Parser):
                 **obj.dict() if not self.field_constraints else {},
             )
 
+        if obj.nullable and self.strict_nullable:
+            if isinstance(obj.type, list) and 'null' not in obj.type:
+                obj.type.append('null')
+            elif isinstance(obj.type, str) and obj.type != 'null':
+                obj.type = [obj.type, 'null']
+
         if isinstance(obj.type, list):
             return self.data_type(
                 data_types=[

--- a/tests/data/expected/main/main_typed_dict_nullable_strict_nullable/output.py
+++ b/tests/data/expected/main/main_typed_dict_nullable_strict_nullable/output.py
@@ -29,8 +29,8 @@ class User(TypedDict):
 class Api(TypedDict):
     apiKey: NotRequired[str]
     apiVersionNumber: NotRequired[str]
-    apiUrl: NotRequired[str]
-    apiDocumentationUrl: NotRequired[str]
+    apiUrl: NotRequired[Optional[str]]
+    apiDocumentationUrl: NotRequired[Optional[str]]
 
 
 Apis = Optional[List[Api]]


### PR DESCRIPTION
This fixes an issue where array items are not generated as `Optional`, despite adding the `nullable: true` property: https://github.com/koxudaxi/datamodel-code-generator/issues/1496
I'm not sure if this is the best way to fix it, but it works well for me.