### PR TITLE
Fix `--remove-special-field-name-prefix` + fields (e.g. enum members) starting with numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,8 +377,8 @@ Field customization:
                         only can be used with --snake-case-field (default: `_`
                         )
   --remove-special-field-name-prefix
-                        Remove field name prefix when first character can't be
-                        used as Python field name
+                        Remove field name prefix if it has a special meaning
+                        e.g. underscores
   --snake-case-field    Change camel-case field name to snake-case
   --special-field-name-prefix SPECIAL_FIELD_NAME_PREFIX
                         Set field name prefix when first character can't be

--- a/datamodel_code_generator/arguments.py
+++ b/datamodel_code_generator/arguments.py
@@ -297,7 +297,7 @@ field_options.add_argument(
 )
 field_options.add_argument(
     '--remove-special-field-name-prefix',
-    help="Remove field name prefix when first character can't be used as Python field name",
+    help="Remove field name prefix if it has a special meaning e.g. underscores",
     action='store_true',
     default=None,
 )

--- a/datamodel_code_generator/arguments.py
+++ b/datamodel_code_generator/arguments.py
@@ -297,7 +297,7 @@ field_options.add_argument(
 )
 field_options.add_argument(
     '--remove-special-field-name-prefix',
-    help="Remove field name prefix if it has a special meaning e.g. underscores",
+    help='Remove field name prefix if it has a special meaning e.g. underscores',
     action='store_true',
     default=None,
 )

--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -229,7 +229,7 @@ class FieldNameResolver:
 
         name = re.sub(r'[¹²³⁴⁵⁶⁷⁸⁹]|\W', '_', name)
         if name[0].isnumeric():
-            name = f'{self.special_field_name_prefix}{name}'
+            name = f'{self.special_field_name_prefix}_{name}'
 
         # We should avoid having a field begin with an underscore, as it
         # causes pydantic to consider it as private

--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -229,7 +229,7 @@ class FieldNameResolver:
 
         name = re.sub(r'[¹²³⁴⁵⁶⁷⁸⁹]|\W', '_', name)
         if name[0].isnumeric():
-            name = f"{self.special_field_name_prefix}{name}"
+            name = f'{self.special_field_name_prefix}{name}'
 
         # We should avoid having a field begin with an underscore, as it
         # causes pydantic to consider it as private

--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -229,7 +229,7 @@ class FieldNameResolver:
 
         name = re.sub(r'[¹²³⁴⁵⁶⁷⁸⁹]|\W', '_', name)
         if name[0].isnumeric():
-            name = f'_{name}'
+            name = f"{self.special_field_name_prefix}{name}"
 
         # We should avoid having a field begin with an underscore, as it
         # causes pydantic to consider it as private


### PR DESCRIPTION
Fixes #1644

@koxudaxi It seemed to me that this would be a good place. Please correct if not.
Also, I'm not that sure about the option description I suggested. But I think that it should be reformulated to prevent confusion.