### PR TITLE
Fix error when JsonSchemaObject is bool with Pydantic v2

### DIFF
--- a/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -42,7 +42,9 @@ class Constraints(_Constraints):
     pattern: Optional[str] = Field(None, alias='pattern')
 
     @model_validator(mode='before')
-    def validate_min_max_items(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def validate_min_max_items(cls, values: Any) -> Dict[str, Any]:
+        if not isinstance(values, dict):  # pragma: no cover
+            return values
         min_items = values.pop('minItems', None)
         if min_items is not None:
             values['minLength'] = min_items

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -191,6 +191,8 @@ class JsonSchemaObject(BaseModel):
     def validate_exclusive_maximum_and_exclusive_minimum(
         cls, values: Dict[str, Any]
     ) -> Any:
+        if not values:
+            return values
         exclusive_maximum: Union[float, bool, None] = values.get('exclusiveMaximum')
         exclusive_minimum: Union[float, bool, None] = values.get('exclusiveMinimum')
 

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -188,10 +188,8 @@ class JsonSchemaObject(BaseModel):
     __extra_key__: str = SPECIAL_PATH_FORMAT.format('extras')
 
     @model_validator(mode='before')
-    def validate_exclusive_maximum_and_exclusive_minimum(
-        cls, values: Dict[str, Any]
-    ) -> Any:
-        if not values:
+    def validate_exclusive_maximum_and_exclusive_minimum(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
             return values
         exclusive_maximum: Union[float, bool, None] = values.get('exclusiveMaximum')
         exclusive_minimum: Union[float, bool, None] = values.get('exclusiveMinimum')

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -362,9 +362,11 @@ def test_parse_default(source_obj, generated_classes):
 
 def test_parse_array_schema():
     parser = JsonSchemaParser('')
-    # with pytest.raises(ValidationError):
-    parser.parse_raw_obj(
-        'array schema', {'type': 'array', 'properties': {'name': True}}, []
+    parser.parse_raw_obj('schema', {'type': 'object', 'properties': {'name': True}}, [])
+    assert (
+        dump_templates(list(parser.results))
+        == """class Schema(BaseModel):
+    name: Optional[Any] = None"""
     )
 
 

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -360,6 +360,14 @@ def test_parse_default(source_obj, generated_classes):
     assert dump_templates(list(parser.results)) == generated_classes
 
 
+def test_parse_array_schema():
+    parser = JsonSchemaParser('')
+    # with pytest.raises(ValidationError):
+    parser.parse_raw_obj(
+        'array schema', {'type': 'array', 'properties': {'name': True}}, []
+    )
+
+
 def test_parse_nested_array():
     parser = JsonSchemaParser(
         DATA_PATH / 'nested_array.json',


### PR DESCRIPTION
I don't know what the ramifications of this change are, but I know this change seems to skip the error when data classes from json schema