### PR TITLE
Improve json_schema_extra to pydanticv2 Field with readOnly/writeOnly 

### DIFF
--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -92,7 +92,7 @@ def black_find_project_root(sources: Sequence[Path]) -> Path:
         from typing import Iterable, Tuple, Union
 
         def _find_project_root(
-            srcs: Union[Sequence[str], Iterable[str]]
+            srcs: Union[Sequence[str], Iterable[str]],
         ) -> Union[Tuple[Path, str], Path]:
             ...
 

--- a/datamodel_code_generator/model/base.py
+++ b/datamodel_code_generator/model/base.py
@@ -117,6 +117,7 @@ class DataModelFieldBase(_BaseModel):
     use_one_literal_as_default: bool = False
     _exclude_fields: ClassVar[Set[str]] = {'parent'}
     _pass_fields: ClassVar[Set[str]] = {'parent', 'data_type'}
+    can_have_extra_keys: ClassVar[bool] = True
 
     if not TYPE_CHECKING:
 

--- a/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -69,7 +69,19 @@ class DataModelField(DataModelFieldV1):
     }
     constraints: Optional[Constraints] = None
     _PARSE_METHOD: ClassVar[str] = 'model_validate'
+    json_schema_extra: Dict[str, Any] = {}
+    @property
+    def field(self) -> Optional[str]:
+        field = super().field
 
+        if self.json_schema_extra:
+            if field is not None:
+                field = field.split(")")[0]
+                field += f", json_schema_extra={self.json_schema_extra})"
+            else:
+                field = f"Field(..., json_schema_extra={self.json_schema_extra})"
+
+        return field
     @field_validator('extras')
     def validate_extras(cls, values: Any) -> Dict[str, Any]:
         if not isinstance(values, dict):

--- a/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -70,18 +70,20 @@ class DataModelField(DataModelFieldV1):
     constraints: Optional[Constraints] = None
     _PARSE_METHOD: ClassVar[str] = 'model_validate'
     json_schema_extra: Dict[str, Any] = {}
+
     @property
     def field(self) -> Optional[str]:
         field = super().field
 
         if self.json_schema_extra:
             if field is not None:
-                field = field.split(")")[0]
-                field += f", json_schema_extra={self.json_schema_extra})"
+                field = field.split(')')[0]
+                field += f', json_schema_extra={self.json_schema_extra})'
             else:
-                field = f"Field(..., json_schema_extra={self.json_schema_extra})"
+                field = f'Field(..., json_schema_extra={self.json_schema_extra})'
 
         return field
+
     @field_validator('extras')
     def validate_extras(cls, values: Any) -> Dict[str, Any]:
         if not isinstance(values, dict):

--- a/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -101,19 +101,8 @@ class DataModelField(DataModelFieldV1):
     }
     constraints: Optional[Constraints] = None
     _PARSE_METHOD: ClassVar[str] = 'model_validate'
+    can_have_extra_keys: ClassVar[bool] = False
     json_schema_extra: Dict[str, Any] = {}
-
-    @property
-    def field(self) -> Optional[str]:
-        field = super().field
-        if self.json_schema_extra:
-            if field is not None:
-                field = field[:-1]
-                field += f', json_schema_extra={self.json_schema_extra})'
-            else:
-                field = f'Field(..., json_schema_extra={self.json_schema_extra})'
-
-        return field
 
     @field_validator('extras')
     def validate_extras(cls, values: Any) -> Dict[str, Any]:

--- a/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -74,10 +74,9 @@ class DataModelField(DataModelFieldV1):
     @property
     def field(self) -> Optional[str]:
         field = super().field
-
         if self.json_schema_extra:
             if field is not None:
-                field = field.split(')')[0]
+                field = field[:-1]
                 field += f', json_schema_extra={self.json_schema_extra})'
             else:
                 field = f'Field(..., json_schema_extra={self.json_schema_extra})'

--- a/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -102,7 +102,6 @@ class DataModelField(DataModelFieldV1):
     constraints: Optional[Constraints] = None
     _PARSE_METHOD: ClassVar[str] = 'model_validate'
     can_have_extra_keys: ClassVar[bool] = False
-    json_schema_extra: Dict[str, Any] = {}
 
     @field_validator('extras')
     def validate_extras(cls, values: Any) -> Dict[str, Any]:

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -237,6 +237,7 @@ class JsonSchemaObject(BaseModel):
     allOf: List[JsonSchemaObject] = []
     enum: List[Any] = []
     writeOnly: Optional[bool] = None
+    readOnly: Optional[bool] = None
     properties: Optional[Dict[str, Union[JsonSchemaObject, bool]]] = None
     required: List[str] = []
     ref: Optional[str] = Field(default=None, alias='$ref')
@@ -571,12 +572,24 @@ class JsonSchemaParser(Parser):
             else None,
             strip_default_none=self.strip_default_none,
             extras=self.get_field_extras(field),
+            json_schema_extra=self.get_json_schema_extra(field),
             use_annotated=self.use_annotated,
             use_field_description=self.use_field_description,
             use_default_kwarg=self.use_default_kwarg,
             original_name=original_field_name,
             has_default=field.has_default,
         )
+
+    def get_json_schema_extra(self, field: JsonSchemaObject) -> Dict[str, Any]:
+        json_schema_extra = {}
+
+        if field.readOnly is not None:
+            json_schema_extra["readOnly"] = field.readOnly
+
+        if field.writeOnly is not None:
+            json_schema_extra["writeOnly"] = field.writeOnly
+
+        return json_schema_extra
 
     def get_data_type(self, obj: JsonSchemaObject) -> DataType:
         if obj.type is None:

--- a/datamodel_code_generator/parser/jsonschema.py
+++ b/datamodel_code_generator/parser/jsonschema.py
@@ -584,10 +584,10 @@ class JsonSchemaParser(Parser):
         json_schema_extra = {}
 
         if field.readOnly is not None:
-            json_schema_extra["readOnly"] = field.readOnly
+            json_schema_extra['readOnly'] = field.readOnly
 
         if field.writeOnly is not None:
-            json_schema_extra["writeOnly"] = field.writeOnly
+            json_schema_extra['writeOnly'] = field.writeOnly
 
         return json_schema_extra
 

--- a/tests/data/expected/main/main_jsonschema_field_extras_field_extra_keys_v2/output.py
+++ b/tests/data/expected/main/main_jsonschema_field_extras_field_extra_keys_v2/output.py
@@ -14,7 +14,7 @@ class Extras(BaseModel):
         None,
         description='normal key',
         examples=['example'],
-        json_schema_extra={'key2': 456, 'invalid_key_1': 'abc'},
+        json_schema_extra={'key2': 456, 'invalid-key-1': 'abc'},
         repr=True,
     )
     age: Optional[int] = Field(

--- a/tests/data/expected/main/main_jsonschema_field_extras_field_include_all_keys/output.py
+++ b/tests/data/expected/main/main_jsonschema_field_extras_field_include_all_keys/output.py
@@ -20,9 +20,10 @@ class Extras(BaseModel):
         invalid_key_1='abc',
         key1=123,
         key2=456,
+        readOnly=True,
         register_='hij',
         repr=True,
         schema_='klm',
         x_abc=True,
     )
-    age: Optional[int] = Field(None, example=12, examples=[13, 20])
+    age: Optional[int] = Field(None, example=12, examples=[13, 20], writeOnly=True)

--- a/tests/data/expected/main/main_jsonschema_field_extras_field_include_all_keys_v2/output.py
+++ b/tests/data/expected/main/main_jsonschema_field_extras_field_include_all_keys_v2/output.py
@@ -17,16 +17,17 @@ class Extras(BaseModel):
         json_schema_extra={
             'key1': 123,
             'key2': 456,
-            'field_exclude': 123,
-            'invalid_key_1': 'abc',
-            'field_invalid_key_2': 'efg',
-            'field_comment': 'comment',
-            'register_': 'hij',
-            'schema_': 'klm',
-            'x_abc': True,
+            '$exclude': 123,
+            'invalid-key-1': 'abc',
+            '-invalid+key_2': 'efg',
+            '$comment': 'comment',
+            'register': 'hij',
+            'schema': 'klm',
+            'x-abc': True,
+            'readOnly': True,
         },
         repr=True,
     )
     age: Optional[int] = Field(
-        None, examples=[13, 20], json_schema_extra={'example': 12}
+        None, examples=[13, 20], json_schema_extra={'example': 12, 'writeOnly': True}
     )

--- a/tests/data/jsonschema/extras.json
+++ b/tests/data/jsonschema/extras.json
@@ -17,11 +17,13 @@
       "schema": "klm",
       "x-repr": true,
       "x-abc": true,
-      "example": "example"
+      "example": "example",
+      "readOnly": true
     },
     "age": {
       "type": "integer",
       "example": 12,
+      "writeOnly": true,
       "examples": [
         13,
         20


### PR DESCRIPTION
## Description
Pydantic v2 `Field` allows you to pass in extra data when generating a json-schema with `Model.model_json_schema()`.

This PR adds the `json_schema_extra` kwarg to a pydantic v2 Field with included `readOnly` and `writeOnly` values if they exist on the `JsonSchemaObject`. Now when generating with `model_json_schema()`, it will include the read/write only values on the schema.

https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.json_schema_extra