### PR TITLE
Enable ability to use custom `JsonSchemaObject` in `JsonSchemaParser`

### DIFF
--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -232,9 +232,9 @@ class Pet(BaseModel):
                 },
             },
             """class Person(BaseModel):
-        firstName: Optional[str] = None
-        lastName: Optional[str] = None
-        age: Optional[conint(ge=0)] = None""",
+    firstName: Optional[str] = None
+    lastName: Optional[str] = None
+    age: Optional[conint(ge=0)] = None""",
         ),
         (
             {
@@ -265,8 +265,8 @@ class Pet(BaseModel):
                 },
             },
             """class Person(BaseModel):
-        name: Optional[str] = None
-        home_address: Optional[HomeAddress] = None""",
+    name: Optional[str] = None
+    home_address: Optional[HomeAddress] = None""",
         ),
     ],
 )
@@ -291,7 +291,7 @@ def test_parse_object(source_obj, generated_classes):
                 'discriminator': 'type',
             },
             """class AnyObject(BaseModel):
-        __root__: Any = Field(..., description='This field accepts any object', discriminator='type', title='AnyJson')""",
+    __root__: Any = Field(..., description='This field accepts any object', discriminator='type', title='AnyJson')""",
         )
     ],
 )
@@ -347,13 +347,13 @@ def test_parse_one_of_object(source_obj, generated_classes):
                 },
             },
             """class Defaults(BaseModel):
-        string: Optional[str] = 'default string'
-        string_on_field: Optional[str] = Field('default string', description='description')
-        number: Optional[float] = 123
-        number_on_field: Optional[float] = Field(123, description='description')
-        number_array: Optional[List] = [1, 2, 3]
-        string_array: Optional[List] = ['a', 'b', 'c']
-        object: Optional[Dict[str, Any]] = {'key': 'value'}""",
+    string: Optional[str] = 'default string'
+    string_on_field: Optional[str] = Field('default string', description='description')
+    number: Optional[float] = 123
+    number_on_field: Optional[float] = Field(123, description='description')
+    number_array: Optional[List] = [1, 2, 3]
+    string_array: Optional[List] = ['a', 'b', 'c']
+    object: Optional[Dict[str, Any]] = {'key': 'value'}""",
         )
     ],
 )
@@ -503,10 +503,10 @@ def test_no_additional_imports():
                 },
             },
             """class Person(BaseModel):
-        firstName: Optional[int] = None
-        lastName: Optional[int] = None
-        age: Optional[confloat(ge=0.0)] = None
-        real_age: Optional[conint(ge=0)] = None""",
+    firstName: Optional[int] = None
+    lastName: Optional[int] = None
+    age: Optional[confloat(ge=0.0)] = None
+    real_age: Optional[conint(ge=0)] = None""",
         ),
     ],
 )

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 from unittest.mock import call
 
+import pydantic
 import pytest
 import yaml
 
@@ -231,9 +232,9 @@ class Pet(BaseModel):
                 },
             },
             """class Person(BaseModel):
-    firstName: Optional[str] = None
-    lastName: Optional[str] = None
-    age: Optional[conint(ge=0)] = None""",
+        firstName: Optional[str] = None
+        lastName: Optional[str] = None
+        age: Optional[conint(ge=0)] = None""",
         ),
         (
             {
@@ -264,8 +265,8 @@ class Pet(BaseModel):
                 },
             },
             """class Person(BaseModel):
-    name: Optional[str] = None
-    home_address: Optional[HomeAddress] = None""",
+        name: Optional[str] = None
+        home_address: Optional[HomeAddress] = None""",
         ),
     ],
 )
@@ -290,7 +291,7 @@ def test_parse_object(source_obj, generated_classes):
                 'discriminator': 'type',
             },
             """class AnyObject(BaseModel):
-    __root__: Any = Field(..., description='This field accepts any object', discriminator='type', title='AnyJson')""",
+        __root__: Any = Field(..., description='This field accepts any object', discriminator='type', title='AnyJson')""",
         )
     ],
 )
@@ -346,13 +347,13 @@ def test_parse_one_of_object(source_obj, generated_classes):
                 },
             },
             """class Defaults(BaseModel):
-    string: Optional[str] = 'default string'
-    string_on_field: Optional[str] = Field('default string', description='description')
-    number: Optional[float] = 123
-    number_on_field: Optional[float] = Field(123, description='description')
-    number_array: Optional[List] = [1, 2, 3]
-    string_array: Optional[List] = ['a', 'b', 'c']
-    object: Optional[Dict[str, Any]] = {'key': 'value'}""",
+        string: Optional[str] = 'default string'
+        string_on_field: Optional[str] = Field('default string', description='description')
+        number: Optional[float] = 123
+        number_on_field: Optional[float] = Field(123, description='description')
+        number_array: Optional[List] = [1, 2, 3]
+        string_array: Optional[List] = ['a', 'b', 'c']
+        object: Optional[Dict[str, Any]] = {'key': 'value'}""",
         )
     ],
 )
@@ -502,12 +503,15 @@ def test_no_additional_imports():
                 },
             },
             """class Person(BaseModel):
-    firstName: Optional[int] = None
-    lastName: Optional[int] = None
-    age: Optional[confloat(ge=0.0)] = None
-    real_age: Optional[conint(ge=0)] = None""",
+        firstName: Optional[int] = None
+        lastName: Optional[int] = None
+        age: Optional[confloat(ge=0.0)] = None
+        real_age: Optional[conint(ge=0)] = None""",
         ),
     ],
+)
+@pytest.mark.skipif(
+    pydantic.VERSION < '2.0.0', reason='Require Pydantic version 2.0.0 or later '
 )
 def test_json_schema_parser_extension(source_obj, generated_classes):
     """
@@ -524,7 +528,7 @@ def test_json_schema_parser_extension(source_obj, generated_classes):
                 self.type = self.alt_type
 
     class AltJsonSchemaParser(JsonSchemaParser):
-        SCHEMA_OJBECT_TYPE = AltJsonSchemaObject
+        SCHEMA_OBJECT_TYPE = AltJsonSchemaObject
 
     parser = AltJsonSchemaParser(
         data_model_field_type=DataModelFieldBase,


### PR DESCRIPTION
As described in #1781, I have a need to extend the `JsonSchemaParser` to handle an "extension" to JSON schema. In that discussion, I noted that I figured out method for achieving this, but it required duplication with slight alteration of code already present in the `JsonSchemaParser`.

This PR is a possible solution to avoiding that issue. It does this by factoring the direct call to the `JsonSchemaObject` out into a class variable which can be overridden to a subclass of the `JsonSchemaObject` by a sub classing the `JsonSchemaParser`. If there are better alternate solutions to this issue feel free to close this PR and suggest them in #1781.