### PR TITLE
format: support black >=24

### DIFF
--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -137,9 +137,10 @@ class CodeFormatter:
                     'experimental-string-processing'
                 )
             else:
-                experimental_string_processing = config.get(
-                    'preview', False
-                ) and config.get('unstable', False)
+                experimental_string_processing = config.get('preview', False) and (
+                    config.get('unstable', False)
+                    or 'string_processing' in config.get('enable-unstable-feature', [])
+                )
 
         if experimental_string_processing is not None:  # pragma: no cover
             if black.__version__.startswith('19.'):  # type: ignore

--- a/datamodel_code_generator/format.py
+++ b/datamodel_code_generator/format.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 from warnings import warn
 
 import black
+import black.mode
 import isort
 
 from datamodel_code_generator.util import cached_property, load_toml
@@ -131,9 +132,14 @@ class CodeFormatter:
         if wrap_string_literal is not None:
             experimental_string_processing = wrap_string_literal
         else:
-            experimental_string_processing = config.get(
-                'experimental-string-processing'
-            )
+            if black.__version__ < '24.1.0':  # type: ignore
+                experimental_string_processing = config.get(
+                    'experimental-string-processing'
+                )
+            else:
+                experimental_string_processing = config.get(
+                    'preview', False
+                ) and config.get('unstable', False)
 
         if experimental_string_processing is not None:  # pragma: no cover
             if black.__version__.startswith('19.'):  # type: ignore
@@ -141,10 +147,16 @@ class CodeFormatter:
                     f"black doesn't support `experimental-string-processing` option"  # type: ignore
                     f' for wrapping string literal in {black.__version__}'
                 )
-            else:
+            elif black.__version__ < '24.1.0':  # type: ignore
                 black_kwargs[
                     'experimental_string_processing'
                 ] = experimental_string_processing
+            elif experimental_string_processing:
+                black_kwargs['preview'] = True
+                black_kwargs['unstable'] = config.get('unstable', False)
+                black_kwargs['enabled_features'] = {
+                    black.mode.Preview.string_processing
+                }
 
         if TYPE_CHECKING:
             self.black_mode: black.FileMode


### PR DESCRIPTION
Fixes #1821

In black >= 24, string processing requires `--preview` and either all `--unstable` features, or explicitly enabling `string_processing` in the unstable features (using [`--enable-unstable-feature`](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#enable-unstable-feature)).

There are modifications to the black style between versions 23 and 24, such that the snapshot tests are failing with black 24.1.0. The development dependency is therefore still pinned to version 23.x.y.
@koxudaxi is there a mechanism to test against multiple versions of black (and adapt the snapshots)?

I guess that this code will get reworked or deprecated when #1643 is implemented?