### PR TITLE
fix(ModuleImports): This PR fixes the module import resolver for module of type `BaseClassDataType`

### DIFF
--- a/datamodel_code_generator/parser/base.py
+++ b/datamodel_code_generator/parser/base.py
@@ -681,7 +681,8 @@ class Parser(ABC):
                     continue
 
                 if isinstance(data_type, BaseClassDataType):
-                    from_ = ''.join(relative(model.module_name, data_type.full_name))
+                    left, right = relative(model.module_name, data_type.full_name)
+                    from_ = ''.join([left, right]) if left.endswith('.') else '.'.join([left, right])
                     import_ = data_type.reference.short_name
                     full_path = from_, import_
                 else:


### PR DESCRIPTION
### Description
Currently, there is a bug in datamodel-codegenerator's import resolver. While parsing and resolving the imports for a module, if the data model is of data type `BaseClassDataType` and the length of split `reference_path` is greater than the length of split `current_module`, the final `output_path` resolved is incorrect.

### Example
`current_module`: "api.schemas"
`reference`: "api.this.that.ClassToImport"
`relative(current_module, reference)` returns: ('.this', 'that')
resulting `from_` value for model of instance `BaseClassDataType`: `..thisthat`

This PR fixes this error by ensuring that when joining the tuple returned by the `relative` method it is checked that the first item in the tuple ends with a `.`