### PR TITLE
Add from_attributes to ConfigDict

### DIFF
--- a/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -18,6 +18,7 @@ class ConfigDict(_BaseModel):
     title: Optional[str] = None
     populate_by_name: Optional[bool] = None
     allow_extra_fields: Optional[bool] = None
+    from_attributes: Optional[bool] = None
     frozen: Optional[bool] = None
     arbitrary_types_allowed: Optional[bool] = None
     protected_namespaces: Optional[Tuple[str, ...]] = None


### PR DESCRIPTION
Added an option to set the `from_attributes` in `PydanticV2` models through the `--extra-template-data`. This lets you automatically add `ConfigDict` with `from_attributes` to your templates, making it easier to create models that work well with [ORM attributes](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.from_attributes)

```bash
datamodel-codegen --output-model-type pydantic_v2.BaseModel \
    --extra-template-data ./extra.json \
    --input-file-type jsonschema \
    --input ./schema.json --output ./tmp.py
```

extra.json:
```json
{
  "#all#": {
    "config": {
      "from_attributes": "True"
    }
  }
}
```

tmp.py:
```
# generated by datamodel-codegen:
#   filename:  schema.json
#   timestamp: 2024-05-05T11:18:15+00:00

from __future__ import annotations

from typing import Any

from pydantic import BaseModel, ConfigDict, RootModel


class Model(RootModel[Any]):
    model_config = ConfigDict(
        from_attributes=True,
    )
    root: Any


class Example(BaseModel):
    model_config = ConfigDict(
        from_attributes=True,
    )
    value: Any
```