### PR TITLE
patch pydantic v1.10.9 conflict with py3.12

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -32,7 +32,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-codspeed-3.12-v1-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
 
       - name: Run benchmarks

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,18 +25,18 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-codspeed-3.12-v1-${{ hashFiles('**/poetry.lock') }}
+      # - name: Load cached venv
+      #   id: cached-poetry-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .venv
+      #     key: venv-${{ runner.os }}-codspeed-3.12-v1-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: poetry run pytest tests/ --codspeed
+          run: poetry run pytest tests/ --codspeed -n auto

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,14 +25,14 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-      # - name: Load cached venv
-      #   id: cached-poetry-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: .venv
-      #     key: venv-${{ runner.os }}-codspeed-3.12-v1-${{ hashFiles('**/poetry.lock') }}
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-codspeed-3.12-v1-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
 
       - name: Run benchmarks

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,4 +39,4 @@ jobs:
         uses: CodSpeedHQ/action@v1
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
-          run: poetry run pytest tests/ --codspeed -n auto
+          run: poetry run pytest tests/ --codspeed

--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -29,6 +29,7 @@ from urllib.parse import ParseResult
 
 import yaml
 
+import datamodel_code_generator.pydantic_patch  # noqa: F401
 from datamodel_code_generator.format import PythonVersion
 from datamodel_code_generator.parser import DefaultPutDict, LiteralType
 from datamodel_code_generator.parser.base import Parser

--- a/datamodel_code_generator/pydantic_patch.py
+++ b/datamodel_code_generator/pydantic_patch.py
@@ -1,9 +1,13 @@
+import sys
+
 import pydantic.typing
 
 
 def patched_evaluate_forwardref(forward_ref, globalns, localns=None):
     try:
-        return forward_ref._evaluate(globalns, localns or None, set())  # pragma: no cover
+        return forward_ref._evaluate(
+            globalns, localns or None, set()
+        )  # pragma: no cover
     except TypeError:
         # Fallback for Python 3.12 compatibility
         return forward_ref._evaluate(
@@ -11,4 +15,5 @@ def patched_evaluate_forwardref(forward_ref, globalns, localns=None):
         )
 
 
-pydantic.typing.evaluate_forwardref = patched_evaluate_forwardref
+if '3.12' in sys.version:
+    pydantic.typing.evaluate_forwardref = patched_evaluate_forwardref

--- a/datamodel_code_generator/pydantic_patch.py
+++ b/datamodel_code_generator/pydantic_patch.py
@@ -1,0 +1,14 @@
+import pydantic.typing
+
+
+def patched_evaluate_forwardref(forward_ref, globalns, localns=None):
+    try:
+        return forward_ref._evaluate(globalns, localns or None, set())
+    except TypeError:
+        # Fallback for Python 3.12 compatibility
+        return forward_ref._evaluate(
+            globalns, localns or None, set(), recursive_guard=set()
+        )
+
+
+pydantic.typing.evaluate_forwardref = patched_evaluate_forwardref

--- a/datamodel_code_generator/pydantic_patch.py
+++ b/datamodel_code_generator/pydantic_patch.py
@@ -3,7 +3,7 @@ import pydantic.typing
 
 def patched_evaluate_forwardref(forward_ref, globalns, localns=None):
     try:
-        return forward_ref._evaluate(globalns, localns or None, set())
+        return forward_ref._evaluate(globalns, localns or None, set())  # pragma: no cover
     except TypeError:
         # Fallback for Python 3.12 compatibility
         return forward_ref._evaluate(

--- a/datamodel_code_generator/pydantic_patch.py
+++ b/datamodel_code_generator/pydantic_patch.py
@@ -3,7 +3,9 @@ import sys
 import pydantic.typing
 
 
-def patched_evaluate_forwardref(forward_ref, globalns, localns=None):  # pragma: no cover
+def patched_evaluate_forwardref(
+    forward_ref, globalns, localns=None
+):  # pragma: no cover
     try:
         return forward_ref._evaluate(
             globalns, localns or None, set()

--- a/datamodel_code_generator/pydantic_patch.py
+++ b/datamodel_code_generator/pydantic_patch.py
@@ -3,7 +3,7 @@ import sys
 import pydantic.typing
 
 
-def patched_evaluate_forwardref(forward_ref, globalns, localns=None):
+def patched_evaluate_forwardref(forward_ref, globalns, localns=None):  # pragma: no cover
     try:
         return forward_ref._evaluate(
             globalns, localns or None, set()
@@ -15,5 +15,5 @@ def patched_evaluate_forwardref(forward_ref, globalns, localns=None):
         )
 
 
-if '3.12' in sys.version:
+if '3.12' in sys.version:  # pragma: no cover
     pydantic.typing.evaluate_forwardref = patched_evaluate_forwardref


### PR DESCRIPTION
There are errors in pipelines that run the testing configuration `python=3.12` and `pydantic=1.10.9`. The error is something like:
```
| ________________ ERROR collecting tests/parser/test_openapi.py _________________
| tests/parser/test_openapi.py:10: in <module>
|     from datamodel_code_generator import OpenAPIScope, PythonVersion
| datamodel_code_generator/__init__.py:35: in <module>
|     from datamodel_code_generator.parser.base import Parser
| datamodel_code_generator/parser/base.py:37: in <module>
|     from datamodel_code_generator.model import pydantic as pydantic_model
| datamodel_code_generator/model/__init__.py:5: in <module>
|     from ..types import DataTypeManager as DataTypeManagerABC
| datamodel_code_generator/types.py:240: in <module>
|     class DataType(_BaseModel):
| .venv/lib/python3.12/site-packages/pydantic/main.py:286: in __new__
|     cls.__try_update_forward_refs__()
| .venv/lib/python3.12/site-packages/pydantic/main.py:808: in __try_update_forward_refs__
|     update_model_forward_refs(cls, cls.__fields__.values(), cls.__config__.json_encoders, localns, (NameError,))
| .venv/lib/python3.12/site-packages/pydantic/typing.py:554: in update_model_forward_refs
|     update_field_forward_refs(f, globalns=globalns, localns=localns)
| .venv/lib/python3.12/site-packages/pydantic/typing.py:520: in update_field_forward_refs
|     field.type_ = evaluate_forwardref(field.type_, globalns, localns or None)
| .venv/lib/python3.12/site-packages/pydantic/typing.py:66: in evaluate_forwardref
|     return cast(Any, type_)._evaluate(globalns, localns, set())
| E   TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
```
and results in a massive amount of errors like:
```
ERROR tests/test_format.py - TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'
```


To patch the missing `recursive_guard` keyword argument, I created a `pydantic_patch` file that gets imported early in `datamodel_code_generator.__init__.py` and that patches the underlying `evaluate_forwardref` function.

This PR is should fix most of the broken tests in the pipelines for pull requests #2013, #2009 and #2008.