### PR TITLE
Support `use_enum_values` in `ConfigDict`

### DIFF
--- a/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -23,6 +23,7 @@ class ConfigDict(_BaseModel):
     arbitrary_types_allowed: Optional[bool] = None
     protected_namespaces: Optional[Tuple[str, ...]] = None
     regex_engine: Optional[str] = None
+    use_enum_values: Optional[bool] = None
 
 
 __all__ = [


### PR DESCRIPTION
https://github.com/koxudaxi/datamodel-code-generator/discussions/466#discussioncomment-11026869

Meanwhile, I am trying to override the `ConfigDict.jinja2` template, but it doesn't work - it seems to be ignored

```
model_config = ConfigDict(
{%- for field_name, value in config.dict(exclude_unset=True).items() %}
    {{ field_name }}={{ value }},
{%- endfor %}
    use_enum_values=True
)
```

See https://github.com/koxudaxi/datamodel-code-generator/issues/2136