### PR TITLE
Fix content-hash; add pre-commit-check for poetry.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,26 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.6.9'
-    hooks:
-      - id: ruff
-        files: "^datamodel_code_generator|^tests"
-        exclude: "^tests/data"
-        args: [ --fix ]
-      - id: ruff-format
-        files: "^datamodel_code_generator|^tests"
-        exclude: "^tests/data"
-  - repo: https://github.com/codespell-project/codespell
-    # Configuration for codespell is in pyproject.toml
-    rev: v2.3.0
-    hooks:
-    - id: codespell
-      additional_dependencies:
-        - tomli
-      exclude: "^tests/|^CODE_OF_CONDUCT.md"
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: 'v0.6.9'
+  hooks:
+  - id: ruff
+    files: "^datamodel_code_generator|^tests"
+    exclude: "^tests/data"
+    args: [ --fix ]
+  - id: ruff-format
+    files: "^datamodel_code_generator|^tests"
+    exclude: "^tests/data"
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.3.0
+  hooks:
+  - id: codespell
+    additional_dependencies:
+    - tomli
+    exclude: "^tests/|^CODE_OF_CONDUCT.md"
+- repo: https://github.com/python-poetry/poetry
+  rev: 1.8.3
+  hooks:
+  - id: poetry-check
+  - id: poetry-lock
+    args:
+    - --no-update

--- a/poetry.lock
+++ b/poetry.lock
@@ -2050,5 +2050,4 @@ validation = ["openapi-spec-validator", "prance"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "100e4c19bd2aef114c50ef8b73189d526cf1c2787ce7c99379bdad8481c1c79b"
-
+content-hash = "d5ab8dcdc7d561db1c3de2c9ad014cbca2bcf232b031cfddb1b0e6e5c0a80066"


### PR DESCRIPTION
The `content-hash` entry was invalid.

Also added checks for poetry to pre-commit and fixed formatting of .pre-commit-config.yaml