### PR TITLE
fix(parser): custom_template_dir not passed to data_model_type for OpenAPIScope.Parameters

### DIFF
--- a/datamodel_code_generator/parser/openapi.py
+++ b/datamodel_code_generator/parser/openapi.py
@@ -513,6 +513,7 @@ class OpenAPIParser(JsonSchemaParser):
                     fields=fields,
                     reference=reference,
                     custom_base_class=self.base_class,
+                    custom_template_dir=self.custom_template_dir,
                     keyword_only=self.keyword_only,
                 )
             )


### PR DESCRIPTION
When generating OpenAPI Parameters model with custom_template_dir, it uses the default template rather than the customized one. It appears that custom_template_dir is not being passed when instantiating the class.