### PR TITLE
fix: Preserve class names when generating models from JSON Schema 202…

### DIFF
--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -573,7 +573,9 @@ class ModelResolver:
         split_ref = ref.rsplit('/', 1)
         if len(split_ref) == 1:
             original_name = Path(
-                split_ref[0].rstrip('#') if self.is_external_root_ref(path) else split_ref[0]
+                split_ref[0].rstrip('#')
+                if self.is_external_root_ref(path)
+                else split_ref[0]
             ).stem
         else:
             original_name = (

--- a/datamodel_code_generator/reference.py
+++ b/datamodel_code_generator/reference.py
@@ -573,11 +573,11 @@ class ModelResolver:
         split_ref = ref.rsplit('/', 1)
         if len(split_ref) == 1:
             original_name = Path(
-                split_ref[0][:-1] if self.is_external_root_ref(path) else split_ref[0]
+                split_ref[0].rstrip('#') if self.is_external_root_ref(path) else split_ref[0]
             ).stem
         else:
             original_name = (
-                Path(split_ref[1][:-1]).stem
+                Path(split_ref[1].rstrip('#')).stem
                 if self.is_external_root_ref(path)
                 else split_ref[1]
             )

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -2,7 +2,7 @@ from pathlib import PurePosixPath, PureWindowsPath
 
 import pytest
 
-from datamodel_code_generator.reference import get_relative_path, ModelResolver
+from datamodel_code_generator.reference import ModelResolver, get_relative_path
 
 
 @pytest.mark.parametrize(
@@ -48,15 +48,20 @@ def test_get_relative_path_windows(
         get_relative_path(PureWindowsPath(base_path), PureWindowsPath(target_path))
     ) == PureWindowsPath(expected)
 
+
 def test_model_resolver_add_ref_with_hash():
     model_resolver = ModelResolver()
-    reference = model_resolver.add_ref('https://json-schema.org/draft/2020-12/meta/core#')
+    reference = model_resolver.add_ref(
+        'https://json-schema.org/draft/2020-12/meta/core#'
+    )
     assert reference.original_name == 'core'
+
 
 def test_model_resolver_add_ref_without_hash():
     model_resolver = ModelResolver()
     reference = model_resolver.add_ref('meta/core')
     assert reference.original_name == 'core'
+
 
 def test_model_resolver_add_ref_unevaluated():
     model_resolver = ModelResolver()

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -2,7 +2,7 @@ from pathlib import PurePosixPath, PureWindowsPath
 
 import pytest
 
-from datamodel_code_generator.reference import get_relative_path
+from datamodel_code_generator.reference import get_relative_path, ModelResolver
 
 
 @pytest.mark.parametrize(
@@ -47,3 +47,18 @@ def test_get_relative_path_windows(
     assert PureWindowsPath(
         get_relative_path(PureWindowsPath(base_path), PureWindowsPath(target_path))
     ) == PureWindowsPath(expected)
+
+def test_model_resolver_add_ref_with_hash():
+    model_resolver = ModelResolver()
+    reference = model_resolver.add_ref('https://json-schema.org/draft/2020-12/meta/core#')
+    assert reference.original_name == 'core'
+
+def test_model_resolver_add_ref_without_hash():
+    model_resolver = ModelResolver()
+    reference = model_resolver.add_ref('meta/core')
+    assert reference.original_name == 'core'
+
+def test_model_resolver_add_ref_unevaluated():
+    model_resolver = ModelResolver()
+    reference = model_resolver.add_ref('meta/unevaluated')
+    assert reference.original_name == 'unevaluated'


### PR DESCRIPTION
Fix: https://github.com/koxudaxi/datamodel-code-generator/issues/2032

This pull request includes changes to improve the handling of references in the `datamodel_code_generator` and adds new tests to ensure the functionality works as expected. The most important changes include modifying the `add_ref` method to handle trailing hash characters and adding new test cases for the `ModelResolver` class.

Improvements to reference handling:

* [`datamodel_code_generator/reference.py`](diffhunk://#diff-259f730c63785bc011adf7836b80688ebdc8e1370be54755beab33094b2c32b0L576-R580): Modified the `add_ref` method to use `rstrip('#')` instead of slicing to remove trailing hash characters from references.

New test cases:

* [`tests/test_reference.py`](diffhunk://#diff-6c64fde74e6a2c2faf8ecc3c1f230aeb11daa1a3b6aa894f53f3f1ae1318d97eL5-R5): Added import for `ModelResolver` and new test cases to verify the `add_ref` method handles references with and without trailing hash characters correctly. [[1]](diffhunk://#diff-6c64fde74e6a2c2faf8ecc3c1f230aeb11daa1a3b6aa894f53f3f1ae1318d97eL5-R5) [[2]](diffhunk://#diff-6c64fde74e6a2c2faf8ecc3c1f230aeb11daa1a3b6aa894f53f3f1ae1318d97eR50-R64)