### PR TITLE
typo: Fix 'Allow to' sentence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Field customization:
                         Use schema description to populate field docstring
 
 Model customization:
-  --allow-extra-fields  Allow to pass extra fields, if this flag is not passed, extra fields
+  --allow-extra-fields  Allow passing extra fields, if this flag is not passed, extra fields
                         are forbidden.
   --allow-population-by-field-name
                         Allow population by field name

--- a/datamodel_code_generator/arguments.py
+++ b/datamodel_code_generator/arguments.py
@@ -98,7 +98,7 @@ base_options.add_argument(
 # ======================================================================================
 model_options.add_argument(
     '--allow-extra-fields',
-    help='Allow to pass extra fields, if this flag is not passed, extra fields are forbidden.',
+    help='Allow passing extra fields, if this flag is not passed, extra fields are forbidden.',
     action='store_true',
     default=None,
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -429,7 +429,7 @@ Field customization:
                         Use schema description to populate field docstring
 
 Model customization:
-  --allow-extra-fields  Allow to pass extra fields, if this flag is not passed, extra fields
+  --allow-extra-fields  Allow passing extra fields, if this flag is not passed, extra fields
                         are forbidden.
   --allow-population-by-field-name
                         Allow population by field name


### PR DESCRIPTION
Hi!  I'm packaging this project for inclusion into Debian, and our QA tools found a small typo nit:

```
I: datamodel-codegen: typo-in-manual-page "Allow to" "Allow one to" [usr/share/man/man1/datamodel-codegen.1.gz:155]
```

How about this patch?

Debian packages is available here: https://salsa.debian.org/python-team/packages/python-datamodel-code-generator/

Thanks,
/Simon