### PR TITLE
Bump default target Python version to 3.9

### DIFF
--- a/datamodel_code_generator/__init__.py
+++ b/datamodel_code_generator/__init__.py
@@ -237,7 +237,7 @@ def generate(
     input_file_type: InputFileType = InputFileType.Auto,
     output: Optional[Path] = None,
     output_model_type: DataModelType = DataModelType.PydanticBaseModel,
-    target_python_version: PythonVersion = PythonVersion.PY_38,
+    target_python_version: PythonVersion = PythonVersion.PY_39,
     base_class: str = '',
     additional_imports: Optional[List[str]] = None,
     custom_template_dir: Optional[Path] = None,


### PR DESCRIPTION
Python 3.8 reached end-of-life in October 2024.

`typing.Annotated` was added in Python 3.9, so using annotations will no longer need `typing_extensions` by default.