### PR TITLE
Include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ readme = "README.md"
 license = "MIT"
 homepage = "https://github.com/koxudaxi/datamodel-code-generator"
 repository = "https://github.com/koxudaxi/datamodel-code-generator"
+include = [
+    { path = "tests", format = "sdist" },
+]
 
 
 classifiers = [


### PR DESCRIPTION
Including tests would make it easier for downstream distributors (e.g. Debian) to ensure that changes to other dependencies haven't broken this package.