### PR TITLE
Fix #2333. Remove not none arg parse defaults.

### DIFF
--- a/src/datamodel_code_generator/arguments.py
+++ b/src/datamodel_code_generator/arguments.py
@@ -168,7 +168,7 @@ model_options.add_argument(
     "--treat-dot-as-module",
     help="treat dotted module names as modules",
     action="store_true",
-    default=False,
+    default=None,
 )
 model_options.add_argument(
     "--use-schema-description",
@@ -186,14 +186,14 @@ model_options.add_argument(
     "--use-pendulum",
     help="use pendulum instead of datetime",
     action="store_true",
-    default=False,
+    default=None,
 )
 model_options.add_argument(
     "--use-exact-imports",
     help='import exact types instead of modules, for example: "from .foo import Bar" instead of '
     '"from . import foo" with "foo.Bar"',
     action="store_true",
-    default=False,
+    default=None,
 )
 model_options.add_argument(
     "--output-datetime-class",

--- a/tests/main/test_main_general.py
+++ b/tests/main/test_main_general.py
@@ -14,7 +14,7 @@ from datamodel_code_generator import (
     generate,
     snooper_to_methods,
 )
-from datamodel_code_generator.__main__ import Exit, main
+from datamodel_code_generator.__main__ import Config, Exit, main
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -69,6 +69,19 @@ def test_show_help_when_no_input(mocker: MockerFixture) -> None:
     assert return_code == Exit.ERROR
     assert isatty_mock.called
     assert print_help_mock.called
+
+
+def test_no_args_has_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    No argument should have a default value set because it would override pyproject.toml values.
+
+    Default values are set in __main__.Config class.
+    """
+    namespace = Namespace()
+    monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace)
+    main([])
+    for field in Config.get_fields():
+        assert getattr(namespace, field, None) is None
 
 
 @freeze_time("2019-07-26")


### PR DESCRIPTION
### Steps

- [x] Remove not `None` arg parse defaults
- [x] Check that default values for those options, provided in `__main__.Config`, are the same.

Fix #2333 

### Breaking changes

None