### PR TITLE
[Chore] Remove Python 3.8 from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ env_list =
     3.11
     3.10
     3.9
-    3.8
     readme
     coverage
     py3.12-black{24, 23, 22}
@@ -80,7 +79,6 @@ depends =
     3.11
     3.10
     3.9
-    3.8
     py3.12-black{24, 23, 22}
 dependency_groups = coverage
 


### PR DESCRIPTION
## Facts

- Python 3.8 support has been dropped in https://github.com/koxudaxi/datamodel-code-generator/pull/2324
- Tox still has Python 3.8 among their envs

## What has been done

- [x] Removed Python 3.8 environment in Tox