### PR TITLE
fix: Pass encoding parameter to parser in init.generate()

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -482,6 +482,7 @@ def generate(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915
         keyword_only=keyword_only,
         no_alias=no_alias,
         formatters=formatters,
+        encoding=encoding,
         **kwargs,
     )
 


### PR DESCRIPTION
Fixes: https://github.com/koxudaxi/datamodel-code-generator/issues/2362