### PR TITLE
fix: TypeError: '<' not supported between instances of 'str' and 'NoneType'

### DIFF
--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -88,6 +88,8 @@ def to_hashable(item: Any) -> Any:
         return frozenset(to_hashable(i) for i in item)
     if isinstance(item, BaseModel):
         return to_hashable(item.dict())
+    if item is None:
+        return ""
     return item
 
 


### PR DESCRIPTION
I'm afraid I don't know exactly what triggers this, but in my big openapi spec this gets triggered (with v0.30):

```
Traceback (most recent call last):
  File "/home/gjc/.cache/uv/archive-v0/zrUKlPLuGJsfxDV0Mede0/lib/python3.12/site-packages/datamodel_code_generator/__main__.py", line 458, in main
    generate(
  File "/home/gjc/.cache/uv/archive-v0/zrUKlPLuGJsfxDV0Mede0/lib/python3.12/site-packages/datamodel_code_generator/__init__.py", line 492, in generate
    results = parser.parse()
              ^^^^^^^^^^^^^^
  File "/home/gjc/.cache/uv/archive-v0/zrUKlPLuGJsfxDV0Mede0/lib/python3.12/site-packages/datamodel_code_generator/parser/base.py", line 1311, in parse
    self.__reuse_model(models, require_update_action_models)
  File "/home/gjc/.cache/uv/archive-v0/zrUKlPLuGJsfxDV0Mede0/lib/python3.12/site-packages/datamodel_code_generator/parser/base.py", line 868, in __reuse_model
    model_key = tuple(to_hashable(v) for v in (model.render(class_name="M"), model.imports))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gjc/.cache/uv/archive-v0/zrUKlPLuGJsfxDV0Mede0/lib/python3.12/site-packages/datamodel_code_generator/parser/base.py", line 868, in <genexpr>
    model_key = tuple(to_hashable(v) for v in (model.render(class_name="M"), model.imports))
                      ^^^^^^^^^^^^^^
  File "/home/gjc/.cache/uv/archive-v0/zrUKlPLuGJsfxDV0Mede0/lib/python3.12/site-packages/datamodel_code_generator/parser/base.py", line 76, in to_hashable
    return tuple(sorted(to_hashable(i) for i in item))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```

The objects in question look like:

```
Import(from_="typing", import_="Annotated", alias=None, reference_path=None)
```

Which are transformed into:
```
    (
        ("alias", None),
        ("from_", "typing"),
        ("import_", "Annotated"),
        ("reference_path", None),
    ),
```

Now, those `None`s will cause `sorted()` to raise that TypeError.

The simple fix is to transform None into "": this is only used as key in a cache, so it doesn't really matter as long as the value is predictable and hashable.