### PR TITLE
Support `coerce_numbers_to_str` in `ConfigDict`

### DIFF
--- a/src/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -27,7 +27,7 @@ class ConfigDict(_BaseModel):
     protected_namespaces: Optional[tuple[str, ...]] = None  # noqa: UP045
     regex_engine: Optional[str] = None  # noqa: UP045
     use_enum_values: Optional[bool] = None  # noqa: UP045
-    coerce_numbers_to_str: Optional[str] = None  # noqa: UP045
+    coerce_numbers_to_str: Optional[bool] = None  # noqa: UP045
 
 
 __all__ = [

--- a/src/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -27,6 +27,7 @@ class ConfigDict(_BaseModel):
     protected_namespaces: Optional[tuple[str, ...]] = None  # noqa: UP045
     regex_engine: Optional[str] = None  # noqa: UP045
     use_enum_values: Optional[bool] = None  # noqa: UP045
+    coerce_numbers_to_str: Optional[str] = None  # noqa: UP045
 
 
 __all__ = [

--- a/tests/data/expected/main/openapi/extra_template_data_config_pydantic_v2.py
+++ b/tests/data/expected/main/openapi/extra_template_data_config_pydantic_v2.py
@@ -12,6 +12,7 @@ from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel
 class Pet(BaseModel):  # 1 2, 1 2, this is just a pet
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
+        coerce_numbers_to_str=True,
     )
     id: int
     name: str

--- a/tests/data/openapi/extra_data.json
+++ b/tests/data/openapi/extra_data.json
@@ -1,6 +1,8 @@
 {
   "Pet": {
     "comment": "1 2, 1 2, this is just a pet",
-    "config":{"arbitrary_types_allowed": "True"}
+    "config":{
+      "arbitrary_types_allowed": "True",
+      "coerce_numbers_to_str": "True"}
   }
 }


### PR DESCRIPTION
Support setting `coerce_numbers_to_str` in the Pydantic `ConfigDict` via `extra_template_data`.

https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.coerce_numbers_to_str

There are other ConfigDict values that you might consider adding as well, but this one was the blocker for us.