### PR TITLE
Add the path data type to the type parser

### DIFF
--- a/src/datamodel_code_generator/model/types.py
+++ b/src/datamodel_code_generator/model/types.py
@@ -49,6 +49,7 @@ def type_map_factory(data_type: type[DataType]) -> dict[Types, DataType]:
         Types.ipv6: data_type_str,
         Types.ipv4_network: data_type_str,
         Types.ipv6_network: data_type_str,
+        Types.path: data_type_str,
         Types.boolean: data_type(type="bool"),
         Types.object: data_type.from_import(IMPORT_ANY, is_dict=True),
         Types.null: data_type(type="None"),


### PR DESCRIPTION
Right now, trying to use the `TypedDict` generator when an OpenAPI specifications contains an input of type `path` raises an error. With the `Pydantic` generator, this does not happen.

The issue is fixed by simply adding a conversion for the `path` type to the `type_map_factory`.