### PR TITLE
Allow parsing non-string lists for required fields

### DIFF
--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -211,6 +211,37 @@ class JsonSchemaObject(BaseModel):
             return value.replace("#", "#/")
         return value
 
+    @field_validator("required", mode="before")
+    def validate_required(cls, value: Any) -> Any:  # noqa: N805
+        if value is None:
+            return []
+        if isinstance(value, list):  # noqa: PLR1702
+            # Filter to only include valid strings, excluding invalid objects
+            required_fields: list[str] = []
+            for item in value:
+                if isinstance(item, str):
+                    required_fields.append(item)
+
+                # In some cases, the required field can include "anyOf", "oneOf", or "allOf" as a dict (#2297)
+                elif isinstance(item, dict):
+                    for key, val in item.items():
+                        if isinstance(val, list):
+                            # If 'anyOf' or "oneOf" is present, we won't include it in required fields
+                            if key in {"anyOf", "oneOf"}:
+                                continue
+
+                            if key == "allOf":
+                                # If 'allOf' is present, we include them as required fields
+                                required_fields.extend(sub_item for sub_item in val if isinstance(sub_item, str))
+                            else:
+                                warn(f"Invalid required field: {key!r} with value {val!r}", stacklevel=2)
+                        else:
+                            warn(f"Invalid required field: {key!r} with value {val!r}", stacklevel=2)
+
+            return required_fields
+
+        return value
+
     items: Optional[Union[list[JsonSchemaObject], JsonSchemaObject, bool]] = None  # noqa: UP007, UP045
     uniqueItems: Optional[bool] = None  # noqa: N815, UP045
     type: Optional[Union[str, list[str]]] = None  # noqa: UP007, UP045
@@ -1552,7 +1583,7 @@ class JsonSchemaParser(Parser):
         raw: dict[str, Any],
         path: list[str],
     ) -> None:
-        self.parse_obj(name, self.SCHEMA_OBJECT_TYPE.parse_obj(raw), path)
+        self.parse_obj(name, self.SCHEMA_OBJECT_TYPE.model_validate(raw), path)
 
     def parse_obj(
         self,

--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -233,12 +233,8 @@ class JsonSchemaObject(BaseModel):
                             if key == "allOf":
                                 # If 'allOf' is present, we include them as required fields
                                 required_fields.extend(sub_item for sub_item in val if isinstance(sub_item, str))
-                            else:
-                                warn(f"Invalid required field: {key!r} with value {val!r}", stacklevel=2)
-                        else:
-                            warn(f"Invalid required field: {key!r} with value {val!r}", stacklevel=2)
 
-            return required_fields
+            value = required_fields
 
         return value
 

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_allof_required_fields/output.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_allof_required_fields/output.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class EmailMessage(BaseModel):
+    message: str = Field(..., description='The email message text.')
+    subject: str = Field(..., description='The subject line of the email.')
+    to: List[str] = Field(..., description='A list of email addresses.')

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_anyof_required/output.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_anyof_required/output.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class EmailMessage(BaseModel):
+    bcc: Optional[List[str]] = Field(
+        None, description='A list of "blind carbon copy" email addresses.'
+    )
+    cc: Optional[List[str]] = Field(
+        None, description='A list of "carbon copy" email addresses.'
+    )
+    message: str = Field(..., description='The email message text.')
+    subject: str = Field(..., description='The subject line of the email.')
+    to: Optional[List[str]] = Field(None, description='A list of email addresses.')

--- a/tests/data/expected/parser/openapi/openapi_parser_parse_required_null/output.py
+++ b/tests/data/expected/parser/openapi/openapi_parser_parse_required_null/output.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class Type(Enum):
+    my_first_object = 'my_first_object'
+    my_second_object = 'my_second_object'
+    my_third_object = 'my_third_object'
+
+
+class ObjectBase(BaseModel):
+    name: Optional[str] = Field(None, description='Name of the object')
+    type: Optional[Type] = Field(None, description='Object type')

--- a/tests/data/openapi/allof_required_fields.yaml
+++ b/tests/data/openapi/allof_required_fields.yaml
@@ -1,0 +1,25 @@
+openapi: "3.0.0"
+components:
+  schemas:
+    EmailMessage:
+      title: Email message
+      description: |
+        An email message. There must be at least one recipient in `to`, `cc`, or `bcc`.
+      type: object
+      required:
+        - allOf:
+            - message
+            - subject
+            - to
+      properties:
+        message:
+          type: string
+          description: The email message text.
+        subject:
+          type: string
+          description: The subject line of the email.
+        to:
+          type: array
+          description: A list of email addresses.
+          items:
+            type: string

--- a/tests/data/openapi/anyof_required.yaml
+++ b/tests/data/openapi/anyof_required.yaml
@@ -1,0 +1,37 @@
+openapi: "3.0.0"
+components:
+  schemas:
+    EmailMessage:
+      title: Email message
+      description: |
+        An email message. There must be at least one recipient in `to`, `cc`, or `bcc`.
+      type: object
+      required:
+        - message
+        - subject
+        - anyOf:
+            - to
+            - cc
+            - bcc
+      properties:
+        bcc:
+          type: array
+          items:
+            type: string
+          description: A list of "blind carbon copy" email addresses.
+        cc:
+          type: array
+          items:
+            type: string
+          description: A list of "carbon copy" email addresses.
+        message:
+          type: string
+          description: The email message text.
+        subject:
+          type: string
+          description: The subject line of the email.
+        to:
+          type: array
+          description: A list of email addresses.
+          items:
+            type: string

--- a/tests/data/openapi/required_null.yaml
+++ b/tests/data/openapi/required_null.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+components:
+  schemas:
+    ObjectBase:
+      description: Object schema
+      type: object
+      properties:
+        name:
+          description: Name of the object
+          type: string
+        type:
+          description: Object type
+          type: string
+          enum:
+            - my_first_object
+            - my_second_object
+            - my_third_object
+      required: null

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -372,6 +372,14 @@ def test_openapi_parser_parse_anyof(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert parser.parse() == (EXPECTED_OPEN_API_PATH / "openapi_parser_parse_anyof" / "output.py").read_text()
 
 
+def test_openapi_parser_parse_anyof_required(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    parser = OpenAPIParser(
+        Path(DATA_PATH / "anyof_required.yaml"),
+    )
+    assert parser.parse() == (EXPECTED_OPEN_API_PATH / "openapi_parser_parse_anyof_required" / "output.py").read_text()
+
+
 def test_openapi_parser_parse_nested_anyof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
@@ -413,6 +421,17 @@ def test_openapi_parser_parse_allof(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         Path(DATA_PATH / "allof.yaml"),
     )
     assert parser.parse() == (EXPECTED_OPEN_API_PATH / "openapi_parser_parse_allof" / "output.py").read_text()
+
+
+def test_openapi_parser_parse_allof_required_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    parser = OpenAPIParser(
+        Path(DATA_PATH / "allof_required_fields.yaml"),
+    )
+    assert (
+        parser.parse()
+        == (EXPECTED_OPEN_API_PATH / "openapi_parser_parse_allof_required_fields" / "output.py").read_text()
+    )
 
 
 def test_openapi_parser_parse_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -499,6 +518,12 @@ def test_openapi_parser_parse_remote_ref(tmp_path: Path, monkeypatch: pytest.Mon
     expected_file = get_expected_file("openapi_parser_parse_remote_ref", True, True)
 
     assert parser.parse() == expected_file.read_text()
+
+
+def test_openapi_parser_parse_required_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    parser = OpenAPIParser(source=Path(DATA_PATH / "required_null.yaml"))
+    assert parser.parse() == (EXPECTED_OPEN_API_PATH / "openapi_parser_parse_required_null" / "output.py").read_text()
 
 
 def test_openapi_model_resolver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
The `required` field, when trying to get parsed as a `JsonSchemaObject` was only allowed to be of the type `list[str]`.

This PR adds a field validator which runs before, to pre-process `required` fields which are set to `null` or which have `anyOf`'s in them (like the OpenAPI schema's generated by [Elastic's Kibana API documentation](https://www.elastic.co/docs/api/doc/kibana/)).

Fixes #2297