### PR TITLE
Use Pytest `tmp_path` fixture instead of `TemporaryDirectory`

### DIFF
--- a/tests/main/graphql/test_annotated.py
+++ b/tests/main/graphql/test_annotated.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
 import pytest
 from freezegun import freeze_time
 
 from datamodel_code_generator.__main__ import Exit, main
 from tests.main.test_main_general import DATA_PATH, EXPECTED_MAIN_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 GRAPHQL_DATA_PATH: Path = DATA_PATH / "graphql"
 EXPECTED_GRAPHQL_PATH: Path = EXPECTED_MAIN_PATH / "graphql"
@@ -22,104 +24,99 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_annotated() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "annotated.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-annotated",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated.py").read_text()
+def test_annotated(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "annotated.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-annotated",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_annotated_use_standard_collections() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "annotated.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-annotated",
-            "--use-standard-collections",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_use_standard_collections.py").read_text()
+def test_annotated_use_standard_collections(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "annotated.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-annotated",
+        "--use-standard-collections",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_use_standard_collections.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_annotated_use_standard_collections_use_union_operator() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "annotated.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-annotated",
-            "--use-standard-collections",
-            "--use-union-operator",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_GRAPHQL_PATH / "annotated_use_standard_collections_use_union_operator.py").read_text()
-        )
+def test_annotated_use_standard_collections_use_union_operator(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "annotated.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-annotated",
+        "--use-standard-collections",
+        "--use-union-operator",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_GRAPHQL_PATH / "annotated_use_standard_collections_use_union_operator.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_annotated_use_union_operator() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "annotated.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-annotated",
-            "--use-union-operator",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_use_union_operator.py").read_text()
+def test_annotated_use_union_operator(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "annotated.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-annotated",
+        "--use-union-operator",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_use_union_operator.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_annotated_field_aliases() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "field-aliases.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-annotated",
-            "--aliases",
-            str(GRAPHQL_DATA_PATH / "field-aliases.json"),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_field_aliases.py").read_text()
+def test_annotated_field_aliases(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "field-aliases.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-annotated",
+        "--aliases",
+        str(GRAPHQL_DATA_PATH / "field-aliases.json"),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_field_aliases.py").read_text()

--- a/tests/main/graphql/test_main_graphql.py
+++ b/tests/main/graphql/test_main_graphql.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
 import black
 import isort
@@ -11,6 +10,9 @@ from freezegun import freeze_time
 
 from datamodel_code_generator.__main__ import Exit, main
 from tests.main.test_main_general import DATA_PATH, EXPECTED_MAIN_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 GRAPHQL_DATA_PATH: Path = DATA_PATH / "graphql"
 EXPECTED_GRAPHQL_PATH: Path = EXPECTED_MAIN_PATH / "graphql"
@@ -41,21 +43,20 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_simple_star_wars(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "simple-star-wars.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / expected_output).read_text()
+def test_main_graphql_simple_star_wars(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "simple-star-wars.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
@@ -63,36 +64,34 @@ def test_main_graphql_simple_star_wars(output_model: str, expected_output: str) 
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_different_types_of_fields() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "different-types-of-fields.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "different_types_of_fields.py").read_text()
+def test_main_graphql_different_types_of_fields(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "different-types-of-fields.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "different_types_of_fields.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_use_default_kwarg() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "annotated.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--use-default-kwarg",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_use_default_kwarg.py").read_text()
+def test_main_use_default_kwarg(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "annotated.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--use-default-kwarg",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "annotated_use_default_kwarg.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -100,21 +99,20 @@ def test_main_use_default_kwarg() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_custom_scalar_types() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "custom-scalar-types.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--extra-template-data",
-            str(GRAPHQL_DATA_PATH / "custom-scalar-types.json"),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "custom_scalar_types.py").read_text()
+def test_main_graphql_custom_scalar_types(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "custom-scalar-types.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--extra-template-data",
+        str(GRAPHQL_DATA_PATH / "custom-scalar-types.json"),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "custom_scalar_types.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -122,21 +120,20 @@ def test_main_graphql_custom_scalar_types() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_field_aliases() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "field-aliases.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--aliases",
-            str(GRAPHQL_DATA_PATH / "field-aliases.json"),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "field_aliases.py").read_text()
+def test_main_graphql_field_aliases(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "field-aliases.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--aliases",
+        str(GRAPHQL_DATA_PATH / "field-aliases.json"),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "field_aliases.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -144,19 +141,18 @@ def test_main_graphql_field_aliases() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_enums() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "enums.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "enums.py").read_text()
+def test_main_graphql_enums(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "enums.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "enums.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -164,19 +160,18 @@ def test_main_graphql_enums() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_union() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "union.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "union.py").read_text()
+def test_main_graphql_union(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "union.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "union.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -184,23 +179,22 @@ def test_main_graphql_union() -> None:
     reason="See https://github.com/PyCQA/isort/issues/1600 for example",
 )
 @freeze_time("2019-07-26")
-def test_main_graphql_additional_imports_isort_4() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "additional-imports.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--extra-template-data",
-            str(GRAPHQL_DATA_PATH / "additional-imports-types.json"),
-            "--additional-imports",
-            "datetime.datetime,datetime.date,mymodule.myclass.MyCustomPythonClass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "additional_imports_isort4.py").read_text()
+def test_main_graphql_additional_imports_isort_4(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "additional-imports.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--extra-template-data",
+        str(GRAPHQL_DATA_PATH / "additional-imports-types.json"),
+        "--additional-imports",
+        "datetime.datetime,datetime.date,mymodule.myclass.MyCustomPythonClass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "additional_imports_isort4.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -212,23 +206,22 @@ def test_main_graphql_additional_imports_isort_4() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_additional_imports_isort_5_or_6() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "additional-imports.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--extra-template-data",
-            str(GRAPHQL_DATA_PATH / "additional-imports-types.json"),
-            "--additional-imports",
-            "datetime.datetime,datetime.date,mymodule.myclass.MyCustomPythonClass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "additional_imports_isort5.py").read_text()
+def test_main_graphql_additional_imports_isort_5_or_6(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "additional-imports.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--extra-template-data",
+        str(GRAPHQL_DATA_PATH / "additional-imports-types.json"),
+        "--additional-imports",
+        "datetime.datetime,datetime.date,mymodule.myclass.MyCustomPythonClass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "additional_imports_isort5.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -236,21 +229,20 @@ def test_main_graphql_additional_imports_isort_5_or_6() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_custom_formatters() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "custom-scalar-types.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--custom-formatters",
-            "tests.data.python.custom_formatters.add_comment",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "custom_formatters.py").read_text()
+def test_main_graphql_custom_formatters(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "custom-scalar-types.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--custom-formatters",
+        "tests.data.python.custom_formatters.add_comment",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "custom_formatters.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -258,20 +250,19 @@ def test_main_graphql_custom_formatters() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_use_standard_collections() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "use-standard-collections.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--use-standard-collections",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "use_standard_collections.py").read_text()
+def test_main_graphql_use_standard_collections(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "use-standard-collections.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--use-standard-collections",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "use_standard_collections.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -279,35 +270,33 @@ def test_main_graphql_use_standard_collections() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_graphql_use_union_operator() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "use-union-operator.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--use-union-operator",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "use_union_operator.py").read_text()
+def test_main_graphql_use_union_operator(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "use-union-operator.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--use-union-operator",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "use_union_operator.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_graphql_extra_fields_allow() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "simple-star-wars.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--extra-fields",
-            "allow",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "simple_star_wars_extra_fields_allow.py").read_text()
+def test_main_graphql_extra_fields_allow(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "simple-star-wars.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--extra-fields",
+        "allow",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "simple_star_wars_extra_fields_allow.py").read_text()

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -200,20 +200,18 @@ def test_main_jsonschema_external_files(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_collapsed_external_references(tmp_path: Path) -> None:
-    output_path: Path = tmp_path / "output"
-    output_path.mkdir()
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "external_reference"),
         "--output",
-        str(output_path),
+        str(tmp_path),
         "--input-file-type",
         "jsonschema",
         "--collapse-root-models",
     ])
     assert return_code == Exit.OK
-    assert (output_path / "ref0.py").read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_ref0.py").read_text()
-    assert (output_path / "other/ref2.py").read_text() == (
+    assert (tmp_path / "ref0.py").read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_ref0.py").read_text()
+    assert (tmp_path / "other/ref2.py").read_text() == (
         EXPECTED_JSON_SCHEMA_PATH / "external_other_ref2.py"
     ).read_text()
 
@@ -239,20 +237,18 @@ def test_main_jsonschema_multiple_files(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_no_empty_collapsed_external_model(tmp_path: Path) -> None:
-    output_path: Path = tmp_path / "output"
-    output_path.mkdir()
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "external_collapse"),
         "--output",
-        str(output_path),
+        str(tmp_path),
         "--input-file-type",
         "jsonschema",
         "--collapse-root-models",
     ])
     assert return_code == Exit.OK
-    assert not (output_path / "child.py").exists()
-    assert (output_path / "__init__.py").exists()
+    assert not (tmp_path / "child.py").exists()
+    assert (tmp_path / "__init__.py").exists()
 
 
 @pytest.mark.parametrize(
@@ -599,11 +595,9 @@ def test_main_jsonschema_id_as_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "id_stdin.py").read_text()
 
 
-def test_main_jsonschema_ids(tmp_path_factory: pytest.TempPathFactory) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
+def test_main_jsonschema_ids(tmp_path: Path) -> None:
     input_filename = JSON_SCHEMA_DATA_PATH / "ids" / "Organization.schema.json"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([
@@ -653,10 +647,8 @@ def test_main_external_files_in_directory(tmp_path: Path) -> None:
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_nested_directory(tmp_path_factory: pytest.TempPathFactory) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
-    output_path = output_directory / "model"
+def test_main_nested_directory(tmp_path: Path) -> None:
+    output_path = tmp_path / "model"
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "external_files_in_directory"),
@@ -1217,12 +1209,8 @@ def test_main_generate_custom_class_name_generator(tmp_path: Path) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_main_generate_custom_class_name_generator_additional_properties(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
-    output_file = output_directory / "models.py"
+def test_main_generate_custom_class_name_generator_additional_properties(tmp_path: Path) -> None:
+    output_file = tmp_path / "models.py"
 
     def custom_class_name_generator(name: str) -> str:
         return f"Custom{name[0].upper() + name[1:]}"
@@ -2089,12 +2077,10 @@ def test_main_jsonschema_boolean_property(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_modular_default_enum_member(
-    tmp_path_factory: pytest.TempPathFactory,
+    tmp_path: Path,
 ) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = JSON_SCHEMA_DATA_PATH / "modular_default_enum_member"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([
@@ -2115,10 +2101,8 @@ def test_main_jsonschema_modular_default_enum_member(
     reason="Installed black doesn't support Python version 3.10",
 )
 @freeze_time("2019-07-26")
-def test_main_use_union_operator(tmp_path_factory: pytest.TempPathFactory) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
-    output_path = output_directory / "model"
+def test_main_use_union_operator(tmp_path: Path) -> None:
+    output_path = tmp_path / "model"
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "external_files_in_directory"),

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -6,7 +6,6 @@ import shutil
 from argparse import Namespace
 from collections import defaultdict
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from unittest.mock import call
 
@@ -50,38 +49,36 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_inheritance_forward_ref() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        shutil.copy(DATA_PATH / "pyproject.toml", Path(output_dir) / "pyproject.toml")
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "inheritance_forward_ref.json"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "inheritance_forward_ref.py").read_text()
+def test_main_inheritance_forward_ref(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "inheritance_forward_ref.json"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "inheritance_forward_ref.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_inheritance_forward_ref_keep_model_order() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        shutil.copy(DATA_PATH / "pyproject.toml", Path(output_dir) / "pyproject.toml")
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "inheritance_forward_ref.json"),
-            "--output",
-            str(output_file),
-            "--keep-model-order",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "inheritance_forward_ref_keep_model_order.py").read_text()
-        )
+def test_main_inheritance_forward_ref_keep_model_order(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "inheritance_forward_ref.json"),
+        "--output",
+        str(output_file),
+        "--keep-model-order",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "inheritance_forward_ref_keep_model_order.py").read_text()
+    )
 
 
 @pytest.mark.skip(reason="pytest-xdist does not support the test")
@@ -93,181 +90,169 @@ def test_main_without_arguments() -> None:
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_autodetect() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "person.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "auto",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "autodetect.py").read_text()
+def test_main_autodetect(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "auto",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "autodetect.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_autodetect_failed() -> None:
-    with TemporaryDirectory() as input_dir, TemporaryDirectory() as output_dir:
-        input_file: Path = Path(input_dir) / "input.yaml"
-        output_file: Path = Path(output_dir) / "output.py"
+def test_main_autodetect_failed(tmp_path: Path) -> None:
+    input_file: Path = tmp_path / "input.yaml"
+    output_file: Path = tmp_path / "output.py"
 
-        input_file.write_text(":")
+    input_file.write_text(":")
 
-        return_code: Exit = main([
-            "--input",
-            str(input_file),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "auto",
-        ])
-        assert return_code == Exit.ERROR
+    return_code: Exit = main([
+        "--input",
+        str(input_file),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "auto",
+    ])
+    assert return_code == Exit.ERROR
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "person.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text()
+def test_main_jsonschema(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_nested_deep() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_init_file: Path = Path(output_dir) / "__init__.py"
-        output_nested_file: Path = Path(output_dir) / "nested/deep.py"
-        output_empty_parent_nested_file: Path = Path(output_dir) / "empty_parent/nested/deep.py"
+def test_main_jsonschema_nested_deep(tmp_path: Path) -> None:
+    output_init_file: Path = tmp_path / "__init__.py"
+    output_nested_file: Path = tmp_path / "nested/deep.py"
+    output_empty_parent_nested_file: Path = tmp_path / "empty_parent/nested/deep.py"
 
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nested_person.json"),
-            "--output",
-            str(output_dir),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_init_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_deep" / "__init__.py").read_text()
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nested_person.json"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_init_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_deep" / "__init__.py").read_text()
 
-        assert (
-            output_nested_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "nested_deep" / "nested" / "deep.py").read_text()
-        )
-        assert (
-            output_empty_parent_nested_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "nested_deep" / "empty_parent" / "nested" / "deep.py").read_text()
-        )
+    assert (
+        output_nested_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_deep" / "nested" / "deep.py").read_text()
+    )
+    assert (
+        output_empty_parent_nested_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "nested_deep" / "empty_parent" / "nested" / "deep.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_nested_skip() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nested_skip.json"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        nested_skip_dir = EXPECTED_JSON_SCHEMA_PATH / "nested_skip"
-        for path in nested_skip_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(nested_skip_dir)).read_text()
-            assert result == path.read_text()
+def test_main_jsonschema_nested_skip(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nested_skip.json"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    nested_skip_dir = EXPECTED_JSON_SCHEMA_PATH / "nested_skip"
+    for path in nested_skip_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(nested_skip_dir)).read_text()
+        assert result == path.read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_external_files() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "external_parent_root.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_files.py").read_text()
+def test_main_jsonschema_external_files(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "external_parent_root.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_files.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_collapsed_external_references() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir) / "output"
-        output_path.mkdir()
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "external_reference"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert (output_path / "ref0.py").read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_ref0.py").read_text()
-        assert (output_path / "other/ref2.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / "external_other_ref2.py"
-        ).read_text()
+def test_main_jsonschema_collapsed_external_references(tmp_path: Path) -> None:
+    output_path: Path = tmp_path / "output"
+    output_path.mkdir()
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "external_reference"),
+        "--output",
+        str(output_path),
+        "--input-file-type",
+        "jsonschema",
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert (output_path / "ref0.py").read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_ref0.py").read_text()
+    assert (output_path / "other/ref2.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / "external_other_ref2.py"
+    ).read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_multiple_files() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "multiple_files"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "multiple_files"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_main_jsonschema_multiple_files(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "multiple_files"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "multiple_files"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_no_empty_collapsed_external_model() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir) / "output"
-        output_path.mkdir()
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "external_collapse"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert not (output_path / "child.py").exists()
-        assert (output_path / "__init__.py").exists()
+def test_main_jsonschema_no_empty_collapsed_external_model(tmp_path: Path) -> None:
+    output_path: Path = tmp_path / "output"
+    output_path.mkdir()
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "external_collapse"),
+        "--output",
+        str(output_path),
+        "--input-file-type",
+        "jsonschema",
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert not (output_path / "child.py").exists()
+    assert (output_path / "__init__.py").exists()
 
 
 @pytest.mark.parametrize(
@@ -284,38 +269,36 @@ def test_main_jsonschema_no_empty_collapsed_external_model() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_null_and_array(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "null_and_array.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_null_and_array(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "null_and_array.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
-def test_use_default_pydantic_v2_with_json_schema_const() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "use_default_with_const.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-default",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "use_default_with_const.py").read_text()
+def test_use_default_pydantic_v2_with_json_schema_const(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "use_default_with_const.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-default",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "use_default_with_const.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -339,291 +322,285 @@ def test_use_default_pydantic_v2_with_json_schema_const() -> None:
         ),
     ],
 )
-def test_main_complicated_enum_default_member(output_model: str, expected_output: str, option: str | None) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            a
-            for a in [
-                "--input",
-                str(JSON_SCHEMA_DATA_PATH / "complicated_enum.json"),
-                "--output",
-                str(output_file),
-                option,
-                "--output-model",
-                output_model,
-            ]
-            if a
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_complicated_enum_default_member(
+    output_model: str, expected_output: str, option: str | None, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        a
+        for a in [
+            "--input",
+            str(JSON_SCHEMA_DATA_PATH / "complicated_enum.json"),
+            "--output",
+            str(output_file),
+            option,
+            "--output-model",
+            output_model,
+        ]
+        if a
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_json_reuse_enum_default_member() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "duplicate_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--reuse-model",
-            "--set-default-enum-member",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_reuse_enum_default_member.py").read_text()
+def test_main_json_reuse_enum_default_member(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "duplicate_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--reuse-model",
+        "--set-default-enum-member",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_reuse_enum_default_member.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_invalid_model_name_failed(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "invalid_model_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--class-name",
-            "with",
-        ])
-        captured = capsys.readouterr()
-        assert return_code == Exit.ERROR
-        assert captured.err == "title='with' is invalid class name. You have to set `--class-name` option\n"
+def test_main_invalid_model_name_failed(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "invalid_model_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--class-name",
+        "with",
+    ])
+    captured = capsys.readouterr()
+    assert return_code == Exit.ERROR
+    assert captured.err == "title='with' is invalid class name. You have to set `--class-name` option\n"
 
 
 @freeze_time("2019-07-26")
-def test_main_invalid_model_name_converted(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "invalid_model_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        captured = capsys.readouterr()
-        assert return_code == Exit.ERROR
-        assert captured.err == "title='1Xyz' is invalid class name. You have to set `--class-name` option\n"
+def test_main_invalid_model_name_converted(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "invalid_model_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    captured = capsys.readouterr()
+    assert return_code == Exit.ERROR
+    assert captured.err == "title='1Xyz' is invalid class name. You have to set `--class-name` option\n"
 
 
 @freeze_time("2019-07-26")
-def test_main_invalid_model_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "invalid_model_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--class-name",
-            "ValidModelName",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "invalid_model_name.py").read_text()
+def test_main_invalid_model_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "invalid_model_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--class-name",
+        "ValidModelName",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "invalid_model_name.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_root_id_jsonschema_with_local_file(mocker: MockerFixture) -> None:
+def test_main_root_id_jsonschema_with_local_file(mocker: MockerFixture, tmp_path: Path) -> None:
     root_id_response = mocker.Mock()
     root_id_response.text = "dummy"
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_id.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text()
-        httpx_get_mock.assert_not_called()
+
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_id.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text()
+    httpx_get_mock.assert_not_called()
 
 
 @freeze_time("2019-07-26")
-def test_main_root_id_jsonschema_with_remote_file(mocker: MockerFixture) -> None:
+def test_main_root_id_jsonschema_with_remote_file(mocker: MockerFixture, tmp_path: Path) -> None:
     root_id_response = mocker.Mock()
     root_id_response.text = "dummy"
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
-    with TemporaryDirectory() as output_dir:
-        input_file = Path(output_dir, "root_id.json")
-        shutil.copy(JSON_SCHEMA_DATA_PATH / "root_id.json", input_file)
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(input_file),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text()
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/person.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+
+    input_file = tmp_path / "root_id.json"
+    shutil.copy(JSON_SCHEMA_DATA_PATH / "root_id.json", input_file)
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(input_file),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text()
+    httpx_get_mock.assert_has_calls([
+        call(
+            "https://example.com/person.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_root_id_jsonschema_self_refs_with_local_file(mocker: MockerFixture) -> None:
+def test_main_root_id_jsonschema_self_refs_with_local_file(mocker: MockerFixture, tmp_path: Path) -> None:
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_id_self_ref.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text().replace(
-            "filename:  root_id.json", "filename:  root_id_self_ref.json"
-        )
-        httpx_get_mock.assert_not_called()
+
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_id_self_ref.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text().replace(
+        "filename:  root_id.json", "filename:  root_id_self_ref.json"
+    )
+    httpx_get_mock.assert_not_called()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_root_id_jsonschema_self_refs_with_remote_file(mocker: MockerFixture) -> None:
+def test_main_root_id_jsonschema_self_refs_with_remote_file(mocker: MockerFixture, tmp_path: Path) -> None:
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
-    with TemporaryDirectory() as output_dir:
-        input_file = Path(output_dir, "root_id_self_ref.json")
-        shutil.copy(JSON_SCHEMA_DATA_PATH / "root_id_self_ref.json", input_file)
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(input_file),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text().replace(
-            "filename:  root_id.json", "filename:  root_id_self_ref.json"
-        )
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/person.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+
+    input_file = tmp_path / "root_id_self_ref.json"
+    shutil.copy(JSON_SCHEMA_DATA_PATH / "root_id_self_ref.json", input_file)
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(input_file),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id.py").read_text().replace(
+        "filename:  root_id.json", "filename:  root_id_self_ref.json"
+    )
+    httpx_get_mock.assert_has_calls([
+        call(
+            "https://example.com/person.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @freeze_time("2019-07-26")
-def test_main_root_id_jsonschema_with_absolute_remote_file(mocker: MockerFixture) -> None:
+def test_main_root_id_jsonschema_with_absolute_remote_file(mocker: MockerFixture, tmp_path: Path) -> None:
     root_id_response = mocker.Mock()
     root_id_response.text = "dummy"
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
-    with TemporaryDirectory() as output_dir:
-        input_file = Path(output_dir, "root_id_absolute_url.json")
-        shutil.copy(JSON_SCHEMA_DATA_PATH / "root_id_absolute_url.json", input_file)
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(input_file),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id_absolute_url.py").read_text()
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/person.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+
+    input_file = tmp_path / "root_id_absolute_url.json"
+    shutil.copy(JSON_SCHEMA_DATA_PATH / "root_id_absolute_url.json", input_file)
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(input_file),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id_absolute_url.py").read_text()
+    httpx_get_mock.assert_has_calls([
+        call(
+            "https://example.com/person.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @freeze_time("2019-07-26")
-def test_main_root_id_jsonschema_with_absolute_local_file() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_id_absolute_url.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id_absolute_url.py").read_text()
+def test_main_root_id_jsonschema_with_absolute_local_file(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_id_absolute_url.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_id_absolute_url.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_id() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "id.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "id.py").read_text()
+def test_main_jsonschema_id(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "id.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "id.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_id_as_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        monkeypatch.setattr("sys.stdin", (JSON_SCHEMA_DATA_PATH / "id.json").open())
-        return_code: Exit = main([
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "id_stdin.py").read_text()
+def test_main_jsonschema_id_as_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    monkeypatch.setattr("sys.stdin", (JSON_SCHEMA_DATA_PATH / "id.json").open())
+    return_code: Exit = main([
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "id_stdin.py").read_text()
 
 
-def test_main_jsonschema_ids(tmpdir_factory: pytest.TempdirFactory) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+def test_main_jsonschema_ids(tmp_path_factory: pytest.TempPathFactory) -> None:
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = JSON_SCHEMA_DATA_PATH / "ids" / "Organization.schema.json"
     output_path = output_directory / "model"
@@ -645,41 +622,39 @@ def test_main_jsonschema_ids(tmpdir_factory: pytest.TempdirFactory) -> None:
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_external_definitions() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "external_definitions_root.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_definitions.py").read_text()
+def test_main_external_definitions(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "external_definitions_root.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_definitions.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_external_files_in_directory() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "external_files_in_directory" / "person.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_files_in_directory.py").read_text()
+def test_main_external_files_in_directory(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "external_files_in_directory" / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "external_files_in_directory.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_nested_directory(tmpdir_factory: pytest.TempdirFactory) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+def test_main_nested_directory(tmp_path_factory: pytest.TempPathFactory) -> None:
+    output_directory = tmp_path_factory.mktemp("output")
 
     output_path = output_directory / "model"
     return_code: Exit = main([
@@ -699,121 +674,112 @@ def test_main_nested_directory(tmpdir_factory: pytest.TempdirFactory) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_main_circular_reference() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "circular_reference.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "circular_reference.py").read_text()
+def test_main_circular_reference(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "circular_reference.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "circular_reference.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_invalid_enum_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "invalid_enum_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "invalid_enum_name.py").read_text()
+def test_main_invalid_enum_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "invalid_enum_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "invalid_enum_name.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_invalid_enum_name_snake_case_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "invalid_enum_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--snake-case-field",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "invalid_enum_name_snake_case_field.py").read_text()
-        )
+def test_main_invalid_enum_name_snake_case_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "invalid_enum_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--snake-case-field",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "invalid_enum_name_snake_case_field.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_json_reuse_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "duplicate_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--reuse-model",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_reuse_enum.py").read_text()
+def test_main_json_reuse_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "duplicate_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--reuse-model",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_reuse_enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_json_capitalise_enum_members() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "many_case_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--capitalise-enum-members",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_capitalise_enum_members.py").read_text()
+def test_main_json_capitalise_enum_members(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "many_case_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--capitalise-enum-members",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_capitalise_enum_members.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_json_capitalise_enum_members_without_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "person.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--capitalise-enum-members",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "autodetect.py").read_text()
+def test_main_json_capitalise_enum_members_without_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--capitalise-enum-members",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "autodetect.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_similar_nested_array() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "similar_nested_array.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "similar_nested_array.py").read_text()
+def test_main_similar_nested_array(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "similar_nested_array.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "similar_nested_array.py").read_text()
 
 
 @pytest.mark.parametrize(
@@ -830,29 +796,27 @@ def test_main_similar_nested_array() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_require_referenced_field(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--output-datetime-class",
-            "AwareDatetime",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
+def test_main_require_referenced_field(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+        "--output-datetime-class",
+        "AwareDatetime",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
 
-        assert (output_path / "referenced.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output / "referenced.py"
-        ).read_text()
-        assert (output_path / "required.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output / "required.py"
-        ).read_text()
+    assert (tmp_path / "referenced.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output / "referenced.py"
+    ).read_text()
+    assert (tmp_path / "required.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output / "required.py"
+    ).read_text()
 
 
 @pytest.mark.parametrize(
@@ -869,29 +833,27 @@ def test_main_require_referenced_field(output_model: str, expected_output: str) 
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_require_referenced_field_naive_datetime(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--output-datetime-class",
-            "NaiveDatetime",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
+def test_main_require_referenced_field_naive_datetime(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+        "--output-datetime-class",
+        "NaiveDatetime",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
 
-        assert (output_path / "referenced.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output / "referenced.py"
-        ).read_text()
-        assert (output_path / "required.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output / "required.py"
-        ).read_text()
+    assert (tmp_path / "referenced.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output / "referenced.py"
+    ).read_text()
+    assert (tmp_path / "required.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output / "required.py"
+    ).read_text()
 
 
 @pytest.mark.parametrize(
@@ -912,262 +874,240 @@ def test_main_require_referenced_field_naive_datetime(output_model: str, expecte
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_require_referenced_field_datetime(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
+def test_main_require_referenced_field_datetime(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
+        "--output",
+        str(object=tmp_path),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
 
-        assert (output_path / "referenced.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output / "referenced.py"
+    assert (tmp_path / "referenced.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output / "referenced.py"
+    ).read_text()
+    assert (tmp_path / "required.py").read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output / "required.py"
+    ).read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_json_pointer(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "json_pointer.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_pointer.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_nested_json_pointer(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nested_json_pointer.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_json_pointer.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_jsonschema_multiple_files_json_pointer(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "multiple_files_json_pointer"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "multiple_files_json_pointer"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_root_model_with_additional_properties(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties.py").read_text()
+    )
+
+
+@freeze_time("2019-07-26")
+def test_main_root_model_with_additional_properties_use_generic_container_types(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-generic-container-types",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (
+            EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties_use_generic_container_types.py"
         ).read_text()
-        assert (output_path / "required.py").read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output / "required.py"
-        ).read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_json_pointer() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
+def test_main_root_model_with_additional_properties_use_standard_collections(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-standard-collections",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties_use_standard_collections.py").read_text()
+    )
+
+
+@freeze_time("2019-07-26")
+def test_main_root_model_with_additional_properties_literal(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--enum-field-as-literal",
+        "all",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties_literal.py").read_text()
+    )
+
+
+@freeze_time("2019-07-26")
+def test_main_jsonschema_multiple_files_ref(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "multiple_files_self_ref"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_jsonschema_multiple_files_ref_test_json(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    with chdir(JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref"):
         return_code: Exit = main([
             "--input",
-            str(JSON_SCHEMA_DATA_PATH / "json_pointer.json"),
+            "test.json",
             "--output",
             str(output_file),
             "--input-file-type",
             "jsonschema",
         ])
         assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_pointer.py").read_text()
+        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "multiple_files_self_ref_single.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_nested_json_pointer() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
+def test_main_space_field_enum_snake_case_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    with chdir(JSON_SCHEMA_DATA_PATH / "space_field_enum.json"):
         return_code: Exit = main([
             "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nested_json_pointer.json"),
+            "space_field_enum.json",
             "--output",
             str(output_file),
             "--input-file-type",
             "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_json_pointer.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_jsonschema_multiple_files_json_pointer() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "multiple_files_json_pointer"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "multiple_files_json_pointer"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_root_model_with_additional_properties() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
+            "--snake-case-field",
+            "--original-field-name-delimiter",
+            " ",
         ])
         assert return_code == Exit.OK
         assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties.py").read_text()
+            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "space_field_enum_snake_case_field.py").read_text()
         )
-
-
-@freeze_time("2019-07-26")
-def test_main_root_model_with_additional_properties_use_generic_container_types() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-generic-container-types",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (
-                EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties_use_generic_container_types.py"
-            ).read_text()
-        )
-
-
-@freeze_time("2019-07-26")
-def test_main_root_model_with_additional_properties_use_standard_collections() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-standard-collections",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (
-                EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties_use_standard_collections.py"
-            ).read_text()
-        )
-
-
-@freeze_time("2019-07-26")
-def test_main_root_model_with_additional_properties_literal(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_model_with_additional_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--enum-field-as-literal",
-            "all",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "root_model_with_additional_properties_literal.py").read_text()
-        )
-
-
-@freeze_time("2019-07-26")
-def test_main_jsonschema_multiple_files_ref() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "multiple_files_self_ref"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_jsonschema_multiple_files_ref_test_json() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        with chdir(JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref"):
-            return_code: Exit = main([
-                "--input",
-                "test.json",
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "jsonschema",
-            ])
-            assert return_code == Exit.OK
-            assert (
-                output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "multiple_files_self_ref_single.py").read_text()
-            )
-
-
-@freeze_time("2019-07-26")
-def test_main_space_field_enum_snake_case_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        with chdir(JSON_SCHEMA_DATA_PATH / "space_field_enum.json"):
-            return_code: Exit = main([
-                "--input",
-                "space_field_enum.json",
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "jsonschema",
-                "--snake-case-field",
-                "--original-field-name-delimiter",
-                " ",
-            ])
-            assert return_code == Exit.OK
-            assert (
-                output_file.read_text()
-                == (EXPECTED_JSON_SCHEMA_PATH / "space_field_enum_snake_case_field.py").read_text()
-            )
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_all_of_ref() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        with chdir(JSON_SCHEMA_DATA_PATH / "all_of_ref"):
-            return_code: Exit = main([
-                "--input",
-                "test.json",
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "jsonschema",
-                "--class-name",
-                "Test",
-            ])
-            assert return_code == Exit.OK
-            assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_ref.py").read_text()
+def test_main_all_of_ref(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    with chdir(JSON_SCHEMA_DATA_PATH / "all_of_ref"):
+        return_code: Exit = main([
+            "--input",
+            "test.json",
+            "--output",
+            str(output_file),
+            "--input-file-type",
+            "jsonschema",
+            "--class-name",
+            "Test",
+        ])
+        assert return_code == Exit.OK
+        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_ref.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_all_of_with_object() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        with chdir(JSON_SCHEMA_DATA_PATH):
-            return_code: Exit = main([
-                "--input",
-                "all_of_with_object.json",
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "jsonschema",
-            ])
-            assert return_code == Exit.OK
-            assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_with_object.py").read_text()
+def test_main_all_of_with_object(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    with chdir(JSON_SCHEMA_DATA_PATH):
+        return_code: Exit = main([
+            "--input",
+            "all_of_with_object.json",
+            "--output",
+            str(output_file),
+            "--input-file-type",
+            "jsonschema",
+        ])
+        assert return_code == Exit.OK
+        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_with_object.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -1175,119 +1115,112 @@ def test_main_all_of_with_object() -> None:
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_main_combined_array() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        with chdir(JSON_SCHEMA_DATA_PATH):
-            return_code: Exit = main([
-                "--input",
-                "combined_array.json",
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "jsonschema",
-            ])
-            assert return_code == Exit.OK
-            assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "combined_array.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_jsonschema_pattern() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
+def test_main_combined_array(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    with chdir(JSON_SCHEMA_DATA_PATH):
         return_code: Exit = main([
             "--input",
-            str(JSON_SCHEMA_DATA_PATH / "pattern.json"),
+            "combined_array.json",
             "--output",
             str(output_file),
             "--input-file-type",
             "jsonschema",
         ])
         assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern.py").read_text()
+        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "combined_array.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_generate() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        input_ = (JSON_SCHEMA_DATA_PATH / "person.json").relative_to(Path.cwd())
-        assert not input_.is_absolute()
-        generate(
-            input_=input_,
-            input_file_type=InputFileType.JsonSchema,
-            output=output_file,
-        )
-
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text()
+def test_main_jsonschema_pattern(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "pattern.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_generate_non_pydantic_output() -> None:
+def test_main_generate(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    input_ = (JSON_SCHEMA_DATA_PATH / "person.json").relative_to(Path.cwd())
+    assert not input_.is_absolute()
+    generate(
+        input_=input_,
+        input_file_type=InputFileType.JsonSchema,
+        output=output_file,
+    )
+
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_generate_non_pydantic_output(tmp_path: Path) -> None:
     """
     See https://github.com/koxudaxi/datamodel-code-generator/issues/1452.
     """
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        input_ = (JSON_SCHEMA_DATA_PATH / "simple_string.json").relative_to(Path.cwd())
-        assert not input_.is_absolute()
-        generate(
-            input_=input_,
-            input_file_type=InputFileType.JsonSchema,
-            output=output_file,
-            output_model_type=DataModelType.DataclassesDataclass,
-        )
+    output_file: Path = tmp_path / "output.py"
+    input_ = (JSON_SCHEMA_DATA_PATH / "simple_string.json").relative_to(Path.cwd())
+    assert not input_.is_absolute()
+    generate(
+        input_=input_,
+        input_file_type=InputFileType.JsonSchema,
+        output=output_file,
+        output_model_type=DataModelType.DataclassesDataclass,
+    )
 
-        file = EXPECTED_JSON_SCHEMA_PATH / "generate_non_pydantic_output.py"
-        assert output_file.read_text() == file.read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_generate_from_directory() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        input_ = (JSON_SCHEMA_DATA_PATH / "external_files_in_directory").relative_to(Path.cwd())
-        assert not input_.is_absolute()
-        assert input_.is_dir()
-        generate(
-            input_=input_,
-            input_file_type=InputFileType.JsonSchema,
-            output=output_path,
-        )
-
-        main_nested_directory = EXPECTED_JSON_SCHEMA_PATH / "nested_directory"
-
-        for path in main_nested_directory.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_nested_directory)).read_text()
-            assert result == path.read_text()
+    file = EXPECTED_JSON_SCHEMA_PATH / "generate_non_pydantic_output.py"
+    assert output_file.read_text() == file.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_generate_custom_class_name_generator() -> None:
+def test_main_generate_from_directory(tmp_path: Path) -> None:
+    input_ = (JSON_SCHEMA_DATA_PATH / "external_files_in_directory").relative_to(Path.cwd())
+    assert not input_.is_absolute()
+    assert input_.is_dir()
+    generate(
+        input_=input_,
+        input_file_type=InputFileType.JsonSchema,
+        output=tmp_path,
+    )
+
+    main_nested_directory = EXPECTED_JSON_SCHEMA_PATH / "nested_directory"
+
+    for path in main_nested_directory.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_nested_directory)).read_text()
+        assert result == path.read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_generate_custom_class_name_generator(tmp_path: Path) -> None:
     def custom_class_name_generator(title: str) -> str:
         return f"Custom{title}"
 
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        input_ = (JSON_SCHEMA_DATA_PATH / "person.json").relative_to(Path.cwd())
-        assert not input_.is_absolute()
-        generate(
-            input_=input_,
-            input_file_type=InputFileType.JsonSchema,
-            output=output_file,
-            custom_class_name_generator=custom_class_name_generator,
-        )
+    output_file: Path = tmp_path / "output.py"
+    input_ = (JSON_SCHEMA_DATA_PATH / "person.json").relative_to(Path.cwd())
+    assert not input_.is_absolute()
+    generate(
+        input_=input_,
+        input_file_type=InputFileType.JsonSchema,
+        output=output_file,
+        custom_class_name_generator=custom_class_name_generator,
+    )
 
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text().replace(
-            "Person", "CustomPerson"
-        )
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text().replace(
+        "Person", "CustomPerson"
+    )
 
 
 @freeze_time("2019-07-26")
 def test_main_generate_custom_class_name_generator_additional_properties(
-    tmpdir_factory: pytest.TempdirFactory,
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     output_file = output_directory / "models.py"
 
@@ -1310,7 +1243,7 @@ def test_main_generate_custom_class_name_generator_additional_properties(
 
 
 @freeze_time("2019-07-26")
-def test_main_http_jsonschema(mocker: MockerFixture) -> None:
+def test_main_http_jsonschema(mocker: MockerFixture, tmp_path: Path) -> None:
     external_directory = JSON_SCHEMA_DATA_PATH / "external_files_in_directory"
 
     def get_mock_response(path: str) -> mocker.Mock:
@@ -1331,81 +1264,80 @@ def test_main_http_jsonschema(mocker: MockerFixture) -> None:
             get_mock_response("definitions/drink/tea.json"),
         ],
     )
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--url",
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--url",
+        "https://example.com/external_files_in_directory/person.json",
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / "external_files_in_directory.py"
+    ).read_text().replace(
+        "#   filename:  person.json",
+        "#   filename:  https://example.com/external_files_in_directory/person.json",
+    )
+    httpx_get_mock.assert_has_calls([
+        call(
             "https://example.com/external_files_in_directory/person.json",
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / "external_files_in_directory.py"
-        ).read_text().replace(
-            "#   filename:  person.json",
-            "#   filename:  https://example.com/external_files_in_directory/person.json",
-        )
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/external_files_in_directory/person.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/relative/animal/pet/pet.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/relative/animal/fur.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/friends.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/food.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/machine/robot.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/drink/coffee.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/drink/tea.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/relative/animal/pet/pet.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/relative/animal/fur.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/friends.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/food.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/machine/robot.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/drink/coffee.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/drink/tea.json",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @freeze_time("2019-07-26")
@@ -1441,6 +1373,7 @@ def test_main_http_jsonschema_with_http_headers_and_http_query_parameters_and_ig
     query_parameters_arguments: tuple[str, ...],
     query_parameters_requests: list[tuple[str, str]],
     http_ignore_tls: bool,
+    tmp_path: Path,
 ) -> None:
     external_directory = JSON_SCHEMA_DATA_PATH / "external_files_in_directory"
 
@@ -1462,122 +1395,119 @@ def test_main_http_jsonschema_with_http_headers_and_http_query_parameters_and_ig
             get_mock_response("definitions/drink/tea.json"),
         ],
     )
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        args = [
-            "--url",
-            "https://example.com/external_files_in_directory/person.json",
-            "--http-headers",
-            *headers_arguments,
-            "--http-query-parameters",
-            *query_parameters_arguments,
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ]
-        if http_ignore_tls:
-            args.append("--http-ignore-tls")
+    output_file: Path = tmp_path / "output.py"
+    args = [
+        "--url",
+        "https://example.com/external_files_in_directory/person.json",
+        "--http-headers",
+        *headers_arguments,
+        "--http-query-parameters",
+        *query_parameters_arguments,
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ]
+    if http_ignore_tls:
+        args.append("--http-ignore-tls")
 
-        return_code: Exit = main(args)
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (
-            EXPECTED_JSON_SCHEMA_PATH / "external_files_in_directory.py"
-        ).read_text().replace(
-            "#   filename:  person.json",
-            "#   filename:  https://example.com/external_files_in_directory/person.json",
-        )
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/external_files_in_directory/person.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/relative/animal/pet/pet.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/relative/animal/fur.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/friends.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/food.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/machine/robot.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/drink/coffee.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-            call(
-                "https://example.com/external_files_in_directory/definitions/drink/tea.json",
-                headers=headers_requests,
-                verify=bool(not http_ignore_tls),
-                follow_redirects=True,
-                params=query_parameters_requests,
-            ),
-        ])
+    return_code: Exit = main(args)
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (
+        EXPECTED_JSON_SCHEMA_PATH / "external_files_in_directory.py"
+    ).read_text().replace(
+        "#   filename:  person.json",
+        "#   filename:  https://example.com/external_files_in_directory/person.json",
+    )
+    httpx_get_mock.assert_has_calls([
+        call(
+            "https://example.com/external_files_in_directory/person.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/relative/animal/pet/pet.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/relative/animal/fur.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/friends.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/food.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/machine/robot.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/drink/coffee.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+        call(
+            "https://example.com/external_files_in_directory/definitions/drink/tea.json",
+            headers=headers_requests,
+            verify=bool(not http_ignore_tls),
+            follow_redirects=True,
+            params=query_parameters_requests,
+        ),
+    ])
 
 
 @freeze_time("2019-07-26")
-def test_main_self_reference() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "self_reference.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "self_reference.py").read_text()
+def test_main_self_reference(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "self_reference.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "self_reference.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_strict_types() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "strict_types.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "strict_types.py").read_text()
+def test_main_strict_types(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "strict_types.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "strict_types.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -1585,233 +1515,216 @@ def test_main_strict_types() -> None:
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_main_strict_types_all() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "strict_types.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--strict-types",
-            "str",
-            "bytes",
-            "int",
-            "float",
-            "bool",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "strict_types_all.py").read_text()
+def test_main_strict_types_all(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "strict_types.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--strict-types",
+        "str",
+        "bytes",
+        "int",
+        "float",
+        "bool",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "strict_types_all.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_strict_types_all_with_field_constraints() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "strict_types.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--strict-types",
-            "str",
-            "bytes",
-            "int",
-            "float",
-            "bool",
-            "--field-constraints",
-        ])
+def test_main_strict_types_all_with_field_constraints(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "strict_types.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--strict-types",
+        "str",
+        "bytes",
+        "int",
+        "float",
+        "bool",
+        "--field-constraints",
+    ])
 
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "strict_types_all_field_constraints.py").read_text()
-        )
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "strict_types_all_field_constraints.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_special_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_enum.py").read_text()
+def test_main_jsonschema_special_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_special_enum_special_field_name_prefix() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--special-field-name-prefix",
-            "special",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "special_enum_special_field_name_prefix.py").read_text()
-        )
+def test_main_jsonschema_special_enum_special_field_name_prefix(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--special-field-name-prefix",
+        "special",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_enum_special_field_name_prefix.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_special_enum_special_field_name_prefix_keep_private() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--special-field-name-prefix",
-            "",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "special_enum_special_field_name_prefix_keep_private.py").read_text()
-        )
+def test_main_jsonschema_special_enum_special_field_name_prefix_keep_private(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--special-field-name-prefix",
+        "",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "special_enum_special_field_name_prefix_keep_private.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_special_model_remove_special_field_name_prefix() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_prefix_model.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--remove-special-field-name-prefix",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "special_model_remove_special_field_name_prefix.py").read_text()
-        )
+def test_main_jsonschema_special_model_remove_special_field_name_prefix(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_prefix_model.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--remove-special-field-name-prefix",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "special_model_remove_special_field_name_prefix.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_subclass_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "subclass_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-subclass-enum",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "subclass_enum.py").read_text()
+def test_main_jsonschema_subclass_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "subclass_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-subclass-enum",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "subclass_enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_special_enum_empty_enum_field_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--empty-enum-field-name",
-            "empty",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_enum_empty_enum_field_name.py").read_text()
-        )
+def test_main_jsonschema_special_enum_empty_enum_field_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--empty-enum-field-name",
+        "empty",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_enum_empty_enum_field_name.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_special_field_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_field_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_field_name.py").read_text()
+def test_main_jsonschema_special_field_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_field_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "special_field_name.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_complex_one_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "complex_one_of.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "complex_one_of.py").read_text()
+def test_main_jsonschema_complex_one_of(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "complex_one_of.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "complex_one_of.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_complex_any_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "complex_any_of.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "complex_any_of.py").read_text()
+def test_main_jsonschema_complex_any_of(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "complex_any_of.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "complex_any_of.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_combine_one_of_object() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "combine_one_of_object.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "combine_one_of_object.py").read_text()
+def test_main_jsonschema_combine_one_of_object(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "combine_one_of_object.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "combine_one_of_object.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -1831,42 +1744,42 @@ def test_main_jsonschema_combine_one_of_object() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_jsonschema_combine_any_of_object(union_mode: str | None, output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main(
-            [
-                "--input",
-                str(JSON_SCHEMA_DATA_PATH / "combine_any_of_object.json"),
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "jsonschema",
-                "--output-model",
-                output_model,
-            ]
-            + ([] if union_mode is None else ["--union-mode", union_mode])
-        )
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
-
-
-@pytest.mark.benchmark
-@freeze_time("2019-07-26")
-def test_main_jsonschema_field_include_all_keys() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
+def test_main_jsonschema_combine_any_of_object(
+    union_mode: str | None, output_model: str, expected_output: str, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main(
+        [
             "--input",
-            str(JSON_SCHEMA_DATA_PATH / "person.json"),
+            str(JSON_SCHEMA_DATA_PATH / "combine_any_of_object.json"),
             "--output",
             str(output_file),
             "--input-file-type",
             "jsonschema",
-            "--field-include-all-keys",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text()
+            "--output-model",
+            output_model,
+        ]
+        + ([] if union_mode is None else ["--union-mode", union_mode])
+    )
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+
+
+@pytest.mark.benchmark
+@freeze_time("2019-07-26")
+def test_main_jsonschema_field_include_all_keys(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--field-include-all-keys",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "general.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -1883,24 +1796,25 @@ def test_main_jsonschema_field_include_all_keys() -> None:
         ),
     ],
 )
-def test_main_jsonschema_field_extras_field_include_all_keys(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "extras.json"),
-            "--output",
-            str(output_file),
-            "--output-model",
-            output_model,
-            "--input-file-type",
-            "jsonschema",
-            "--field-include-all-keys",
-            "--field-extra-keys-without-x-prefix",
-            "x-repr",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_field_extras_field_include_all_keys(
+    output_model: str, expected_output: str, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "extras.json"),
+        "--output",
+        str(output_file),
+        "--output-model",
+        output_model,
+        "--input-file-type",
+        "jsonschema",
+        "--field-include-all-keys",
+        "--field-extra-keys-without-x-prefix",
+        "x-repr",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
@@ -1917,26 +1831,25 @@ def test_main_jsonschema_field_extras_field_include_all_keys(output_model: str, 
         ),
     ],
 )
-def test_main_jsonschema_field_extras_field_extra_keys(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "extras.json"),
-            "--output",
-            str(output_file),
-            "--output-model",
-            output_model,
-            "--input-file-type",
-            "jsonschema",
-            "--field-extra-keys",
-            "key2",
-            "invalid-key-1",
-            "--field-extra-keys-without-x-prefix",
-            "x-repr",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_field_extras_field_extra_keys(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "extras.json"),
+        "--output",
+        str(output_file),
+        "--output-model",
+        output_model,
+        "--input-file-type",
+        "jsonschema",
+        "--field-extra-keys",
+        "key2",
+        "invalid-key-1",
+        "--field-extra-keys-without-x-prefix",
+        "x-repr",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
@@ -1953,21 +1866,20 @@ def test_main_jsonschema_field_extras_field_extra_keys(output_model: str, expect
         ),
     ],
 )
-def test_main_jsonschema_field_extras(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "extras.json"),
-            "--output",
-            str(output_file),
-            "--output-model",
-            output_model,
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_field_extras(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "extras.json"),
+        "--output",
+        str(output_file),
+        "--output-model",
+        output_model,
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @pytest.mark.skipif(
@@ -1988,53 +1900,50 @@ def test_main_jsonschema_field_extras(output_model: str, expected_output: str) -
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_jsonschema_custom_type_path(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "custom_type_path.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_custom_type_path(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "custom_type_path.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_custom_base_path() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "custom_base_path.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "custom_base_path.py").read_text()
+def test_main_jsonschema_custom_base_path(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "custom_base_path.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "custom_base_path.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_long_description() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "long_description.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "long_description.py").read_text()
+def test_long_description(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "long_description.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "long_description.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2042,23 +1951,21 @@ def test_long_description() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_long_description_wrap_string_literal() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "long_description.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--wrap-string-literal",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "long_description_wrap_string_literal.py").read_text()
-        )
+def test_long_description_wrap_string_literal(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "long_description.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--wrap-string-literal",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "long_description_wrap_string_literal.py").read_text()
+    )
 
 
 def test_version(capsys: pytest.CaptureFixture) -> None:
@@ -2071,130 +1978,120 @@ def test_version(capsys: pytest.CaptureFixture) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_jsonschema_pattern_properties() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "pattern_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern_properties.py").read_text()
+def test_jsonschema_pattern_properties(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "pattern_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern_properties.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_jsonschema_pattern_properties_field_constraints() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "pattern_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--field-constraints",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "pattern_properties_field_constraints.py").read_text()
-        )
+def test_jsonschema_pattern_properties_field_constraints(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "pattern_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--field-constraints",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern_properties_field_constraints.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_jsonschema_titles() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "titles.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "titles.py").read_text()
+def test_jsonschema_titles(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "titles.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "titles.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_jsonschema_titles_use_title_as_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "titles.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-title-as-name",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "titles_use_title_as_name.py").read_text()
+def test_jsonschema_titles_use_title_as_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "titles.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-title-as-name",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "titles_use_title_as_name.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_jsonschema_without_titles_use_title_as_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "without_titles.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-title-as-name",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "without_titles_use_title_as_name.py").read_text()
-        )
+def test_jsonschema_without_titles_use_title_as_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "without_titles.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-title-as-name",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "without_titles_use_title_as_name.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_has_default_value() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "has_default_value.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "has_default_value.py").read_text()
+def test_main_jsonschema_has_default_value(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "has_default_value.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "has_default_value.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_boolean_property() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "boolean_property.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "boolean_property.py").read_text()
+def test_main_jsonschema_boolean_property(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "boolean_property.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "boolean_property.py").read_text()
 
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_modular_default_enum_member(
-    tmpdir_factory: pytest.TempdirFactory,
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = JSON_SCHEMA_DATA_PATH / "modular_default_enum_member"
     output_path = output_directory / "model"
@@ -2218,8 +2115,8 @@ def test_main_jsonschema_modular_default_enum_member(
     reason="Installed black doesn't support Python version 3.10",
 )
 @freeze_time("2019-07-26")
-def test_main_use_union_operator(tmpdir_factory: pytest.TempdirFactory) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+def test_main_use_union_operator(tmp_path_factory: pytest.TempPathFactory) -> None:
+    output_directory = tmp_path_factory.mktemp("output")
 
     output_path = output_directory / "model"
     return_code: Exit = main([
@@ -2241,202 +2138,189 @@ def test_main_use_union_operator(tmpdir_factory: pytest.TempdirFactory) -> None:
 
 @freeze_time("2019-07-26")
 @pytest.mark.parametrize("as_module", [True, False])
-def test_treat_dot_as_module(as_module: bool) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
+def test_treat_dot_as_module(as_module: bool, tmp_path: Path) -> None:
+    if as_module:
+        return_code: Exit = main([
+            "--input",
+            str(JSON_SCHEMA_DATA_PATH / "treat_dot_as_module"),
+            "--output",
+            str(tmp_path),
+            "--treat-dot-as-module",
+        ])
+    else:
+        return_code: Exit = main([
+            "--input",
+            str(JSON_SCHEMA_DATA_PATH / "treat_dot_as_module"),
+            "--output",
+            str(tmp_path),
+        ])
+    assert return_code == Exit.OK
+    path_extension = "treat_dot_as_module" if as_module else "treat_dot_not_as_module"
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / path_extension
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
         if as_module:
-            return_code: Exit = main([
-                "--input",
-                str(JSON_SCHEMA_DATA_PATH / "treat_dot_as_module"),
-                "--output",
-                str(output_path),
-                "--treat-dot-as-module",
-            ])
-        else:
-            return_code: Exit = main([
-                "--input",
-                str(JSON_SCHEMA_DATA_PATH / "treat_dot_as_module"),
-                "--output",
-                str(output_path),
-            ])
-        assert return_code == Exit.OK
-        path_extension = "treat_dot_as_module" if as_module else "treat_dot_not_as_module"
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / path_extension
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            if as_module:
-                assert str(path.relative_to(main_modular_dir)).count(".") == 1
-            assert result == path.read_text()
+            assert str(path.relative_to(main_modular_dir)).count(".") == 1
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_duplicate_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "duplicate_name"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "duplicate_name"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_main_jsonschema_duplicate_name(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "duplicate_name"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "duplicate_name"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_items_boolean() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "items_boolean.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "items_boolean.py").read_text()
+def test_main_jsonschema_items_boolean(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "items_boolean.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "items_boolean.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_array_in_additional_properites() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "array_in_additional_properties.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "array_in_additional_properties.py").read_text()
+def test_main_jsonschema_array_in_additional_properites(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "array_in_additional_properties.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "array_in_additional_properties.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_nullable_object() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nullable_object.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nullable_object.py").read_text()
+def test_main_jsonschema_nullable_object(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nullable_object.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nullable_object.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_object_has_one_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "object_has_one_of.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "object_has_one_of.py").read_text()
+def test_main_jsonschema_object_has_one_of(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "object_has_one_of.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "object_has_one_of.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_json_pointer_array() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "json_pointer_array.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_pointer_array.py").read_text()
+def test_main_jsonschema_json_pointer_array(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "json_pointer_array.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "json_pointer_array.py").read_text()
 
 
 @pytest.mark.filterwarnings("error")
-def test_main_disable_warnings_config(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "person.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-union-operator",
-            "--target-python-version",
-            f"3.{MIN_VERSION}",
-            "--disable-warnings",
-        ])
-        captured = capsys.readouterr()
-        assert return_code == Exit.OK
-        assert not captured.err
+def test_main_disable_warnings_config(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-union-operator",
+        "--target-python-version",
+        f"3.{MIN_VERSION}",
+        "--disable-warnings",
+    ])
+    captured = capsys.readouterr()
+    assert return_code == Exit.OK
+    assert not captured.err
 
 
 @pytest.mark.filterwarnings("error")
-def test_main_disable_warnings(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "all_of_with_object.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--disable-warnings",
-        ])
-        captured = capsys.readouterr()
-        assert return_code == Exit.OK
-        assert not captured.err
+def test_main_disable_warnings(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "all_of_with_object.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--disable-warnings",
+    ])
+    captured = capsys.readouterr()
+    assert return_code == Exit.OK
+    assert not captured.err
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_pattern_properties_by_reference() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "pattern_properties_by_reference.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern_properties_by_reference.py").read_text()
+def test_main_jsonschema_pattern_properties_by_reference(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "pattern_properties_by_reference.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "pattern_properties_by_reference.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_dataclass_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "user.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "dataclasses.dataclass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "dataclass_field.py").read_text()
+def test_main_dataclass_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "user.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "dataclasses.dataclass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "dataclass_field.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2444,132 +2328,121 @@ def test_main_dataclass_field() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_jsonschema_enum_root_literal() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "enum_in_root" / "enum_in_root.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--use-schema-description",
-            "--use-title-as-name",
-            "--field-constraints",
-            "--target-python-version",
-            "3.9",
-            "--allow-population-by-field-name",
-            "--strip-default-none",
-            "--use-default",
-            "--enum-field-as-literal",
-            "all",
-            "--snake-case-field",
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_in_enum.py").read_text()
+def test_main_jsonschema_enum_root_literal(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "enum_in_root" / "enum_in_root.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--use-schema-description",
+        "--use-title-as-name",
+        "--field-constraints",
+        "--target-python-version",
+        "3.9",
+        "--allow-population-by-field-name",
+        "--strip-default-none",
+        "--use-default",
+        "--enum-field-as-literal",
+        "all",
+        "--snake-case-field",
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "root_in_enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_nullable_any_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nullable_any_of.json"),
-            "--output",
-            str(output_file),
-            "--field-constraints",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nullable_any_of.py").read_text()
+def test_main_nullable_any_of(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nullable_any_of.json"),
+        "--output",
+        str(output_file),
+        "--field-constraints",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nullable_any_of.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_nullable_any_of_use_union_operator() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nullable_any_of.json"),
-            "--output",
-            str(output_file),
-            "--field-constraints",
-            "--use-union-operator",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nullable_any_of_use_union_operator.py").read_text()
-        )
+def test_main_nullable_any_of_use_union_operator(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nullable_any_of.json"),
+        "--output",
+        str(output_file),
+        "--field-constraints",
+        "--use-union-operator",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nullable_any_of_use_union_operator.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_nested_all_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "nested_all_of.json"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_all_of.py").read_text()
+def test_main_nested_all_of(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "nested_all_of.json"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "nested_all_of.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_all_of_any_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "all_of_any_of"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        all_of_any_of_dir = EXPECTED_JSON_SCHEMA_PATH / "all_of_any_of"
-        for path in all_of_any_of_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(all_of_any_of_dir)).read_text()
-            assert result == path.read_text()
+def test_main_all_of_any_of(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "all_of_any_of"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    all_of_any_of_dir = EXPECTED_JSON_SCHEMA_PATH / "all_of_any_of"
+    for path in all_of_any_of_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(all_of_any_of_dir)).read_text()
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_all_of_one_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "all_of_one_of"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        all_of_any_of_dir = EXPECTED_JSON_SCHEMA_PATH / "all_of_one_of"
-        for path in all_of_any_of_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(all_of_any_of_dir)).read_text()
-            assert result == path.read_text()
+def test_main_all_of_one_of(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "all_of_one_of"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    all_of_any_of_dir = EXPECTED_JSON_SCHEMA_PATH / "all_of_one_of"
+    for path in all_of_any_of_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(all_of_any_of_dir)).read_text()
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_null() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "null.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "null.py").read_text()
+def test_main_null(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "null.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "null.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -2577,24 +2450,23 @@ def test_main_null() -> None:
     reason="Require Black version 23.3.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_typed_dict_special_field_name_with_inheritance_model() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "special_field_name_with_inheritance_model.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-            "--target-python-version",
-            "3.11",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "typed_dict_special_field_name_with_inheritance_model.py").read_text()
-        )
+def test_main_typed_dict_special_field_name_with_inheritance_model(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "special_field_name_with_inheritance_model.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+        "--target-python-version",
+        "3.11",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "typed_dict_special_field_name_with_inheritance_model.py").read_text()
+    )
 
 
 @pytest.mark.skipif(
@@ -2602,24 +2474,21 @@ def test_main_typed_dict_special_field_name_with_inheritance_model() -> None:
     reason="Require Black version 23.3.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_typed_dict_not_required_nullable() -> None:
+def test_main_typed_dict_not_required_nullable(tmp_path: Path) -> None:
     """Test main function writing to TypedDict, with combos of Optional/NotRequired."""
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "not_required_nullable.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-            "--target-python-version",
-            "3.11",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "typed_dict_not_required_nullable.py").read_text()
-        )
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "not_required_nullable.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+        "--target-python-version",
+        "3.11",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "typed_dict_not_required_nullable.py").read_text()
 
 
 @pytest.mark.parametrize(
@@ -2640,21 +2509,22 @@ def test_main_typed_dict_not_required_nullable() -> None:
     int(black.__version__.split(".")[0]) < 24,
     reason="Installed black doesn't support the new style",
 )
-def test_main_jsonschema_discriminator_literals(output_model: str, expected_output: str, min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "discriminator_literals.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            output_model,
-            "--target-python",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_discriminator_literals(
+    output_model: str, expected_output: str, min_version: str, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "discriminator_literals.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        output_model,
+        "--target-python",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2662,21 +2532,20 @@ def test_main_jsonschema_discriminator_literals(output_model: str, expected_outp
     int(black.__version__.split(".")[0]) < 24,
     reason="Installed black doesn't support the new style",
 )
-def test_main_jsonschema_discriminator_literals_with_no_mapping(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "discriminator_no_mapping.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--target-python",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_no_mapping.py").read_text()
+def test_main_jsonschema_discriminator_literals_with_no_mapping(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "discriminator_no_mapping.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--target-python",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_no_mapping.py").read_text()
 
 
 @pytest.mark.parametrize(
@@ -2693,23 +2562,24 @@ def test_main_jsonschema_discriminator_literals_with_no_mapping(min_version: str
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_jsonschema_external_discriminator(output_model: str, expected_output: str, min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "discriminator_with_external_reference" / "inner_folder" / "schema.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            output_model,
-            "--target-python",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text(), (
-            EXPECTED_JSON_SCHEMA_PATH / expected_output
-        )
+def test_main_jsonschema_external_discriminator(
+    output_model: str, expected_output: str, min_version: str, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "discriminator_with_external_reference" / "inner_folder" / "schema.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        output_model,
+        "--target-python",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text(), (
+        EXPECTED_JSON_SCHEMA_PATH / expected_output
+    )
 
 
 @pytest.mark.parametrize(
@@ -2727,47 +2597,43 @@ def test_main_jsonschema_external_discriminator(output_model: str, expected_outp
 )
 @freeze_time("2019-07-26")
 def test_main_jsonschema_external_discriminator_folder(
-    output_model: str, expected_output: str, min_version: str
+    output_model: str, expected_output: str, min_version: str, tmp_path: Path
 ) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "discriminator_with_external_reference"),
-            "--output",
-            str(output_path),
-            "--output-model-type",
-            output_model,
-            "--target-python",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / expected_output
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text(), path
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "discriminator_with_external_reference"),
+        "--output",
+        str(tmp_path),
+        "--output-model-type",
+        output_model,
+        "--target-python",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / expected_output
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text(), path
 
 
 @freeze_time("2019-07-26")
-def test_main_duplicate_field_constraints() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "duplicate_field_constraints"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--collapse-root-models",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "duplicate_field_constraints"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_main_duplicate_field_constraints(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "duplicate_field_constraints"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+        "--collapse-root-models",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "duplicate_field_constraints"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2775,76 +2641,71 @@ def test_main_duplicate_field_constraints() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_duplicate_field_constraints_msgspec(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "duplicate_field_constraints"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            "msgspec.Struct",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "duplicate_field_constraints_msgspec"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_main_duplicate_field_constraints_msgspec(min_version: str, tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "duplicate_field_constraints"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        "msgspec.Struct",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "duplicate_field_constraints_msgspec"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_dataclass_field_defs() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "user_defs.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "dataclasses.dataclass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "dataclass_field.py").read_text().replace(
-            "filename:  user.json", "filename:  user_defs.json"
-        )
+def test_main_dataclass_field_defs(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "user_defs.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "dataclasses.dataclass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "dataclass_field.py").read_text().replace(
+        "filename:  user.json", "filename:  user_defs.json"
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_dataclass_default() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "user_default.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "dataclasses.dataclass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "dataclass_field_default.py").read_text()
+def test_main_dataclass_default(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "user_default.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "dataclasses.dataclass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "dataclass_field_default.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_all_of_ref_self() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "all_of_ref_self.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_ref_self.py").read_text()
+def test_main_all_of_ref_self(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "all_of_ref_self.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_ref_self.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2852,124 +2713,111 @@ def test_main_all_of_ref_self() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_array_field_constraints() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "array_field_constraints.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--target-python-version",
-            "3.9",
-            "--field-constraints",
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "array_field_constraints.py").read_text()
+def test_main_array_field_constraints(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "array_field_constraints.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--target-python-version",
+        "3.9",
+        "--field-constraints",
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "array_field_constraints.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_all_of_use_default() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "all_of_default.json"),
-            "--output",
-            str(output_file),
-            "--use-default",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_use_default.py").read_text()
+def test_all_of_use_default(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "all_of_default.json"),
+        "--output",
+        str(output_file),
+        "--use-default",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "all_of_use_default.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_root_one_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "root_one_of"),
-            "--output",
-            str(output_path),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        expected_directory = EXPECTED_JSON_SCHEMA_PATH / "root_one_of"
-        for path in expected_directory.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(expected_directory)).read_text()
-            assert result == path.read_text()
+def test_main_root_one_of(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "root_one_of"),
+        "--output",
+        str(tmp_path),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    expected_directory = EXPECTED_JSON_SCHEMA_PATH / "root_one_of"
+    for path in expected_directory.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(expected_directory)).read_text()
+        assert result == path.read_text()
 
 
 @freeze_time("2019-07-26")
-def test_one_of_with_sub_schema_array_item() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "one_of_with_sub_schema_array_item.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "one_of_with_sub_schema_array_item.py").read_text()
-        )
+def test_one_of_with_sub_schema_array_item(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "one_of_with_sub_schema_array_item.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "one_of_with_sub_schema_array_item.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_jsonschema_with_custom_formatters() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        formatter_config = {
-            "license_file": str(
-                Path(__file__).parent.parent.parent / "data/python/custom_formatters/license_example.txt"
-            )
-        }
-        formatter_config_path = Path(output_dir, "formatter_config")
-        with formatter_config_path.open("w") as f:
-            json.dump(formatter_config, f)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "person.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--custom-formatters",
-            "tests.data.python.custom_formatters.add_license",
-            "--custom-formatters-kwargs",
-            str(formatter_config_path),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "custom_formatters.py").read_text()
+def test_main_jsonschema_with_custom_formatters(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    formatter_config = {
+        "license_file": str(Path(__file__).parent.parent.parent / "data/python/custom_formatters/license_example.txt")
+    }
+    formatter_config_path = tmp_path / "formatter_config"
+    formatter_config_path.write_text(json.dumps(formatter_config))
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--custom-formatters",
+        "tests.data.python.custom_formatters.add_license",
+        "--custom-formatters-kwargs",
+        str(formatter_config_path),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "custom_formatters.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_imports_correct() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "imports_correct"),
-            "--output",
-            str(output_path),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "imports_correct"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_main_imports_correct(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "imports_correct"),
+        "--output",
+        str(tmp_path),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "imports_correct"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @pytest.mark.parametrize(
@@ -2986,21 +2834,20 @@ def test_main_imports_correct() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_jsonschema_duration(output_model: str, expected_output: str, min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "duration.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            output_model,
-            "--target-python",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_duration(output_model: str, expected_output: str, min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "duration.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        output_model,
+        "--target-python",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
@@ -3008,27 +2855,26 @@ def test_main_jsonschema_duration(output_model: str, expected_output: str, min_v
     int(black.__version__.split(".")[0]) < 24,
     reason="Installed black doesn't support the new style",
 )
-def test_main_jsonschema_keyword_only_msgspec(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "discriminator_literals.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            "msgspec.Struct",
-            "--keyword-only",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_literals_msgspec_keyword_only.py").read_text()
-        )
+def test_main_jsonschema_keyword_only_msgspec(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "discriminator_literals.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        "msgspec.Struct",
+        "--keyword-only",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_literals_msgspec_keyword_only.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
@@ -3036,29 +2882,28 @@ def test_main_jsonschema_keyword_only_msgspec(min_version: str) -> None:
     int(black.__version__.split(".")[0]) < 24,
     reason="Installed black doesn't support the new style",
 )
-def test_main_jsonschema_keyword_only_msgspec_with_extra_data(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "discriminator_literals.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            "msgspec.Struct",
-            "--keyword-only",
-            "--target-python-version",
-            min_version,
-            "--extra-template-data",
-            str(JSON_SCHEMA_DATA_PATH / "extra_data_msgspec.json"),
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_literals_msgspec_keyword_only_omit_defaults.py").read_text()
-        )
+def test_main_jsonschema_keyword_only_msgspec_with_extra_data(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "discriminator_literals.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        "msgspec.Struct",
+        "--keyword-only",
+        "--target-python-version",
+        min_version,
+        "--extra-template-data",
+        str(JSON_SCHEMA_DATA_PATH / "extra_data_msgspec.json"),
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_literals_msgspec_keyword_only_omit_defaults.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
@@ -3066,45 +2911,42 @@ def test_main_jsonschema_keyword_only_msgspec_with_extra_data(min_version: str) 
     int(black.__version__.split(".")[0]) < 24,
     reason="Installed black doesn't support the new style",
 )
-def test_main_jsonschema_openapi_keyword_only_msgspec_with_extra_data() -> None:
+def test_main_jsonschema_openapi_keyword_only_msgspec_with_extra_data(tmp_path: Path) -> None:
     extra_data = json.loads((JSON_SCHEMA_DATA_PATH / "extra_data_msgspec.json").read_text())
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        generate(
-            input_=JSON_SCHEMA_DATA_PATH / "discriminator_literals.json",
-            output=output_file,
-            input_file_type=InputFileType.JsonSchema,
-            output_model_type=DataModelType.MsgspecStruct,
-            keyword_only=True,
-            target_python_version=PythonVersionMin,
-            extra_template_data=defaultdict(dict, extra_data),
-            # Following values are implied by `msgspec.Struct` in the CLI
-            use_annotated=True,
-            field_constraints=True,
-        )
-        assert (
-            output_file.read_text()
-            == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_literals_msgspec_keyword_only_omit_defaults.py").read_text()
-        )
+    output_file: Path = tmp_path / "output.py"
+    generate(
+        input_=JSON_SCHEMA_DATA_PATH / "discriminator_literals.json",
+        output=output_file,
+        input_file_type=InputFileType.JsonSchema,
+        output_model_type=DataModelType.MsgspecStruct,
+        keyword_only=True,
+        target_python_version=PythonVersionMin,
+        extra_template_data=defaultdict(dict, extra_data),
+        # Following values are implied by `msgspec.Struct` in the CLI
+        use_annotated=True,
+        field_constraints=True,
+    )
+    assert (
+        output_file.read_text()
+        == (EXPECTED_JSON_SCHEMA_PATH / "discriminator_literals_msgspec_keyword_only_omit_defaults.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_invalid_import_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "invalid_import_name"),
-            "--output",
-            str(output_path),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "invalid_import_name"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_main_invalid_import_name(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "invalid_import_name"),
+        "--output",
+        str(tmp_path),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_JSON_SCHEMA_PATH / "invalid_import_name"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @pytest.mark.parametrize(
@@ -3121,42 +2963,40 @@ def test_main_invalid_import_name() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_jsonschema_field_has_same_name(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "field_has_same_name.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_jsonschema_field_has_same_name(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "field_has_same_name.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_jsonschema_required_and_any_of_required() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "required_and_any_of_required.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "required_and_any_of_required.py").read_text()
+def test_main_jsonschema_required_and_any_of_required(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "required_and_any_of_required.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / "required_and_any_of_required.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_json_pointer_escaped_segments() -> None:
+def test_main_json_pointer_escaped_segments(tmp_path: Path) -> None:
     schema = {
         "definitions": {
             "foo/bar": {"type": "object", "properties": {"value": {"type": "string"}}},
@@ -3181,26 +3021,26 @@ def test_main_json_pointer_escaped_segments() -> None:
         "class Foo1bar(BaseModel):\n    value: Optional[str] = None\n\n"
         "class Model(BaseModel):\n    foo_bar: Optional[Foo1bar] = None\n    baz_qux: Optional[Baz0qux] = None\n"
     )
-    with TemporaryDirectory() as output_dir:
-        input_file = Path(output_dir) / "input.json"
-        output_file = Path(output_dir) / "output.py"
-        input_file.write_text(json.dumps(schema))
-        return_code: Exit = main([
-            "--input",
-            str(input_file),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        result = output_file.read_text()
-        # Normalize whitespace for comparison
-        assert "".join(result.split()) == "".join(expected.split())
+
+    input_file = tmp_path / "input.json"
+    output_file = tmp_path / "output.py"
+    input_file.write_text(json.dumps(schema))
+    return_code: Exit = main([
+        "--input",
+        str(input_file),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    result = output_file.read_text()
+    # Normalize whitespace for comparison
+    assert "".join(result.split()) == "".join(expected.split())
 
 
 @freeze_time("2019-07-26")
-def test_main_json_pointer_percent_encoded_segments() -> None:
+def test_main_json_pointer_percent_encoded_segments(tmp_path: Path) -> None:
     schema = {
         "definitions": {
             "foo/bar": {"type": "object", "properties": {"value": {"type": "string"}}},
@@ -3231,22 +3071,22 @@ def test_main_json_pointer_percent_encoded_segments() -> None:
         "    baz_qux: Optional[Baz7Equx] = None\n"
         "    space_key: Optional[Space20key] = None\n"
     )
-    with TemporaryDirectory() as output_dir:
-        input_file = Path(output_dir) / "input.json"
-        output_file = Path(output_dir) / "output.py"
-        input_file.write_text(json.dumps(schema))
-        return_code: Exit = main([
-            "--input",
-            str(input_file),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-        ])
-        assert return_code == Exit.OK
-        result = output_file.read_text()
-        # Normalize whitespace for comparison
-        assert "".join(result.split()) == "".join(expected.split())
+
+    input_file = tmp_path / "input.json"
+    output_file = tmp_path / "output.py"
+    input_file.write_text(json.dumps(schema))
+    return_code: Exit = main([
+        "--input",
+        str(input_file),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+    ])
+    assert return_code == Exit.OK
+    result = output_file.read_text()
+    # Normalize whitespace for comparison
+    assert "".join(result.split()) == "".join(expected.split())
 
 
 @pytest.mark.parametrize(
@@ -3285,20 +3125,19 @@ def test_main_json_pointer_percent_encoded_segments() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_extra_fields(extra_fields: str, output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_SCHEMA_DATA_PATH / "extra_fields.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--extra-fields",
-            extra_fields,
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()
+def test_main_extra_fields(extra_fields: str, output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_SCHEMA_DATA_PATH / "extra_fields.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--extra-fields",
+        extra_fields,
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_SCHEMA_PATH / expected_output).read_text()

--- a/tests/main/openapi/test_main_openapi.py
+++ b/tests/main/openapi/test_main_openapi.py
@@ -7,7 +7,6 @@ import shutil
 from argparse import Namespace
 from collections import defaultdict
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
@@ -51,17 +50,16 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "general.py").read_text()
+def test_main(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "general.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -69,23 +67,22 @@ def test_main() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_discriminator_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "discriminator_enum.yaml"),
-            "--output",
-            str(output_file),
-            "--target-python-version",
-            "3.10",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / "enum.py").read_text()
+def test_main_openapi_discriminator_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "discriminator_enum.yaml"),
+        "--output",
+        str(output_file),
+        "--target-python-version",
+        "3.10",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / "enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -93,96 +90,91 @@ def test_main_openapi_discriminator_enum() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_discriminator_enum_duplicate() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "discriminator_enum_duplicate.yaml"),
-            "--output",
-            str(output_file),
-            "--target-python-version",
-            "3.10",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / "enum_duplicate.py").read_text()
+def test_main_openapi_discriminator_enum_duplicate(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "discriminator_enum_duplicate.yaml"),
+        "--output",
+        str(output_file),
+        "--target-python-version",
+        "3.10",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / "enum_duplicate.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_discriminator_with_properties() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "discriminator_with_properties.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
+def test_main_openapi_discriminator_with_properties(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "discriminator_with_properties.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
 
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / "with_properties.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_pydantic_basemodel() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "general.py").read_text()
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / "with_properties.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_base_class() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        shutil.copy(DATA_PATH / "pyproject.toml", Path(output_dir) / "pyproject.toml")
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--base-class",
-            "custom_module.Base",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "base_class.py").read_text()
+def test_main_pydantic_basemodel(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "general.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_target_python_version() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--target-python-version",
-            f"3.{MIN_VERSION}",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "target_python_version.py").read_text()
+def test_main_base_class(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--base-class",
+        "custom_module.Base",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "base_class.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_target_python_version(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--target-python-version",
+        f"3.{MIN_VERSION}",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "target_python_version.py").read_text()
 
 
 @pytest.mark.benchmark
-def test_main_modular(tmpdir_factory: pytest.TempdirFactory) -> None:
+def test_main_modular(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test main function on modular file."""
 
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -195,10 +187,10 @@ def test_main_modular(tmpdir_factory: pytest.TempdirFactory) -> None:
         assert result == path.read_text()
 
 
-def test_main_modular_reuse_model(tmpdir_factory: pytest.TempdirFactory) -> None:
+def test_main_modular_reuse_model(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test main function on modular file."""
 
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -225,10 +217,10 @@ def test_main_modular_no_file() -> None:
     assert main(["--input", str(input_filename)]) == Exit.ERROR
 
 
-def test_main_modular_filename(tmpdir_factory: pytest.TempdirFactory) -> None:
+def test_main_modular_filename(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test main function on modular file with filename."""
 
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_filename = output_directory / "model.py"
@@ -349,7 +341,7 @@ def test_main_openapi_custom_template_dir(
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_pyproject() -> None:
+def test_pyproject(tmp_path: Path) -> None:
     if platform.system() == "Windows":
 
         def get_path(path: str) -> str:
@@ -360,96 +352,87 @@ def test_pyproject() -> None:
         def get_path(path: str) -> str:
             return str(path)
 
-    with TemporaryDirectory() as output_dir:
-        output_path = Path(output_dir)
-
-        with chdir(output_path):
-            output_file: Path = output_path / "output.py"
-            pyproject_toml_path = Path(DATA_PATH) / "project" / "pyproject.toml"
-            pyproject_toml = (
-                pyproject_toml_path.read_text()
-                .replace("INPUT_PATH", get_path(OPEN_API_DATA_PATH / "api.yaml"))
-                .replace("OUTPUT_PATH", get_path(output_file))
-                .replace("ALIASES_PATH", get_path(OPEN_API_DATA_PATH / "empty_aliases.json"))
-                .replace(
-                    "EXTRA_TEMPLATE_DATA_PATH",
-                    get_path(OPEN_API_DATA_PATH / "empty_data.json"),
-                )
-                .replace("CUSTOM_TEMPLATE_DIR_PATH", get_path(output_path))
+    with chdir(tmp_path):
+        output_file: Path = tmp_path / "output.py"
+        pyproject_toml_path = Path(DATA_PATH) / "project" / "pyproject.toml"
+        pyproject_toml = (
+            pyproject_toml_path.read_text()
+            .replace("INPUT_PATH", get_path(OPEN_API_DATA_PATH / "api.yaml"))
+            .replace("OUTPUT_PATH", get_path(output_file))
+            .replace("ALIASES_PATH", get_path(OPEN_API_DATA_PATH / "empty_aliases.json"))
+            .replace(
+                "EXTRA_TEMPLATE_DATA_PATH",
+                get_path(OPEN_API_DATA_PATH / "empty_data.json"),
             )
-            (output_path / "pyproject.toml").write_text(pyproject_toml)
+            .replace("CUSTOM_TEMPLATE_DIR_PATH", get_path(tmp_path))
+        )
+        (tmp_path / "pyproject.toml").write_text(pyproject_toml)
 
-            return_code: Exit = main([])
-            assert return_code == Exit.OK
-            assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pyproject.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_pyproject_not_found() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path = Path(output_dir)
-        with chdir(output_path):
-            output_file: Path = output_path / "output.py"
-            return_code: Exit = main([
-                "--input",
-                str(OPEN_API_DATA_PATH / "api.yaml"),
-                "--output",
-                str(output_file),
-            ])
-            assert return_code == Exit.OK
-            assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pyproject_not_found.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path = Path(output_dir)
-        output_file: Path = output_path / "output.py"
-        monkeypatch.setattr("sys.stdin", (OPEN_API_DATA_PATH / "api.yaml").open())
-        return_code: Exit = main([
-            "--output",
-            str(output_file),
-        ])
+        return_code: Exit = main([])
         assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "stdin.py").read_text()
+        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pyproject.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_validation(mocker: MockerFixture) -> None:
-    mock_prance = mocker.patch("prance.BaseParser")
-
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
+def test_pyproject_not_found(tmp_path: Path) -> None:
+    with chdir(tmp_path):
+        output_file: Path = tmp_path / "output.py"
         return_code: Exit = main([
             "--input",
             str(OPEN_API_DATA_PATH / "api.yaml"),
             "--output",
             str(output_file),
-            "--validation",
         ])
         assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "validation.py").read_text()
-        mock_prance.assert_called_once()
+        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pyproject_not_found.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_validation_failed(mocker: MockerFixture) -> None:
+def test_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    monkeypatch.setattr("sys.stdin", (OPEN_API_DATA_PATH / "api.yaml").open())
+    return_code: Exit = main([
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "stdin.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_validation(mocker: MockerFixture, tmp_path: Path) -> None:
+    mock_prance = mocker.patch("prance.BaseParser")
+
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--validation",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "validation.py").read_text()
+    mock_prance.assert_called_once()
+
+
+@freeze_time("2019-07-26")
+def test_validation_failed(mocker: MockerFixture, tmp_path: Path) -> None:
     mock_prance = mocker.patch("prance.BaseParser", side_effect=Exception("error"))
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        assert (
-            main([
-                "--input",
-                str(OPEN_API_DATA_PATH / "invalid.yaml"),
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "openapi",
-                "--validation",
-            ])
-            == Exit.ERROR
-        )
-        mock_prance.assert_called_once()
+    output_file: Path = tmp_path / "output.py"
+    assert (
+        main([
+            "--input",
+            str(OPEN_API_DATA_PATH / "invalid.yaml"),
+            "--output",
+            str(output_file),
+            "--input-file-type",
+            "openapi",
+            "--validation",
+        ])
+        == Exit.ERROR
+    )
+    mock_prance.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -487,21 +470,20 @@ def test_validation_failed(mocker: MockerFixture) -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_with_field_constraints(output_model: str, expected_output: str, args: list[str]) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
-            "--output",
-            str(output_file),
-            "--field-constraints",
-            "--output-model-type",
-            output_model,
-            *args,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_with_field_constraints(output_model: str, expected_output: str, args: list[str], tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
+        "--output",
+        str(output_file),
+        "--field-constraints",
+        "--output-model-type",
+        output_model,
+        *args,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @pytest.mark.parametrize(
@@ -518,19 +500,18 @@ def test_main_with_field_constraints(output_model: str, expected_output: str, ar
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_without_field_constraints(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_without_field_constraints(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @pytest.mark.parametrize(
@@ -551,128 +532,120 @@ def test_main_without_field_constraints(output_model: str, expected_output: str)
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_with_aliases(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--aliases",
-            str(OPEN_API_DATA_PATH / "aliases.json"),
-            "--target-python",
-            "3.9",
-            "--output-model",
-            output_model,
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_with_aliases(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--aliases",
+        str(OPEN_API_DATA_PATH / "aliases.json"),
+        "--target-python",
+        "3.9",
+        "--output-model",
+        output_model,
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
-def test_main_with_bad_aliases() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--aliases",
-            str(OPEN_API_DATA_PATH / "not.json"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.ERROR
+def test_main_with_bad_aliases(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--aliases",
+        str(OPEN_API_DATA_PATH / "not.json"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.ERROR
 
 
-def test_main_with_more_bad_aliases() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--aliases",
-            str(OPEN_API_DATA_PATH / "list.json"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.ERROR
+def test_main_with_more_bad_aliases(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--aliases",
+        str(OPEN_API_DATA_PATH / "list.json"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.ERROR
 
 
-def test_main_with_bad_extra_data() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--extra-template-data",
-            str(OPEN_API_DATA_PATH / "not.json"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.ERROR
+def test_main_with_bad_extra_data(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--extra-template-data",
+        str(OPEN_API_DATA_PATH / "not.json"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.ERROR
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_with_snake_case_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--snake-case-field",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "with_snake_case_field.py").read_text()
+def test_main_with_snake_case_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--snake-case-field",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "with_snake_case_field.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_with_strip_default_none() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--strip-default-none",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "with_strip_default_none.py").read_text()
+def test_main_with_strip_default_none(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--strip-default-none",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "with_strip_default_none.py").read_text()
 
 
-def test_disable_timestamp() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--disable-timestamp",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "disable_timestamp.py").read_text()
+def test_disable_timestamp(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--disable-timestamp",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "disable_timestamp.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_enable_version_header() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--enable-version-header",
-        ])
-        assert return_code == Exit.OK
-        expected = (EXPECTED_OPENAPI_PATH / "enable_version_header.py").read_text()
-        expected = expected.replace("#   version:   0.0.0", f"#   version:   {get_version()}")
-        assert output_file.read_text() == expected
+def test_enable_version_header(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--enable-version-header",
+    ])
+    assert return_code == Exit.OK
+    expected = (EXPECTED_OPENAPI_PATH / "enable_version_header.py").read_text()
+    expected = expected.replace("#   version:   0.0.0", f"#   version:   {get_version()}")
+    assert output_file.read_text() == expected
 
 
 @pytest.mark.parametrize(
@@ -693,20 +666,19 @@ def test_enable_version_header() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_allow_population_by_field_name(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--allow-population-by-field-name",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_allow_population_by_field_name(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--allow-population-by-field-name",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @pytest.mark.parametrize(
@@ -727,20 +699,19 @@ def test_allow_population_by_field_name(output_model: str, expected_output: str)
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_allow_extra_fields(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--allow-extra-fields",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_allow_extra_fields(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--allow-extra-fields",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @pytest.mark.parametrize(
@@ -761,84 +732,79 @@ def test_allow_extra_fields(output_model: str, expected_output: str) -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_enable_faux_immutability(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--enable-faux-immutability",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_enable_faux_immutability(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--enable-faux-immutability",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_use_default() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--use-default",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "use_default.py").read_text()
+def test_use_default(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--use-default",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "use_default.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_force_optional() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--force-optional",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "force_optional.py").read_text()
+def test_force_optional(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--force-optional",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "force_optional.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_with_exclusive() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "exclusive.yaml"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "with_exclusive.py").read_text()
+def test_main_with_exclusive(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "exclusive.yaml"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "with_exclusive.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_subclass_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "subclass_enum.json"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "subclass_enum.py").read_text()
+def test_main_subclass_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "subclass_enum.json"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "subclass_enum.py").read_text()
 
 
-def test_main_use_standard_collections(tmpdir_factory: pytest.TempdirFactory) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+def test_main_use_standard_collections(tmp_path_factory: pytest.TempPathFactory) -> None:
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -861,8 +827,8 @@ def test_main_use_standard_collections(tmpdir_factory: pytest.TempdirFactory) ->
     black.__version__.split(".")[0] >= "24",
     reason="Installed black doesn't support the old style",
 )
-def test_main_use_generic_container_types(tmpdir_factory: pytest.TempdirFactory) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+def test_main_use_generic_container_types(tmp_path_factory: pytest.TempPathFactory) -> None:
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -887,9 +853,9 @@ def test_main_use_generic_container_types(tmpdir_factory: pytest.TempdirFactory)
 )
 @pytest.mark.benchmark
 def test_main_use_generic_container_types_standard_collections(
-    tmpdir_factory: pytest.TempdirFactory,
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -937,23 +903,22 @@ def test_main_original_field_name_delimiter_without_snake_case_field(capsys: pyt
         ("msgspec.Struct", "datetime_msgspec.py", "datetime"),
     ],
 )
-def test_main_openapi_aware_datetime(output_model: str, expected_output: str, date_type: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "datetime.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-datetime-class",
-            date_type,
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_openapi_aware_datetime(output_model: str, expected_output: str, date_type: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "datetime.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-datetime-class",
+        date_type,
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
@@ -970,38 +935,36 @@ def test_main_openapi_aware_datetime(output_model: str, expected_output: str, da
         ),
     ],
 )
-def test_main_openapi_datetime(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "datetime.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_openapi_datetime(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "datetime.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_models_not_found(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "no_components.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        captured = capsys.readouterr()
-        assert return_code == Exit.ERROR
-        assert captured.err == "Models not found in the input data\n"
+def test_main_models_not_found(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "no_components.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    captured = capsys.readouterr()
+    assert return_code == Exit.ERROR
+    assert captured.err == "Models not found in the input data\n"
 
 
 @pytest.mark.skipif(
@@ -1009,23 +972,22 @@ def test_main_models_not_found(capsys: pytest.CaptureFixture) -> None:
     reason="Require Pydantic version 1.9.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_enum_models_as_literal_one(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "enum_models.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--enum-field-as-literal",
-            "one",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "one.py").read_text()
+def test_main_openapi_enum_models_as_literal_one(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "enum_models.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--enum-field-as-literal",
+        "one",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "one.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -1033,26 +995,23 @@ def test_main_openapi_enum_models_as_literal_one(min_version: str) -> None:
     reason="Require Pydantic version 1.9.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_use_one_literal_as_default(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "enum_models.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--enum-field-as-literal",
-            "one",
-            "--target-python-version",
-            min_version,
-            "--use-one-literal-as-default",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "one_literal_as_default.py").read_text()
-        )
+def test_main_openapi_use_one_literal_as_default(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "enum_models.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--enum-field-as-literal",
+        "one",
+        "--target-python-version",
+        min_version,
+        "--use-one-literal-as-default",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "one_literal_as_default.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -1064,23 +1023,22 @@ def test_main_openapi_use_one_literal_as_default(min_version: str) -> None:
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_enum_models_as_literal_all(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "enum_models.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--enum-field-as-literal",
-            "all",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "all.py").read_text()
+def test_main_openapi_enum_models_as_literal_all(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "enum_models.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--enum-field-as-literal",
+        "all",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "all.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -1092,75 +1050,71 @@ def test_main_openapi_enum_models_as_literal_all(min_version: str) -> None:
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_enum_models_as_literal() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "enum_models.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--enum-field-as-literal",
-            "all",
-            "--target-python-version",
-            f"3.{MIN_VERSION}",
-        ])
+def test_main_openapi_enum_models_as_literal(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "enum_models.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--enum-field-as-literal",
+        "all",
+        "--target-python-version",
+        f"3.{MIN_VERSION}",
+    ])
 
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "as_literal.py").read_text()
-
-
-@pytest.mark.benchmark
-@freeze_time("2019-07-26")
-def test_main_openapi_all_of_required() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "allof_required.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "allof_required.py").read_text()
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "enum_models" / "as_literal.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_openapi_nullable() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nullable.py").read_text()
+def test_main_openapi_all_of_required(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "allof_required.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "allof_required.py").read_text()
+
+
+@pytest.mark.benchmark
+@freeze_time("2019-07-26")
+def test_main_openapi_nullable(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nullable.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_nullable_strict_nullable() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--strict-nullable",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nullable_strict_nullable.py").read_text()
+def test_main_openapi_nullable_strict_nullable(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--strict-nullable",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nullable_strict_nullable.py").read_text()
 
 
 @pytest.mark.parametrize(
@@ -1185,25 +1139,24 @@ def test_main_openapi_nullable_strict_nullable() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_pattern(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "pattern.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--target-python",
-            "3.9",
-            "--output-model-type",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pattern" / expected_output).read_text().replace(
-            "pattern.json", "pattern.yaml"
-        )
+def test_main_openapi_pattern(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "pattern.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--target-python",
+        "3.9",
+        "--output-model-type",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pattern" / expected_output).read_text().replace(
+        "pattern.json", "pattern.yaml"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1221,31 +1174,32 @@ def test_main_openapi_pattern(output_model: str, expected_output: str) -> None:
     black.__version__.split(".")[0] < "22",
     reason="Installed black doesn't support Python version 3.10",
 )
-def test_main_openapi_pattern_with_lookaround_pydantic_v2(expected_output: str, args: list[str]) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "pattern_lookaround.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--target-python",
-            "3.9",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            *args,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_openapi_pattern_with_lookaround_pydantic_v2(
+    expected_output: str, args: list[str], tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "pattern_lookaround.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--target-python",
+        "3.9",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        *args,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
 def test_main_generate_custom_class_name_generator_modular(
-    tmpdir_factory: pytest.TempdirFactory,
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     output_path = output_directory / "model"
     main_modular_custom_class_name_dir = EXPECTED_OPENAPI_PATH / "modular_custom_class_name"
@@ -1269,7 +1223,7 @@ def test_main_generate_custom_class_name_generator_modular(
 
 
 @freeze_time("2019-07-26")
-def test_main_http_openapi(mocker: MockerFixture) -> None:
+def test_main_http_openapi(mocker: MockerFixture, tmp_path: Path) -> None:
     def get_mock_response(path: str) -> Mock:
         mock = mocker.Mock()
         mock.text = (OPEN_API_DATA_PATH / path).read_text()
@@ -1282,191 +1236,181 @@ def test_main_http_openapi(mocker: MockerFixture) -> None:
             get_mock_response("definitions.yaml"),
         ],
     )
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--url",
+
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--url",
+        "https://example.com/refs.yaml",
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "http_refs.py").read_text()
+    httpx_get_mock.assert_has_calls([
+        call(
             "https://example.com/refs.yaml",
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "http_refs.py").read_text()
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/refs.yaml",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-            call(
-                "https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+        call(
+            "https://teamdigitale.github.io/openapi/0.0.6/definitions.yaml",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @freeze_time("2019-07-26")
-def test_main_disable_appending_item_suffix() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
-            "--output",
-            str(output_file),
-            "--field-constraints",
-            "--disable-appending-item-suffix",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "disable_appending_item_suffix.py").read_text()
+def test_main_disable_appending_item_suffix(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
+        "--output",
+        str(output_file),
+        "--field-constraints",
+        "--disable-appending-item-suffix",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "disable_appending_item_suffix.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_body_and_parameters() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--openapi-scopes",
-            "paths",
-            "schemas",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "general.py").read_text()
+def test_main_openapi_body_and_parameters(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--openapi-scopes",
+        "paths",
+        "schemas",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "general.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_body_and_parameters_remote_ref(mocker: MockerFixture) -> None:
+def test_main_openapi_body_and_parameters_remote_ref(mocker: MockerFixture, tmp_path: Path) -> None:
     input_path = OPEN_API_DATA_PATH / "body_and_parameters_remote_ref.yaml"
     person_response = mocker.Mock()
     person_response.text = input_path.read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
 
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(input_path),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--openapi-scopes",
-            "paths",
-            "schemas",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "remote_ref.py").read_text()
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://schema.example",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(input_path),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--openapi-scopes",
+        "paths",
+        "schemas",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "remote_ref.py").read_text()
+    httpx_get_mock.assert_has_calls([
+        call(
+            "https://schema.example",
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_body_and_parameters_only_paths() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--openapi-scopes",
-            "paths",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "only_paths.py").read_text()
+def test_main_openapi_body_and_parameters_only_paths(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--openapi-scopes",
+        "paths",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "only_paths.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_body_and_parameters_only_schemas() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--openapi-scopes",
-            "schemas",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "only_schemas.py").read_text()
-        )
+def test_main_openapi_body_and_parameters_only_schemas(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--openapi-scopes",
+        "schemas",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "body_and_parameters" / "only_schemas.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_content_in_parameters() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "content_in_parameters.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "content_in_parameters.py").read_text()
+def test_main_openapi_content_in_parameters(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "content_in_parameters.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "content_in_parameters.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_oas_response_reference() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "oas_response_reference.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--openapi-scopes",
-            "paths",
-            "schemas",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "oas_response_reference.py").read_text()
+def test_main_openapi_oas_response_reference(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "oas_response_reference.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--openapi-scopes",
+        "paths",
+        "schemas",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "oas_response_reference.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_json_pointer() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "json_pointer.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "json_pointer.py").read_text()
+def test_main_openapi_json_pointer(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "json_pointer.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "json_pointer.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -1484,56 +1428,55 @@ def test_main_openapi_json_pointer() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_use_annotated_with_field_constraints(output_model: str, expected_output: str, min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
-            "--output",
-            str(output_file),
-            "--field-constraints",
-            "--use-annotated",
-            "--target-python-version",
-            min_version,
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_use_annotated_with_field_constraints(
+    output_model: str, expected_output: str, min_version: str, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
+        "--output",
+        str(output_file),
+        "--field-constraints",
+        "--use-annotated",
+        "--target-python-version",
+        min_version,
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_nested_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nested_enum.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nested_enum.py").read_text()
+def test_main_nested_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nested_enum.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nested_enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_openapi_special_yaml_keywords(mocker: MockerFixture) -> None:
+def test_openapi_special_yaml_keywords(mocker: MockerFixture, tmp_path: Path) -> None:
     mock_prance = mocker.patch("prance.BaseParser")
 
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "special_yaml_keywords.yaml"),
-            "--output",
-            str(output_file),
-            "--validation",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "special_yaml_keywords.py").read_text()
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "special_yaml_keywords.yaml"),
+        "--output",
+        str(output_file),
+        "--validation",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "special_yaml_keywords.py").read_text()
     mock_prance.assert_called_once()
 
 
@@ -1542,110 +1485,101 @@ def test_openapi_special_yaml_keywords(mocker: MockerFixture) -> None:
     reason="Installed black doesn't support Python version 3.10",
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_nullable_use_union_operator() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--use-union-operator",
-            "--strict-nullable",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_OPENAPI_PATH / "nullable_strict_nullable_use_union_operator.py").read_text()
-        )
+def test_main_openapi_nullable_use_union_operator(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--use-union-operator",
+        "--strict-nullable",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_OPENAPI_PATH / "nullable_strict_nullable_use_union_operator.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_external_relative_ref() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "external_relative_ref" / "model_b"),
-            "--output",
-            str(output_path),
-        ])
-        assert return_code == Exit.OK
-        main_modular_dir = EXPECTED_OPENAPI_PATH / "external_relative_ref"
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text()
+def test_external_relative_ref(tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "external_relative_ref" / "model_b"),
+        "--output",
+        str(tmp_path),
+    ])
+    assert return_code == Exit.OK
+    main_modular_dir = EXPECTED_OPENAPI_PATH / "external_relative_ref"
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_collapse_root_models() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "not_real_string.json"),
-            "--output",
-            str(output_file),
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "collapse_root_models.py").read_text()
+def test_main_collapse_root_models(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "not_real_string.json"),
+        "--output",
+        str(output_file),
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "collapse_root_models.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_collapse_root_models_field_constraints() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "not_real_string.json"),
-            "--output",
-            str(output_file),
-            "--collapse-root-models",
-            "--field-constraints",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_OPENAPI_PATH / "collapse_root_models_field_constraints.py").read_text()
-        )
+def test_main_collapse_root_models_field_constraints(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "not_real_string.json"),
+        "--output",
+        str(output_file),
+        "--collapse-root-models",
+        "--field-constraints",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "collapse_root_models_field_constraints.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_collapse_root_models_with_references_to_flat_types() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "flat_type.jsonschema"),
-            "--output",
-            str(output_file),
-            "--collapse-root-models",
-        ])
+def test_main_collapse_root_models_with_references_to_flat_types(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "flat_type.jsonschema"),
+        "--output",
+        str(output_file),
+        "--collapse-root-models",
+    ])
 
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_OPENAPI_PATH / "collapse_root_models_with_references_to_flat_types.py").read_text()
-        )
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_OPENAPI_PATH / "collapse_root_models_with_references_to_flat_types.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_max_items_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "max_items_enum.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "max_items_enum.py").read_text()
+def test_main_openapi_max_items_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "max_items_enum.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "max_items_enum.py").read_text()
 
 
 @pytest.mark.parametrize(
@@ -1662,21 +1596,20 @@ def test_main_openapi_max_items_enum() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_const(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "const.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model",
-            output_model,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_openapi_const(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "const.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model",
+        output_model,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @pytest.mark.parametrize(
@@ -1697,108 +1630,102 @@ def test_main_openapi_const(output_model: str, expected_output: str) -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_const_field(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "const.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model",
-            output_model,
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
+def test_main_openapi_const_field(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "const.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model",
+        output_model,
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / expected_output).read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_complex_reference() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "complex_reference.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "complex_reference.py").read_text()
+def test_main_openapi_complex_reference(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "complex_reference.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "complex_reference.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_reference_to_object_properties() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "reference_to_object_properties.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "reference_to_object_properties.py").read_text()
+def test_main_openapi_reference_to_object_properties(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "reference_to_object_properties.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "reference_to_object_properties.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_reference_to_object_properties_collapse_root_models() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "reference_to_object_properties.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_OPENAPI_PATH / "reference_to_object_properties_collapse_root_models.py").read_text()
-        )
+def test_main_openapi_reference_to_object_properties_collapse_root_models(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "reference_to_object_properties.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_OPENAPI_PATH / "reference_to_object_properties_collapse_root_models.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_override_required_all_of_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "override_required_all_of.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "override_required_all_of.py").read_text()
+def test_main_openapi_override_required_all_of_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "override_required_all_of.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "override_required_all_of.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_use_default_kwarg() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--use-default-kwarg",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "use_default_kwarg.py").read_text()
+def test_main_use_default_kwarg(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--use-default-kwarg",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "use_default_kwarg.py").read_text()
 
 
 @pytest.mark.parametrize(
@@ -1815,19 +1742,18 @@ def test_main_use_default_kwarg() -> None:
     ],
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_discriminator(input_: str, output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / input_),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / output).read_text()
+def test_main_openapi_discriminator(input_: str, output: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / input_),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / output).read_text()
 
 
 @freeze_time("2023-07-27")
@@ -1848,27 +1774,26 @@ def test_main_openapi_discriminator(input_: str, output: str) -> None:
         ("oneOf", None, "in_array.py"),
     ],
 )
-def test_main_openapi_discriminator_in_array(kind: str, option: str | None, expected: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        input_file = f"discriminator_in_array_{kind.lower()}.yaml"
-        return_code: Exit = main([
-            a
-            for a in [
-                "--input",
-                str(OPEN_API_DATA_PATH / input_file),
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "openapi",
-                option,
-            ]
-            if a
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / expected).read_text().replace(
-            "discriminator_in_array.yaml", input_file
-        )
+def test_main_openapi_discriminator_in_array(kind: str, option: str | None, expected: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    input_file = f"discriminator_in_array_{kind.lower()}.yaml"
+    return_code: Exit = main([
+        a
+        for a in [
+            "--input",
+            str(OPEN_API_DATA_PATH / input_file),
+            "--output",
+            str(output_file),
+            "--input-file-type",
+            "openapi",
+            option,
+        ]
+        if a
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "discriminator" / expected).read_text().replace(
+        "discriminator_in_array.yaml", input_file
+    )
 
 
 @pytest.mark.parametrize(
@@ -1893,67 +1818,63 @@ def test_main_openapi_discriminator_in_array(kind: str, option: str | None, expe
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_default_object(output_model: str, expected_output: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path: Path = Path(output_dir)
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "default_object.yaml"),
-            "--output",
-            str(output_dir),
-            "--output-model",
-            output_model,
-            "--input-file-type",
-            "openapi",
-            "--target-python-version",
-            "3.9",
-        ])
-        assert return_code == Exit.OK
+def test_main_openapi_default_object(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "default_object.yaml"),
+        "--output",
+        str(tmp_path),
+        "--output-model",
+        output_model,
+        "--input-file-type",
+        "openapi",
+        "--target-python-version",
+        "3.9",
+    ])
+    assert return_code == Exit.OK
 
-        main_modular_dir = EXPECTED_OPENAPI_PATH / expected_output
-        for path in main_modular_dir.rglob("*.py"):
-            result = output_path.joinpath(path.relative_to(main_modular_dir)).read_text()
-            assert result == path.read_text(), path
+    main_modular_dir = EXPECTED_OPENAPI_PATH / expected_output
+    for path in main_modular_dir.rglob("*.py"):
+        result = tmp_path.joinpath(path.relative_to(main_modular_dir)).read_text()
+        assert result == path.read_text(), path
 
 
 @freeze_time("2019-07-26")
-def test_main_dataclass() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "dataclasses.dataclass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "dataclass.py").read_text()
+def test_main_dataclass(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "dataclasses.dataclass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "dataclass.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_dataclass_base_class() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "dataclasses.dataclass",
-            "--base-class",
-            "custom_base.Base",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "dataclass_base_class.py").read_text()
+def test_main_dataclass_base_class(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "dataclasses.dataclass",
+        "--base-class",
+        "custom_base.Base",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "dataclass_base_class.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_reference_same_hierarchy_directory() -> None:
-    with TemporaryDirectory() as output_dir, chdir(OPEN_API_DATA_PATH / "reference_same_hierarchy_directory"):
-        output_file: Path = Path(output_dir) / "output.py"
+def test_main_openapi_reference_same_hierarchy_directory(tmp_path: Path) -> None:
+    with chdir(OPEN_API_DATA_PATH / "reference_same_hierarchy_directory"):
+        output_file: Path = tmp_path / "output.py"
         return_code: Exit = main([
             "--input",
             "./public/entities.yaml",
@@ -1967,136 +1888,131 @@ def test_main_openapi_reference_same_hierarchy_directory() -> None:
 
 
 @freeze_time("2019-07-26")
-def test_main_multiple_required_any_of() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "multiple_required_any_of.yaml"),
-            "--output",
-            str(output_file),
-            "--collapse-root-models",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "multiple_required_any_of.py").read_text()
+def test_main_multiple_required_any_of(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "multiple_required_any_of.yaml"),
+        "--output",
+        str(output_file),
+        "--collapse-root-models",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "multiple_required_any_of.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_max_min() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "max_min_number.yaml"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "max_min_number.py").read_text()
+def test_main_openapi_max_min(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "max_min_number.yaml"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "max_min_number.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_use_operation_id_as_name() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--use-operation-id-as-name",
-            "--openapi-scopes",
-            "paths",
-            "schemas",
-            "parameters",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "use_operation_id_as_name.py").read_text()
+def test_main_openapi_use_operation_id_as_name(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--use-operation-id-as-name",
+        "--openapi-scopes",
+        "paths",
+        "schemas",
+        "parameters",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "use_operation_id_as_name.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_use_operation_id_as_name_not_found_operation_id(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--use-operation-id-as-name",
-            "--openapi-scopes",
-            "paths",
-            "schemas",
-            "parameters",
-        ])
-        captured = capsys.readouterr()
-        assert return_code == Exit.ERROR
-        assert (
-            captured.err == "All operations must have an operationId when --use_operation_id_as_name is set."
-            "The following path was missing an operationId: pets\n"
-        )
+def test_main_openapi_use_operation_id_as_name_not_found_operation_id(
+    capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "body_and_parameters.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--use-operation-id-as-name",
+        "--openapi-scopes",
+        "paths",
+        "schemas",
+        "parameters",
+    ])
+    captured = capsys.readouterr()
+    assert return_code == Exit.ERROR
+    assert (
+        captured.err == "All operations must have an operationId when --use_operation_id_as_name is set."
+        "The following path was missing an operationId: pets\n"
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_unsorted_optional_fields() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "unsorted_optional_fields.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "dataclasses.dataclass",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "unsorted_optional_fields.py").read_text()
+def test_main_unsorted_optional_fields(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "unsorted_optional_fields.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "dataclasses.dataclass",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "unsorted_optional_fields.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_typed_dict() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict.py").read_text()
+def test_main_typed_dict(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_typed_dict_py(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict_py.py").read_text()
+def test_main_typed_dict_py(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict_py.py").read_text()
 
 
 @pytest.mark.skipif(
     version.parse(black.__version__) < version.parse("23.3.0"),
     reason="Require Black version 23.3.0 or later ",
 )
-def test_main_modular_typed_dict(tmpdir_factory: pytest.TempdirFactory) -> None:
+def test_main_modular_typed_dict(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test main function on modular file."""
 
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -2123,21 +2039,20 @@ def test_main_modular_typed_dict(tmpdir_factory: pytest.TempdirFactory) -> None:
     reason="Require Black version 23.3.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_typed_dict_nullable() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-            "--target-python-version",
-            "3.11",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict_nullable.py").read_text()
+def test_main_typed_dict_nullable(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+        "--target-python-version",
+        "3.11",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict_nullable.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -2145,111 +2060,105 @@ def test_main_typed_dict_nullable() -> None:
     reason="Require Black version 23.3.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_typed_dict_nullable_strict_nullable() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-            "--target-python-version",
-            "3.11",
-            "--strict-nullable",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict_nullable_strict_nullable.py").read_text()
+def test_main_typed_dict_nullable_strict_nullable(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+        "--target-python-version",
+        "3.11",
+        "--strict-nullable",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "typed_dict_nullable_strict_nullable.py").read_text()
 
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_openapi_nullable_31() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "nullable_31.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--strip-default-none",
-            "--use-union-operator",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nullable_31.py").read_text()
+def test_main_openapi_nullable_31(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "nullable_31.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--strip-default-none",
+        "--use-union-operator",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "nullable_31.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_custom_file_header_path() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--custom-file-header-path",
-            str(DATA_PATH / "custom_file_header.txt"),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "custom_file_header.py").read_text()
+def test_main_custom_file_header_path(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--custom-file-header-path",
+        str(DATA_PATH / "custom_file_header.txt"),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "custom_file_header.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_custom_file_header_duplicate_options(capsys: pytest.CaptureFixture) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--custom-file-header-path",
-            str(DATA_PATH / "custom_file_header.txt"),
-            "--custom-file-header",
-            "abc",
-        ])
+def test_main_custom_file_header_duplicate_options(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--custom-file-header-path",
+        str(DATA_PATH / "custom_file_header.txt"),
+        "--custom-file-header",
+        "abc",
+    ])
 
-        captured = capsys.readouterr()
-        assert return_code == Exit.ERROR
-        assert captured.err == "`--custom_file_header_path` can not be used with `--custom_file_header`.\n"
-
-
-@freeze_time("2019-07-26")
-def test_main_pydantic_v2() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pydantic_v2.py").read_text()
+    captured = capsys.readouterr()
+    assert return_code == Exit.ERROR
+    assert captured.err == "`--custom_file_header_path` can not be used with `--custom_file_header`.\n"
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_custom_id_pydantic_v2() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "custom_id.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "custom_id_pydantic_v2.py").read_text()
+def test_main_pydantic_v2(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "pydantic_v2.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_openapi_custom_id_pydantic_v2(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "custom_id.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "custom_id_pydantic_v2.py").read_text()
 
 
 @pytest.mark.skipif(
@@ -2257,21 +2166,20 @@ def test_main_openapi_custom_id_pydantic_v2() -> None:
     reason="isort 5.x don't sort pydantic modules",
 )
 @freeze_time("2019-07-26")
-def test_main_openapi_custom_id_pydantic_v2_custom_base() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "custom_id.yaml"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--base-class",
-            "custom_base.Base",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "custom_id_pydantic_v2_custom_base.py").read_text()
+def test_main_openapi_custom_id_pydantic_v2_custom_base(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "custom_id.yaml"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--base-class",
+        "custom_base.Base",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "custom_id_pydantic_v2_custom_base.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2279,64 +2187,61 @@ def test_main_openapi_custom_id_pydantic_v2_custom_base() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_all_of_with_relative_ref() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "all_of_with_relative_ref" / "openapi.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--keep-model-order",
-            "--collapse-root-models",
-            "--field-constraints",
-            "--use-title-as-name",
-            "--field-include-all-keys",
-            "--use-field-description",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "all_of_with_relative_ref.py").read_text()
+def test_main_openapi_all_of_with_relative_ref(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "all_of_with_relative_ref" / "openapi.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--keep-model-order",
+        "--collapse-root-models",
+        "--field-constraints",
+        "--use-title-as-name",
+        "--field-include-all-keys",
+        "--use-field-description",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "all_of_with_relative_ref.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_msgspec_struct(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--target-python-version",
-            min_version,
-            "--output-model-type",
-            "msgspec.Struct",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_struct.py").read_text()
+def test_main_openapi_msgspec_struct(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--target-python-version",
+        min_version,
+        "--output-model-type",
+        "msgspec.Struct",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_struct.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_msgspec_struct_snake_case(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_ordered_required_fields.yaml"),
-            "--output",
-            str(output_file),
-            "--target-python-version",
-            min_version,
-            "--snake-case-field",
-            "--output-model-type",
-            "msgspec.Struct",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_struct_snake_case.py").read_text()
+def test_main_openapi_msgspec_struct_snake_case(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_ordered_required_fields.yaml"),
+        "--output",
+        str(output_file),
+        "--target-python-version",
+        min_version,
+        "--snake-case-field",
+        "--output-model-type",
+        "msgspec.Struct",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_struct_snake_case.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2344,69 +2249,66 @@ def test_main_openapi_msgspec_struct_snake_case(min_version: str) -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_msgspec_use_annotated_with_field_constraints() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
-            "--output",
-            str(output_file),
-            "--field-constraints",
-            "--target-python-version",
-            "3.9",
-            "--output-model-type",
-            "msgspec.Struct",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_OPENAPI_PATH / "msgspec_use_annotated_with_field_constraints.py").read_text()
-        )
+def test_main_openapi_msgspec_use_annotated_with_field_constraints(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_constrained.yaml"),
+        "--output",
+        str(output_file),
+        "--field-constraints",
+        "--target-python-version",
+        "3.9",
+        "--output-model-type",
+        "msgspec.Struct",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_OPENAPI_PATH / "msgspec_use_annotated_with_field_constraints.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_discriminator_one_literal_as_default() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "discriminator_enum.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--use-one-literal-as-default",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_OPENAPI_PATH / "discriminator" / "enum_one_literal_as_default.py").read_text()
-        )
+def test_main_openapi_discriminator_one_literal_as_default(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "discriminator_enum.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--use-one-literal-as-default",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_OPENAPI_PATH / "discriminator" / "enum_one_literal_as_default.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_discriminator_one_literal_as_default_dataclass() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "discriminator_enum.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "dataclasses.dataclass",
-            "--use-one-literal-as-default",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            == (EXPECTED_OPENAPI_PATH / "discriminator" / "dataclass_enum_one_literal_as_default.py").read_text()
-        )
+def test_main_openapi_discriminator_one_literal_as_default_dataclass(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "discriminator_enum.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "dataclasses.dataclass",
+        "--use-one-literal-as-default",
+    ])
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        == (EXPECTED_OPENAPI_PATH / "discriminator" / "dataclass_enum_one_literal_as_default.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
@@ -2414,24 +2316,23 @@ def test_main_openapi_discriminator_one_literal_as_default_dataclass() -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_keyword_only_dataclass() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "inheritance.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "dataclasses.dataclass",
-            "--keyword-only",
-            "--target-python-version",
-            "3.10",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "dataclass_keyword_only.py").read_text()
+def test_main_openapi_keyword_only_dataclass(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "inheritance.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "dataclasses.dataclass",
+        "--keyword-only",
+        "--target-python-version",
+        "3.10",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "dataclass_keyword_only.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2479,24 +2380,23 @@ def test_main_openapi_dataclass_with_naive_datetime(capsys: pytest.CaptureFixtur
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_keyword_only_msgspec(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "inheritance.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "msgspec.Struct",
-            "--keyword-only",
-            "--target-python-version",
-            min_version,
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_keyword_only.py").read_text()
+def test_main_openapi_keyword_only_msgspec(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "inheritance.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "msgspec.Struct",
+        "--keyword-only",
+        "--target-python-version",
+        min_version,
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_keyword_only.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2504,26 +2404,25 @@ def test_main_openapi_keyword_only_msgspec(min_version: str) -> None:
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_openapi_keyword_only_msgspec_with_extra_data(min_version: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "inheritance.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "msgspec.Struct",
-            "--keyword-only",
-            "--target-python-version",
-            min_version,
-            "--extra-template-data",
-            str(OPEN_API_DATA_PATH / "extra_data_msgspec.json"),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_keyword_only_omit_defaults.py").read_text()
+def test_main_openapi_keyword_only_msgspec_with_extra_data(min_version: str, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "inheritance.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "msgspec.Struct",
+        "--keyword-only",
+        "--target-python-version",
+        min_version,
+        "--extra-template-data",
+        str(OPEN_API_DATA_PATH / "extra_data_msgspec.json"),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_keyword_only_omit_defaults.py").read_text()
 
 
 @freeze_time("2019-07-26")
@@ -2531,98 +2430,93 @@ def test_main_openapi_keyword_only_msgspec_with_extra_data(min_version: str) -> 
     black.__version__.split(".")[0] == "19",
     reason="Installed black doesn't support the old style",
 )
-def test_main_generate_openapi_keyword_only_msgspec_with_extra_data() -> None:
+def test_main_generate_openapi_keyword_only_msgspec_with_extra_data(tmp_path: Path) -> None:
     extra_data = json.loads((OPEN_API_DATA_PATH / "extra_data_msgspec.json").read_text())
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        generate(
-            input_=OPEN_API_DATA_PATH / "inheritance.yaml",
-            output=output_file,
-            input_file_type=InputFileType.OpenAPI,
-            output_model_type=DataModelType.MsgspecStruct,
-            keyword_only=True,
-            target_python_version=PythonVersionMin,
-            extra_template_data=defaultdict(dict, extra_data),
-            # Following values are defaults in the CLI, but not in the API
-            openapi_scopes=[OpenAPIScope.Schemas],
-            # Following values are implied by `msgspec.Struct` in the CLI
-            use_annotated=True,
-            field_constraints=True,
-        )
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_keyword_only_omit_defaults.py").read_text()
+    output_file: Path = tmp_path / "output.py"
+    generate(
+        input_=OPEN_API_DATA_PATH / "inheritance.yaml",
+        output=output_file,
+        input_file_type=InputFileType.OpenAPI,
+        output_model_type=DataModelType.MsgspecStruct,
+        keyword_only=True,
+        target_python_version=PythonVersionMin,
+        extra_template_data=defaultdict(dict, extra_data),
+        # Following values are defaults in the CLI, but not in the API
+        openapi_scopes=[OpenAPIScope.Schemas],
+        # Following values are implied by `msgspec.Struct` in the CLI
+        use_annotated=True,
+        field_constraints=True,
+    )
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "msgspec_keyword_only_omit_defaults.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_referenced_default() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "referenced_default.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "referenced_default.py").read_text()
+def test_main_openapi_referenced_default(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "referenced_default.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "referenced_default.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_duplicate_models() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "duplicate_models2.yaml"),
-            "--output",
-            str(output_file),
-            "--use-operation-id-as-name",
-            "--openapi-scopes",
-            "paths",
-            "schemas",
-            "parameters",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--parent-scoped-naming",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "duplicate_models2.py").read_text()
+def test_duplicate_models(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "duplicate_models2.yaml"),
+        "--output",
+        str(output_file),
+        "--use-operation-id-as-name",
+        "--openapi-scopes",
+        "paths",
+        "schemas",
+        "parameters",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--parent-scoped-naming",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "duplicate_models2.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_shadowed_imports() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "shadowed_imports.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "shadowed_imports.py").read_text()
+def test_main_openapi_shadowed_imports(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "shadowed_imports.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "shadowed_imports.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_openapi_extra_fields_forbid() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "additional_properties.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "openapi",
-            "--extra-fields",
-            "forbid",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "additional_properties.py").read_text()
+def test_main_openapi_extra_fields_forbid(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "additional_properties.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "openapi",
+        "--extra-fields",
+        "forbid",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "additional_properties.py").read_text()

--- a/tests/main/openapi/test_main_openapi.py
+++ b/tests/main/openapi/test_main_openapi.py
@@ -171,13 +171,10 @@ def test_target_python_version(tmp_path: Path) -> None:
 
 
 @pytest.mark.benchmark
-def test_main_modular(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_main_modular(tmp_path: Path) -> None:
     """Test main function on modular file."""
-
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main(["--input", str(input_filename), "--output", str(output_path)])
@@ -187,13 +184,10 @@ def test_main_modular(tmp_path_factory: pytest.TempPathFactory) -> None:
         assert result == path.read_text()
 
 
-def test_main_modular_reuse_model(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_main_modular_reuse_model(tmp_path: Path) -> None:
     """Test main function on modular file."""
-
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([
@@ -217,13 +211,10 @@ def test_main_modular_no_file() -> None:
     assert main(["--input", str(input_filename)]) == Exit.ERROR
 
 
-def test_main_modular_filename(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_main_modular_filename(tmp_path: Path) -> None:
     """Test main function on modular file with filename."""
-
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_filename = output_directory / "model.py"
+    output_filename = tmp_path / "model.py"
 
     assert main(["--input", str(input_filename), "--output", str(output_filename)]) == Exit.ERROR
 
@@ -803,11 +794,9 @@ def test_main_subclass_enum(tmp_path: Path) -> None:
     assert output_file.read_text() == (EXPECTED_OPENAPI_PATH / "subclass_enum.py").read_text()
 
 
-def test_main_use_standard_collections(tmp_path_factory: pytest.TempPathFactory) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
+def test_main_use_standard_collections(tmp_path: Path) -> None:
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([
@@ -827,11 +816,9 @@ def test_main_use_standard_collections(tmp_path_factory: pytest.TempPathFactory)
     black.__version__.split(".")[0] >= "24",
     reason="Installed black doesn't support the old style",
 )
-def test_main_use_generic_container_types(tmp_path_factory: pytest.TempPathFactory) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
+def test_main_use_generic_container_types(tmp_path: Path) -> None:
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([
@@ -853,12 +840,10 @@ def test_main_use_generic_container_types(tmp_path_factory: pytest.TempPathFacto
 )
 @pytest.mark.benchmark
 def test_main_use_generic_container_types_standard_collections(
-    tmp_path_factory: pytest.TempPathFactory,
+    tmp_path: Path,
 ) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([
@@ -1197,11 +1182,9 @@ def test_main_openapi_pattern_with_lookaround_pydantic_v2(
 
 @freeze_time("2019-07-26")
 def test_main_generate_custom_class_name_generator_modular(
-    tmp_path_factory: pytest.TempPathFactory,
+    tmp_path: Path,
 ) -> None:
-    output_directory = tmp_path_factory.mktemp("output")
-
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
     main_modular_custom_class_name_dir = EXPECTED_OPENAPI_PATH / "modular_custom_class_name"
 
     def custom_class_name_generator(name: str) -> str:
@@ -2009,13 +1992,11 @@ def test_main_typed_dict_py(min_version: str, tmp_path: Path) -> None:
     version.parse(black.__version__) < version.parse("23.3.0"),
     reason="Require Black version 23.3.0 or later ",
 )
-def test_main_modular_typed_dict(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_main_modular_typed_dict(tmp_path: Path) -> None:
     """Test main function on modular file."""
 
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main([

--- a/tests/main/test_main_csv.py
+++ b/tests/main/test_main_csv.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
 import pytest
 from freezegun import freeze_time
 
 from datamodel_code_generator.__main__ import Exit, main
 from tests.main.test_main_general import DATA_PATH, EXPECTED_MAIN_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 CSV_DATA_PATH: Path = DATA_PATH / "csv"
 EXPECTED_CSV_PATH: Path = EXPECTED_MAIN_PATH / "csv"
@@ -22,31 +24,29 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_csv_file() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(CSV_DATA_PATH / "simple.csv"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "csv",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_CSV_PATH / "csv_file_simple.py").read_text()
+def test_csv_file(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(CSV_DATA_PATH / "simple.csv"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "csv",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_CSV_PATH / "csv_file_simple.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_csv_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        monkeypatch.setattr("sys.stdin", (CSV_DATA_PATH / "simple.csv").open())
-        return_code: Exit = main([
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "csv",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_CSV_PATH / "csv_stdin_simple.py").read_text()
+def test_csv_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    monkeypatch.setattr("sys.stdin", (CSV_DATA_PATH / "simple.csv").open())
+    return_code: Exit = main([
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "csv",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_CSV_PATH / "csv_stdin_simple.py").read_text()

--- a/tests/main/test_main_general.py
+++ b/tests/main/test_main_general.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import tempfile
 from argparse import Namespace
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 import pytest
@@ -87,112 +85,106 @@ def test_no_args_has_default(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_space_and_special_characters_dict() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(PYTHON_DATA_PATH / "space_and_special_characters_dict.py"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "dict",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "space_and_special_characters_dict.py").read_text()
+def test_space_and_special_characters_dict(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(PYTHON_DATA_PATH / "space_and_special_characters_dict.py"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "dict",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "space_and_special_characters_dict.py").read_text()
 
 
 @freeze_time("2024-12-14")
-def test_direct_input_dict() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file = Path(output_dir) / "output.py"
-        generate(
-            {"foo": 1, "bar": {"baz": 2}},
-            input_file_type=InputFileType.Dict,
-            output=output_file,
-            output_model_type=DataModelType.PydanticV2BaseModel,
-            snake_case_field=True,
-        )
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "direct_input_dict.py").read_text()
+def test_direct_input_dict(tmp_path: Path) -> None:
+    output_file = tmp_path / "output.py"
+    generate(
+        {"foo": 1, "bar": {"baz": 2}},
+        input_file_type=InputFileType.Dict,
+        output=output_file,
+        output_model_type=DataModelType.PydanticV2BaseModel,
+        snake_case_field=True,
+    )
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "direct_input_dict.py").read_text()
 
 
 @freeze_time(TIMESTAMP)
-def test_frozen_dataclasses() -> None:
+def test_frozen_dataclasses(tmp_path: Path) -> None:
     """Test --frozen-dataclasses flag functionality."""
-    with TemporaryDirectory() as output_dir:
-        output_file = Path(output_dir) / "output.py"
-        generate(
-            DATA_PATH / "jsonschema" / "simple_frozen_test.json",
-            input_file_type=InputFileType.JsonSchema,
-            output=output_file,
-            output_model_type=DataModelType.DataclassesDataclass,
-            frozen_dataclasses=True,
-        )
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses.py").read_text()
+    output_file = tmp_path / "output.py"
+    generate(
+        DATA_PATH / "jsonschema" / "simple_frozen_test.json",
+        input_file_type=InputFileType.JsonSchema,
+        output=output_file,
+        output_model_type=DataModelType.DataclassesDataclass,
+        frozen_dataclasses=True,
+    )
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses.py").read_text()
 
 
 @freeze_time(TIMESTAMP)
-def test_frozen_dataclasses_with_keyword_only() -> None:
+def test_frozen_dataclasses_with_keyword_only(tmp_path: Path) -> None:
     """Test --frozen-dataclasses with --keyword-only flag combination."""
 
-    with TemporaryDirectory() as output_dir:
-        output_file = Path(output_dir) / "output.py"
-        generate(
-            DATA_PATH / "jsonschema" / "simple_frozen_test.json",
-            input_file_type=InputFileType.JsonSchema,
-            output=output_file,
-            output_model_type=DataModelType.DataclassesDataclass,
-            frozen_dataclasses=True,
-            keyword_only=True,
-            target_python_version=PythonVersion.PY_310,
-        )
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses_keyword_only.py").read_text()
+    output_file = tmp_path / "output.py"
+    generate(
+        DATA_PATH / "jsonschema" / "simple_frozen_test.json",
+        input_file_type=InputFileType.JsonSchema,
+        output=output_file,
+        output_model_type=DataModelType.DataclassesDataclass,
+        frozen_dataclasses=True,
+        keyword_only=True,
+        target_python_version=PythonVersion.PY_310,
+    )
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses_keyword_only.py").read_text()
 
 
 @freeze_time(TIMESTAMP)
-def test_frozen_dataclasses_command_line() -> None:
+def test_frozen_dataclasses_command_line(tmp_path: Path) -> None:
     """Test --frozen-dataclasses flag via command line."""
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(DATA_PATH / "jsonschema" / "simple_frozen_test.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            "dataclasses.dataclass",
-            "--frozen-dataclasses",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses.py").read_text()
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(DATA_PATH / "jsonschema" / "simple_frozen_test.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        "dataclasses.dataclass",
+        "--frozen-dataclasses",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses.py").read_text()
 
 
 @freeze_time(TIMESTAMP)
-def test_frozen_dataclasses_with_keyword_only_command_line() -> None:
+def test_frozen_dataclasses_with_keyword_only_command_line(tmp_path: Path) -> None:
     """Test --frozen-dataclasses with --keyword-only flag via command line."""
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(DATA_PATH / "jsonschema" / "simple_frozen_test.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "jsonschema",
-            "--output-model-type",
-            "dataclasses.dataclass",
-            "--frozen-dataclasses",
-            "--keyword-only",
-            "--target-python-version",
-            "3.10",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses_keyword_only.py").read_text()
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(DATA_PATH / "jsonschema" / "simple_frozen_test.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "jsonschema",
+        "--output-model-type",
+        "dataclasses.dataclass",
+        "--frozen-dataclasses",
+        "--keyword-only",
+        "--target-python-version",
+        "3.10",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "frozen_dataclasses_keyword_only.py").read_text()
 
 
-def test_filename_with_newline_injection() -> None:
+def test_filename_with_newline_injection(tmp_path: Path) -> None:
     """Test that filenames with newlines cannot inject code into generated files"""
 
     schema_content = """{"type": "object", "properties": {"name": {"type": "string"}}}"""
@@ -203,34 +195,31 @@ import os
 os.system('echo INJECTED')
 # END INJECTION"""
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        output_path = Path(tmpdir) / "output.py"
+    output_path = tmp_path / "output.py"
 
-        generate(
-            input_=schema_content,
-            input_filename=malicious_filename,
-            input_file_type=InputFileType.JsonSchema,
-            output=output_path,
-        )
+    generate(
+        input_=schema_content,
+        input_filename=malicious_filename,
+        input_file_type=InputFileType.JsonSchema,
+        output=output_path,
+    )
 
-        generated_content = output_path.read_text()
+    generated_content = output_path.read_text()
 
-        assert "#   filename:  schema.json # INJECTED CODE: import os" in generated_content, (
-            "Filename not properly sanitized"
-        )
+    assert "#   filename:  schema.json # INJECTED CODE: import os" in generated_content, (
+        "Filename not properly sanitized"
+    )
 
-        assert not any(
-            line.strip().startswith("import os") and not line.strip().startswith("#")
-            for line in generated_content.split("\n")
-        )
-        assert not any(
-            "os.system" in line and not line.strip().startswith("#") for line in generated_content.split("\n")
-        )
+    assert not any(
+        line.strip().startswith("import os") and not line.strip().startswith("#")
+        for line in generated_content.split("\n")
+    )
+    assert not any("os.system" in line and not line.strip().startswith("#") for line in generated_content.split("\n"))
 
-        compile(generated_content, str(output_path), "exec")
+    compile(generated_content, str(output_path), "exec")
 
 
-def test_filename_with_various_control_characters() -> None:
+def test_filename_with_various_control_characters(tmp_path: Path) -> None:
     """Test that various control characters in filenames are properly sanitized"""
 
     schema_content = """{"type": "object", "properties": {"test": {"type": "string"}}}"""
@@ -249,25 +238,24 @@ def test_filename_with_various_control_characters() -> None:
     ]
 
     for test_name, malicious_filename in test_cases:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = Path(tmpdir) / "output.py"
+        output_path = tmp_path / "output.py"
 
-            generate(
-                input_=schema_content,
-                input_filename=malicious_filename,
-                input_file_type=InputFileType.JsonSchema,
-                output=output_path,
-            )
+        generate(
+            input_=schema_content,
+            input_filename=malicious_filename,
+            input_file_type=InputFileType.JsonSchema,
+            output=output_path,
+        )
 
-            generated_content = output_path.read_text()
+        generated_content = output_path.read_text()
 
-            assert not any(
-                line.strip().startswith("import ") and not line.strip().startswith("#")
-                for line in generated_content.split("\n")
-            ), f"Injection found for {test_name}"
+        assert not any(
+            line.strip().startswith("import ") and not line.strip().startswith("#")
+            for line in generated_content.split("\n")
+        ), f"Injection found for {test_name}"
 
-            assert not any(
-                "os.system" in line and not line.strip().startswith("#") for line in generated_content.split("\n")
-            ), f"System call found for {test_name}"
+        assert not any(
+            "os.system" in line and not line.strip().startswith("#") for line in generated_content.split("\n")
+        ), f"System call found for {test_name}"
 
-            compile(generated_content, str(output_path), "exec")
+        compile(generated_content, str(output_path), "exec")

--- a/tests/main/test_main_json.py
+++ b/tests/main/test_main_json.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 from unittest.mock import call
 
@@ -18,6 +16,8 @@ from datamodel_code_generator.__main__ import Exit, main
 from tests.main.test_main_general import DATA_PATH, EXPECTED_MAIN_PATH
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
 
 FixtureRequest = pytest.FixtureRequest
@@ -35,124 +35,117 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_main_json() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
+def test_main_json(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "pet.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "general.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_space_and_special_characters_json(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "space_and_special_characters.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "space_and_special_characters.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_json_failed(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "broken.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+    ])
+    assert return_code == Exit.ERROR
+
+
+@freeze_time("2019-07-26")
+def test_main_json_array_include_null(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "array_include_null.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_array_include_null.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_json_reuse_model(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "duplicate_models.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+        "--reuse-model",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_reuse_model.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_main_json_reuse_model_pydantic2(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "duplicate_models.json"),
+        "--output-model-type",
+        "pydantic_v2.BaseModel",
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+        "--reuse-model",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_reuse_model_pydantic2.py").read_text()
+
+
+@freeze_time("2019-07-26")
+def test_simple_json_snake_case_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    with chdir(JSON_DATA_PATH / "simple.json"):
         return_code: Exit = main([
             "--input",
-            str(JSON_DATA_PATH / "pet.json"),
+            "simple.json",
             "--output",
             str(output_file),
             "--input-file-type",
             "json",
+            "--snake-case-field",
         ])
         assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "general.py").read_text()
+        assert output_file.read_text() == (EXPECTED_JSON_PATH / "simple_json_snake_case_field.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_space_and_special_characters_json() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "space_and_special_characters.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "space_and_special_characters.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_json_failed() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "broken.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-        ])
-        assert return_code == Exit.ERROR
-
-
-@freeze_time("2019-07-26")
-def test_main_json_array_include_null() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "array_include_null.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_array_include_null.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_json_reuse_model() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "duplicate_models.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-            "--reuse-model",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_reuse_model.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_json_reuse_model_pydantic2() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "duplicate_models.json"),
-            "--output-model-type",
-            "pydantic_v2.BaseModel",
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-            "--reuse-model",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_reuse_model_pydantic2.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_simple_json_snake_case_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        with chdir(JSON_DATA_PATH / "simple.json"):
-            return_code: Exit = main([
-                "--input",
-                "simple.json",
-                "--output",
-                str(output_file),
-                "--input-file-type",
-                "json",
-                "--snake-case-field",
-            ])
-            assert return_code == Exit.OK
-            assert output_file.read_text() == (EXPECTED_JSON_PATH / "simple_json_snake_case_field.py").read_text()
-
-
-@freeze_time("2019-07-26")
-def test_main_http_json(mocker: MockerFixture) -> None:
+def test_main_http_json(mocker: MockerFixture, tmp_path: Path) -> None:
     def get_mock_response(path: str) -> mocker.Mock:
         mock = mocker.Mock()
         mock.text = (JSON_DATA_PATH / path).read_text()
@@ -164,30 +157,29 @@ def test_main_http_json(mocker: MockerFixture) -> None:
             get_mock_response("pet.json"),
         ],
     )
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--url",
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--url",
+        "https://example.com/pet.json",
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "general.py").read_text().replace(
+        "#   filename:  pet.json",
+        "#   filename:  https://example.com/pet.json",
+    )
+    httpx_get_mock.assert_has_calls([
+        call(
             "https://example.com/pet.json",
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "general.py").read_text().replace(
-            "#   filename:  pet.json",
-            "#   filename:  https://example.com/pet.json",
-        )
-        httpx_get_mock.assert_has_calls([
-            call(
-                "https://example.com/pet.json",
-                headers=None,
-                verify=True,
-                follow_redirects=True,
-                params=None,
-            ),
-        ])
+            headers=None,
+            verify=True,
+            follow_redirects=True,
+            params=None,
+        ),
+    ])
 
 
 @pytest.mark.skipif(
@@ -195,37 +187,33 @@ def test_main_http_json(mocker: MockerFixture) -> None:
     reason="Require Black version 23.3.0 or later ",
 )
 @freeze_time("2019-07-26")
-def test_main_typed_dict_space_and_special_characters() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "space_and_special_characters.json"),
-            "--output",
-            str(output_file),
-            "--output-model-type",
-            "typing.TypedDict",
-            "--target-python-version",
-            "3.11",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_JSON_PATH / "typed_dict_space_and_special_characters.py").read_text()
-        )
+def test_main_typed_dict_space_and_special_characters(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "space_and_special_characters.json"),
+        "--output",
+        str(output_file),
+        "--output-model-type",
+        "typing.TypedDict",
+        "--target-python-version",
+        "3.11",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "typed_dict_space_and_special_characters.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_json_snake_case_field() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(JSON_DATA_PATH / "snake_case.json"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "json",
-            "--snake-case-field",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_snake_case_field.py").read_text()
+def test_main_json_snake_case_field(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(JSON_DATA_PATH / "snake_case.json"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "json",
+        "--snake-case-field",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_JSON_PATH / "json_snake_case_field.py").read_text()

--- a/tests/main/test_main_yaml.py
+++ b/tests/main/test_main_yaml.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
 import pytest
 from freezegun import freeze_time
 
 from datamodel_code_generator.__main__ import Exit, main
 from tests.main.test_main_general import DATA_PATH, EXPECTED_MAIN_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 YAML_DATA_PATH: Path = DATA_PATH / "yaml"
 
@@ -22,16 +24,15 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
-def test_main_yaml() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(YAML_DATA_PATH / "pet.yaml"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "yaml",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_PATH / "yaml.py").read_text()
+def test_main_yaml(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(YAML_DATA_PATH / "pet.yaml"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "yaml",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_PATH / "yaml.py").read_text()

--- a/tests/parser/test_graphql.py
+++ b/tests/parser/test_graphql.py
@@ -1,69 +1,68 @@
 from __future__ import annotations
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
 
 from freezegun import freeze_time
 
 from datamodel_code_generator.__main__ import Exit, main
 from tests.main.test_main_general import DATA_PATH
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 GRAPHQL_DATA_PATH: Path = DATA_PATH / "graphql"
 EXPECTED_GRAPHQL_PATH: Path = DATA_PATH / "expected" / "parser" / "graphql"
 
 
 @freeze_time("2019-07-26")
-def test_graphql_field_enum() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "field-default-enum.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-            "--set-default-enum-member",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "field-default-enum.py").read_text()
+def test_graphql_field_enum(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "field-default-enum.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+        "--set-default-enum-member",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_GRAPHQL_PATH / "field-default-enum.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_graphql_union_aliased_bug() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "union-aliased-bug.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-        ])
-        assert return_code == Exit.OK
-        actual = output_file.read_text().rstrip()
-        expected = (EXPECTED_GRAPHQL_PATH / "union-aliased-bug.py").read_text().rstrip()
-        if actual != expected:
-            pass
-        assert actual == expected
+def test_graphql_union_aliased_bug(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "union-aliased-bug.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+    ])
+    assert return_code == Exit.OK
+    actual = output_file.read_text().rstrip()
+    expected = (EXPECTED_GRAPHQL_PATH / "union-aliased-bug.py").read_text().rstrip()
+    if actual != expected:
+        pass
+    assert actual == expected
 
 
 @freeze_time("2019-07-26")
-def test_graphql_union_commented() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(GRAPHQL_DATA_PATH / "union-commented.graphql"),
-            "--output",
-            str(output_file),
-            "--input-file-type",
-            "graphql",
-        ])
-        assert return_code == Exit.OK
-        actual = output_file.read_text().rstrip()
-        expected = (EXPECTED_GRAPHQL_PATH / "union-commented.py").read_text().rstrip()
-        if actual != expected:
-            pass
-        assert actual == expected
+def test_graphql_union_commented(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(GRAPHQL_DATA_PATH / "union-commented.graphql"),
+        "--output",
+        str(output_file),
+        "--input-file-type",
+        "graphql",
+    ])
+    assert return_code == Exit.OK
+    actual = output_file.read_text().rstrip()
+    expected = (EXPECTED_GRAPHQL_PATH / "union-commented.py").read_text().rstrip()
+    if actual != expected:
+        pass
+    assert actual == expected

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -70,13 +70,10 @@ def test_target_python_version(tmp_path: Path) -> None:
     assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "target_python_version" / "output.py").read_text()
 
 
-def test_main_modular(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_main_modular(tmp_path: Path) -> None:
     """Test main function on modular file."""
-
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_path = output_directory / "model"
+    output_path = tmp_path / "model"
 
     with freeze_time(TIMESTAMP):
         main(["--input", str(input_filename), "--output", str(output_path)])
@@ -94,13 +91,11 @@ def test_main_modular_no_file() -> None:
     assert main(["--input", str(input_filename)]) == Exit.ERROR
 
 
-def test_main_modular_filename(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_main_modular_filename(tmp_path: Path) -> None:
     """Test main function on modular file with filename."""
 
-    output_directory = tmp_path_factory.mktemp("output")
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
-    output_filename = output_directory / "model.py"
+    output_filename = tmp_path / "model.py"
 
     assert main(["--input", str(input_filename), "--output", str(output_filename)]) == Exit.ERROR
 

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import shutil
 from argparse import Namespace
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import black
 import pytest
@@ -28,56 +27,53 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @freeze_time("2019-07-26")
-def test_main() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "main" / "output.py").read_text()
+def test_main(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "main" / "output.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_main_base_class() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        shutil.copy(DATA_PATH / "pyproject.toml", Path(output_dir) / "pyproject.toml")
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--base-class",
-            "custom_module.Base",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "main_base_class" / "output.py").read_text()
+def test_main_base_class(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--base-class",
+        "custom_module.Base",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "main_base_class" / "output.py").read_text()
 
 
 @freeze_time("2019-07-26")
-def test_target_python_version() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-            "--target-python-version",
-            f"3.{MIN_VERSION}",
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "target_python_version" / "output.py").read_text()
+def test_target_python_version(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+        "--target-python-version",
+        f"3.{MIN_VERSION}",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "target_python_version" / "output.py").read_text()
 
 
-def test_main_modular(tmpdir_factory: pytest.TempdirFactory) -> None:
+def test_main_modular(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test main function on modular file."""
 
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = output_directory / "model"
@@ -98,10 +94,10 @@ def test_main_modular_no_file() -> None:
     assert main(["--input", str(input_filename)]) == Exit.ERROR
 
 
-def test_main_modular_filename(tmpdir_factory: pytest.TempdirFactory) -> None:
+def test_main_modular_filename(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test main function on modular file with filename."""
 
-    output_directory = Path(tmpdir_factory.mktemp("output"))
+    output_directory = tmp_path_factory.mktemp("output")
 
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_filename = output_directory / "model.py"
@@ -154,34 +150,30 @@ def test_main_custom_template_dir(
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_pyproject() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path = Path(output_dir)
-        pyproject_toml = Path(DATA_PATH) / "project" / "pyproject.toml"
-        shutil.copy(pyproject_toml, output_path)
-        output_file: Path = output_path / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api.yaml"),
-            "--output",
-            str(output_file),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "pyproject" / "output.py").read_text()
+def test_pyproject(tmp_path: Path) -> None:
+    pyproject_toml = DATA_PATH / "project" / "pyproject.toml"
+    shutil.copy(pyproject_toml, tmp_path)
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api.yaml"),
+        "--output",
+        str(output_file),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "pyproject" / "output.py").read_text()
 
 
 @pytest.mark.parametrize("language", ["UK", "US"])
-def test_pyproject_respects_both_spellings_of_capitalize_enum_members_flag(language: str) -> None:
-    with TemporaryDirectory() as output_dir:
-        output_path = Path(output_dir)
-        pyproject_toml_data = f"""
+def test_pyproject_respects_both_spellings_of_capitalize_enum_members_flag(language: str, tmp_path: Path) -> None:
+    pyproject_toml_data = f"""
 [tool.datamodel-codegen]
 capitali{"s" if language == "UK" else "z"}e-enum-members = true
 enable-version-header = false
 input-file-type = "jsonschema"
 """
-        with (output_path / "pyproject.toml").open("w") as f:
-            f.write(pyproject_toml_data)
+    with (tmp_path / "pyproject.toml").open("w") as f:
+        f.write(pyproject_toml_data)
 
         input_data = """
 {
@@ -196,11 +188,11 @@ input-file-type = "jsonschema"
   }
 }
 """
-        input_file = output_path / "schema.json"
-        with input_file.open("w") as f:
-            f.write(input_data)
+    input_file = tmp_path / "schema.json"
+    with input_file.open("w") as f:
+        f.write(input_data)
 
-        expected_output = """# generated by datamodel-codegen:
+    expected_output = """# generated by datamodel-codegen:
 #   filename:  schema.json
 
 from __future__ import annotations
@@ -220,18 +212,18 @@ class MyEnum(Enum):
     member_2 = 'member_2'
 """
 
-        output_file: Path = output_path / "output.py"
-        return_code: Exit = main([
-            "--disable-timestamp",
-            "--input",
-            input_file.as_posix(),
-            "--output",
-            output_file.as_posix(),
-        ])
-        assert return_code == Exit.OK
-        assert output_file.read_text() == expected_output, (
-            f"\nExpected  output:\n{expected_output}\n\nGenerated output:\n{output_file.read_text()}"
-        )
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--disable-timestamp",
+        "--input",
+        input_file.as_posix(),
+        "--output",
+        output_file.as_posix(),
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == expected_output, (
+        f"\nExpected  output:\n{expected_output}\n\nGenerated output:\n{output_file.read_text()}"
+    )
 
 
 @pytest.mark.skipif(
@@ -239,71 +231,64 @@ class MyEnum(Enum):
     reason="Installed black doesn't support the old style",
 )
 @freeze_time("2019-07-26")
-def test_pyproject_with_tool_section() -> None:
+def test_pyproject_with_tool_section(tmp_path: Path) -> None:
     """Test that a pyproject.toml with a [tool.datamodel-codegen] section is
     found and its configuration applied.
     """
-    with TemporaryDirectory() as output_dir:
-        output_path = Path(output_dir)
-        pyproject_toml = """
+    pyproject_toml = """
 [tool.datamodel-codegen]
 target-python-version = "3.10"
 strict-types = ["str"]
 """
-        with (output_path / "pyproject.toml").open("w") as f:
-            f.write(pyproject_toml)
-        output_file: Path = output_path / "output.py"
+    (tmp_path / "pyproject.toml").write_text(pyproject_toml)
+    output_file: Path = tmp_path / "output.py"
 
-        # Run main from within the output directory so we can find our
-        # pyproject.toml.
-        with chdir(output_path):
-            return_code: Exit = main([
-                "--input",
-                str((OPEN_API_DATA_PATH / "api.yaml").resolve()),
-                "--output",
-                str(output_file.resolve()),
-            ])
+    # Run main from within the output directory so we can find our
+    # pyproject.toml.
+    with chdir(tmp_path):
+        return_code: Exit = main([
+            "--input",
+            str((OPEN_API_DATA_PATH / "api.yaml").resolve()),
+            "--output",
+            str(output_file.resolve()),
+        ])
 
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text()
-            # We expect the output to use pydantic.StrictStr in place of str
-            == (EXPECTED_MAIN_KR_PATH / "pyproject" / "output.strictstr.py").read_text()
-        )
+    assert return_code == Exit.OK
+    assert (
+        output_file.read_text()
+        # We expect the output to use pydantic.StrictStr in place of str
+        == (EXPECTED_MAIN_KR_PATH / "pyproject" / "output.strictstr.py").read_text()
+    )
 
 
 @freeze_time("2019-07-26")
-def test_main_use_schema_description() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_multiline_docstrings.yaml"),
-            "--output",
-            str(output_file),
-            "--use-schema-description",
-        ])
-        assert return_code == Exit.OK
-        assert (
-            output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "main_use_schema_description" / "output.py").read_text()
-        )
+def test_main_use_schema_description(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_multiline_docstrings.yaml"),
+        "--output",
+        str(output_file),
+        "--use-schema-description",
+    ])
+    assert return_code == Exit.OK
+    assert output_file.read_text() == (EXPECTED_MAIN_KR_PATH / "main_use_schema_description" / "output.py").read_text()
 
 
 @freeze_time("2022-11-11")
-def test_main_use_field_description() -> None:
-    with TemporaryDirectory() as output_dir:
-        output_file: Path = Path(output_dir) / "output.py"
-        return_code: Exit = main([
-            "--input",
-            str(OPEN_API_DATA_PATH / "api_multiline_docstrings.yaml"),
-            "--output",
-            str(output_file),
-            "--use-field-description",
-        ])
-        assert return_code == Exit.OK
-        generated = output_file.read_text()
-        expected = (EXPECTED_MAIN_KR_PATH / "main_use_field_description" / "output.py").read_text()
-        assert generated == expected
+def test_main_use_field_description(tmp_path: Path) -> None:
+    output_file: Path = tmp_path / "output.py"
+    return_code: Exit = main([
+        "--input",
+        str(OPEN_API_DATA_PATH / "api_multiline_docstrings.yaml"),
+        "--output",
+        str(output_file),
+        "--use-field-description",
+    ])
+    assert return_code == Exit.OK
+    generated = output_file.read_text()
+    expected = (EXPECTED_MAIN_KR_PATH / "main_use_field_description" / "output.py").read_text()
+    assert generated == expected
 
 
 def test_capitalise_enum_members(tmp_path: Path) -> None:


### PR DESCRIPTION
This PR wants to clean the tests replacing `TemporaryDirectory` with the `tmp_path` fixture as temporary directory path.
Also `tmpdir_factory` has been replaced with `tmp_path` since the factory was used as a single temporary path.

The advantages are:
- Use a standardized way to create temporary directories with PyTest (so the code is easier to understand)
- Fewer lines of code
- Remove one indentation block in most of the tests

Fixes #2462

