### PR TITLE
fix: RootModel future annotations and extra field 

### DIFF
--- a/src/datamodel_code_generator/model/template/pydantic_v2/RootModel.jinja2
+++ b/src/datamodel_code_generator/model/template/pydantic_v2/RootModel.jinja2
@@ -10,7 +10,7 @@
 {{ decorator }}
 {% endfor -%}
 
-class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)}}]{%- endif -%}):{% if comment is defined %}  # {{ comment }}{% endif %}
+class {{ class_name }}({{ base_class }}{%- if fields -%}["{{get_type_hint(fields)}}"]{%- endif -%}):{% if comment is defined %}  # {{ comment }}{% endif %}
 {%- if description %}
     """
     {{ description | indent(4) }}
@@ -18,7 +18,13 @@ class {{ class_name }}({{ base_class }}{%- if fields -%}[{{get_type_hint(fields)
 {%- endif %}
 {%- if config %}
 {%- filter indent(4) %}
-{% include 'ConfigDict.jinja2' %}
+model_config = ConfigDict(
+{%- for field_name, value in config.dict(exclude_unset=True).items() %}
+    {%- if field_name != 'extra' %}
+    {{ field_name }}={{ value }},
+    {%- endif %}
+{%- endfor %}
+)
 {%- endfilter %}
 {%- endif %}
 {%- if not fields and not description %}


### PR DESCRIPTION
`RootModel` should not have the field `extra` set in pydantic:

https://docs.pydantic.dev/latest/errors/usage_errors/#root-model-extra

`RootModel` does not seem to support future annotations, so quotes must be used:

https://github.com/pydantic/pydantic/discussions/7967