### PR TITLE
Add PEP 257 docstrings to modules and test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,8 @@ lint.ignore = [
   "C901",   # complex structure
   "COM812", # Conflict with formatter
   "CPY",    # No copyright statements
-  "D",      # limited documentation
+  "D203",   # one-blank-line-before-class (conflicts with D211)
+  "D212",   # multi-line-summary-first-line (conflicts with D213)
   "DOC",    # limited documentation
   "FIX002", # line contains to do
   "ISC001", # Conflict with formatter
@@ -186,6 +187,7 @@ lint.isort = { known-first-party = [
   "from __future__ import annotations",
 ] }
 
+lint.pydocstyle.convention = "pep257"
 lint.preview = true
 
 [tool.codespell]

--- a/scripts/update_command_help_on_markdown.py
+++ b/scripts/update_command_help_on_markdown.py
@@ -1,4 +1,6 @@
-from __future__ import annotations  # noqa: INP001
+"""Update command help text in markdown documentation files."""  # noqa: INP001
+
+from __future__ import annotations
 
 import io
 import os
@@ -29,6 +31,7 @@ REPLACE_MAP = {"(default: UTF-8)": "(default: utf-8)", "'": r"''"}
 
 
 def get_help() -> str:
+    """Get formatted help text from argument parser."""
     with io.StringIO() as f:
         arg_parser.print_help(file=f)
         output = f.getvalue()
@@ -39,9 +42,7 @@ def get_help() -> str:
 
 
 def inject_help(markdown_text: str, help_text: str) -> str:
-    # Inject help_text into markdown_text at the position between <!-- start command help --> and <!-- end command
-    # help --> the start and end markers are included in the returned markdown_text
-
+    """Inject help text into markdown between start and end markers."""
     start_pos = markdown_text.find(START_MARK)
     end_pos = markdown_text.find(END_MARK)
     if start_pos == -1 or end_pos == -1:
@@ -60,6 +61,7 @@ def inject_help(markdown_text: str, help_text: str) -> str:
 
 
 def main() -> Exit:
+    """Update or validate command help in target markdown files."""
     help_text = get_help()
     arg_parser.add_argument(
         "--validate",

--- a/src/datamodel_code_generator/arguments.py
+++ b/src/datamodel_code_generator/arguments.py
@@ -1,3 +1,10 @@
+"""CLI argument definitions for datamodel-codegen.
+
+Defines the ArgumentParser and all command-line options organized into groups:
+base options, typing customization, field customization, model customization,
+template customization, OpenAPI-specific options, and general options.
+"""
+
 from __future__ import annotations
 
 import locale
@@ -22,14 +29,19 @@ namespace = Namespace(no_color=False)
 
 
 class SortingHelpFormatter(HelpFormatter):
+    """Help formatter that sorts arguments and adds color to section headers."""
+
     def _bold_cyan(self, text: str) -> str:  # noqa: PLR6301
+        """Wrap text in ANSI bold cyan escape codes."""
         return f"\x1b[36;1m{text}\x1b[0m"
 
     def add_arguments(self, actions: Iterable[Action]) -> None:
+        """Add arguments sorted by option strings."""
         actions = sorted(actions, key=attrgetter("option_strings"))
         super().add_arguments(actions)
 
     def start_section(self, heading: str | None) -> None:
+        """Start a section with optional colored heading."""
         return super().start_section(heading if namespace.no_color or not heading else self._bold_cyan(heading))
 
 

--- a/src/datamodel_code_generator/http.py
+++ b/src/datamodel_code_generator/http.py
@@ -1,3 +1,9 @@
+"""HTTP utilities for fetching remote schema files.
+
+Provides functions to fetch schema content from URLs and join URL references.
+Requires the 'http' extra: `pip install 'datamodel-code-generator[http]'`.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -18,6 +24,7 @@ def get_body(
     ignore_tls: bool = False,  # noqa: FBT001, FBT002
     query_parameters: Sequence[tuple[str, str]] | None = None,
 ) -> str:
+    """Fetch content from a URL with optional headers and query parameters."""
     return httpx.get(
         url,
         headers=headers,
@@ -29,4 +36,5 @@ def get_body(
 
 
 def join_url(url: str, ref: str = ".") -> str:
+    """Join a base URL with a relative reference."""
     return str(httpx.URL(url).join(ref))

--- a/src/datamodel_code_generator/model/__init__.py
+++ b/src/datamodel_code_generator/model/__init__.py
@@ -1,3 +1,9 @@
+"""Model generation module.
+
+Provides factory functions and classes for generating different output formats
+(Pydantic, dataclasses, TypedDict, msgspec) based on configuration.
+"""
+
 from __future__ import annotations
 
 import sys
@@ -17,6 +23,8 @@ DEFAULT_TARGET_PYTHON_VERSION = PythonVersion(f"{sys.version_info.major}.{sys.ve
 
 
 class DataModelSet(NamedTuple):
+    """Collection of model types needed for a specific output format."""
+
     data_model: type[DataModel]
     root_model: type[DataModel]
     field_model: type[DataModelFieldBase]
@@ -32,6 +40,7 @@ def get_data_model_types(
     target_python_version: PythonVersion = DEFAULT_TARGET_PYTHON_VERSION,
     use_type_alias: bool = False,  # noqa: FBT001, FBT002
 ) -> DataModelSet:
+    """Get the appropriate model types for the given output format and Python version."""
     from datamodel_code_generator import DataModelType  # noqa: PLC0415
 
     from . import (  # noqa: PLC0415

--- a/src/datamodel_code_generator/model/dataclass.py
+++ b/src/datamodel_code_generator/model/dataclass.py
@@ -1,3 +1,8 @@
+"""Python dataclass model generator.
+
+Generates Python dataclasses using the @dataclass decorator.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
@@ -33,6 +38,8 @@ def _has_field_assignment(field: DataModelFieldBase) -> bool:
 
 
 class DataClass(DataModel):
+    """DataModel implementation for Python dataclasses."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "dataclass.jinja2"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_DATACLASS,)
 
@@ -55,6 +62,7 @@ class DataClass(DataModel):
         frozen: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize dataclass with fields sorted by field assignment requirement."""
         super().__init__(
             reference=reference,
             fields=sorted(fields, key=_has_field_assignment),
@@ -75,6 +83,8 @@ class DataClass(DataModel):
 
 
 class DataModelField(DataModelFieldBase):
+    """Field implementation for dataclass models."""
+
     _FIELD_KEYS: ClassVar[set[str]] = {
         "default_factory",
         "init",
@@ -87,6 +97,7 @@ class DataModelField(DataModelFieldBase):
     constraints: Optional[Constraints] = None  # noqa: UP045
 
     def process_const(self) -> None:
+        """Process const field constraint."""
         if "const" not in self.extras:
             return
         self.const = True
@@ -98,25 +109,28 @@ class DataModelField(DataModelFieldBase):
 
     @property
     def imports(self) -> tuple[Import, ...]:
+        """Get imports including field() if needed."""
         field = self.field
         if field and field.startswith("field("):
             return chain_as_tuple(super().imports, (IMPORT_FIELD,))
         return super().imports
 
     def self_reference(self) -> bool:  # pragma: no cover
+        """Check if field references its parent dataclass."""
         return isinstance(self.parent, DataClass) and self.parent.reference.path in {
             d.reference.path for d in self.data_type.all_data_types if d.reference
         }
 
     @property
     def field(self) -> str | None:
-        """for backwards compatibility"""
+        """For backwards compatibility."""
         result = str(self)
         if not result:
             return None
         return result
 
     def __str__(self) -> str:
+        """Generate field() call or default value representation."""
         data: dict[str, Any] = {k: v for k, v in self.extras.items() if k in self._FIELD_KEYS}
 
         if self.default != UNDEFINED and self.default is not None:
@@ -147,6 +161,8 @@ class DataModelField(DataModelFieldBase):
 
 
 class DataTypeManager(_DataTypeManager):
+    """Type manager for dataclass models."""
+
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         python_version: PythonVersion = PythonVersionMin,
@@ -159,6 +175,7 @@ class DataTypeManager(_DataTypeManager):
         target_datetime_class: DatetimeClassType = DatetimeClassType.Datetime,
         treat_dot_as_module: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize type manager with datetime type mapping."""
         super().__init__(
             python_version,
             use_standard_collections,

--- a/src/datamodel_code_generator/model/enum.py
+++ b/src/datamodel_code_generator/model/enum.py
@@ -1,3 +1,8 @@
+"""Enumeration model generator.
+
+Provides Enum, StrEnum, and specialized enum classes for code generation.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
@@ -32,6 +37,8 @@ SUBCLASS_BASE_CLASSES: dict[Types, str] = {
 
 
 class Enum(DataModel):
+    """DataModel implementation for Python enumerations."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "Enum.jinja2"
     BASE_CLASS: ClassVar[str] = "enum.Enum"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_ENUM,)
@@ -55,6 +62,7 @@ class Enum(DataModel):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize Enum with optional specialized base class based on type."""
         super().__init__(
             reference=reference,
             fields=fields,
@@ -81,12 +89,15 @@ class Enum(DataModel):
 
     @classmethod
     def get_data_type(cls, types: Types, **kwargs: Any) -> DataType:
+        """Get data type for enum (not implemented)."""
         raise NotImplementedError
 
     def get_member(self, field: DataModelFieldBase) -> Member:
+        """Create a Member instance for the given field."""
         return Member(self, field)
 
     def find_member(self, value: Any) -> Member | None:
+        """Find enum member matching the given value."""
         repr_value = repr(value)
         # Remove surrounding quotes from the string representation
         str_value = str(value).strip("'\"")
@@ -107,15 +118,20 @@ class Enum(DataModel):
 
     @property
     def imports(self) -> tuple[Import, ...]:
+        """Get imports excluding Any."""
         return tuple(i for i in super().imports if i != IMPORT_ANY)
 
 
 class StrEnum(Enum):
+    """String enumeration type."""
+
     BASE_CLASS: ClassVar[str] = "enum.StrEnum"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_STR_ENUM,)
 
 
 class IntEnum(Enum):
+    """Integer enumeration type."""
+
     BASE_CLASS: ClassVar[str] = "enum.IntEnum"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_INT_ENUM,)
 
@@ -132,10 +148,14 @@ Map specialized enum types to their corresponding Enum subclasses.
 
 
 class Member:
+    """Represents an enum member with its parent enum and field."""
+
     def __init__(self, enum: Enum, field: DataModelFieldBase) -> None:
+        """Initialize enum member."""
         self.enum: Enum = enum
         self.field: DataModelFieldBase = field
         self.alias: Optional[str] = None  # noqa: UP045
 
     def __repr__(self) -> str:
+        """Return string representation of enum member."""
         return f"{self.alias or self.enum.name}.{self.field.name}"

--- a/src/datamodel_code_generator/model/imports.py
+++ b/src/datamodel_code_generator/model/imports.py
@@ -1,3 +1,8 @@
+"""Import definitions for model modules.
+
+Provides pre-defined Import objects for dataclasses, TypedDict, msgspec, etc.
+"""
+
 from __future__ import annotations
 
 from datamodel_code_generator.imports import Import

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -1,3 +1,8 @@
+"""msgspec.Struct model generator.
+
+Generates Python models using msgspec.Struct for high-performance serialization.
+"""
+
 from __future__ import annotations
 
 from functools import wraps
@@ -51,6 +56,7 @@ DataModelFieldBaseT = TypeVar("DataModelFieldBaseT", bound=DataModelFieldBase)
 
 
 def import_extender(cls: type[DataModelFieldBaseT]) -> type[DataModelFieldBaseT]:
+    """Extend imports property with msgspec-specific imports."""
     original_imports: property = cls.imports
 
     @wraps(original_imports.fget)  # pyright: ignore[reportArgumentType]
@@ -73,6 +79,8 @@ def import_extender(cls: type[DataModelFieldBaseT]) -> type[DataModelFieldBaseT]
 
 
 class Struct(DataModel):
+    """DataModel implementation for msgspec.Struct."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "msgspec.jinja2"
     BASE_CLASS: ClassVar[str] = "msgspec.Struct"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = ()
@@ -95,6 +103,7 @@ class Struct(DataModel):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize msgspec Struct with fields sorted by field assignment requirement."""
         super().__init__(
             reference=reference,
             fields=sorted(fields, key=_has_field_assignment),
@@ -116,10 +125,13 @@ class Struct(DataModel):
             self.add_base_class_kwarg("kw_only", "True")
 
     def add_base_class_kwarg(self, name: str, value: str) -> None:
+        """Add keyword argument to base class constructor."""
         self.extra_template_data["base_class_kwargs"][name] = value
 
 
 class Constraints(_Constraints):
+    """Constraint model for msgspec fields."""
+
     # To override existing pattern alias
     regex: Optional[str] = Field(None, alias="regex")  # noqa: UP045
     pattern: Optional[str] = Field(None, alias="pattern")  # noqa: UP045
@@ -127,6 +139,8 @@ class Constraints(_Constraints):
 
 @import_extender
 class DataModelField(DataModelFieldBase):
+    """Field implementation for msgspec Struct models."""
+
     _FIELD_KEYS: ClassVar[set[str]] = {
         "default",
         "default_factory",
@@ -152,11 +166,13 @@ class DataModelField(DataModelFieldBase):
     constraints: Optional[Constraints] = None  # noqa: UP045
 
     def self_reference(self) -> bool:  # pragma: no cover
+        """Check if field references its parent Struct."""
         return isinstance(self.parent, Struct) and self.parent.reference.path in {
             d.reference.path for d in self.data_type.all_data_types if d.reference
         }
 
     def process_const(self) -> None:
+        """Process const field constraint."""
         if "const" not in self.extras:
             return
         self.const = True
@@ -166,6 +182,7 @@ class DataModelField(DataModelFieldBase):
             self.data_type = self.data_type.__class__(literals=[const])
 
     def _get_strict_field_constraint_value(self, constraint: str, value: Any) -> Any:
+        """Get constraint value with appropriate numeric type."""
         if value is None or constraint not in self._COMPARE_EXPRESSIONS:
             return value
 
@@ -175,13 +192,14 @@ class DataModelField(DataModelFieldBase):
 
     @property
     def field(self) -> str | None:
-        """for backwards compatibility"""
+        """For backwards compatibility."""
         result = str(self)
         if not result:
             return None
         return result
 
     def __str__(self) -> str:
+        """Generate field() call or default value representation."""
         data: dict[str, Any] = {k: v for k, v in self.extras.items() if k in self._FIELD_KEYS}
         if self.alias:
             data["name"] = self.alias
@@ -218,6 +236,7 @@ class DataModelField(DataModelFieldBase):
 
     @property
     def annotated(self) -> str | None:
+        """Get Annotated type hint with Meta constraints."""
         if not self.use_annotated:  # pragma: no cover
             return None
 
@@ -250,6 +269,7 @@ class DataModelField(DataModelFieldBase):
         return annotated_type
 
     def _get_default_as_struct_model(self) -> str | None:
+        """Convert default value to Struct model using msgspec convert."""
         for data_type in self.data_type.data_types or (self.data_type,):
             # TODO: Check nested data_types
             if data_type.is_dict or self.data_type.is_union:
@@ -275,6 +295,8 @@ class DataModelField(DataModelFieldBase):
 
 
 class DataTypeManager(_DataTypeManager):
+    """Type manager for msgspec Struct models."""
+
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         python_version: PythonVersion = PythonVersionMin,
@@ -287,6 +309,7 @@ class DataTypeManager(_DataTypeManager):
         target_datetime_class: DatetimeClassType | None = None,
         treat_dot_as_module: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize type manager with optional datetime type mapping."""
         super().__init__(
             python_version,
             use_standard_collections,

--- a/src/datamodel_code_generator/model/pydantic/__init__.py
+++ b/src/datamodel_code_generator/model/pydantic/__init__.py
@@ -1,3 +1,9 @@
+"""Pydantic v1 model generator.
+
+Provides BaseModel, CustomRootType, and DataModelField for generating
+Pydantic v1 compatible data models.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
@@ -14,10 +20,13 @@ if TYPE_CHECKING:
 
 
 def dump_resolve_reference_action(class_names: Iterable[str]) -> str:
+    """Generate update_forward_refs() calls for Pydantic v1 models."""
     return "\n".join(f"{class_name}.update_forward_refs()" for class_name in class_names)
 
 
 class Config(_BaseModel):
+    """Pydantic model config options."""
+
     extra: Optional[str] = None  # noqa: UP045
     title: Optional[str] = None  # noqa: UP045
     allow_population_by_field_name: Optional[bool] = None  # noqa: UP045

--- a/src/datamodel_code_generator/model/pydantic/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic/base_model.py
@@ -1,3 +1,8 @@
+"""Pydantic v1 BaseModel implementation.
+
+Provides Constraints, DataModelField, and BaseModel for Pydantic v1.
+"""
+
 from __future__ import annotations
 
 from abc import ABC
@@ -28,6 +33,8 @@ if TYPE_CHECKING:
 
 
 class Constraints(ConstraintsBase):
+    """Pydantic v1 field constraints (gt, ge, lt, le, regex, etc.)."""
+
     gt: Optional[UnionIntFloat] = Field(None, alias="exclusiveMinimum")  # noqa: UP045
     ge: Optional[UnionIntFloat] = Field(None, alias="minimum")  # noqa: UP045
     lt: Optional[UnionIntFloat] = Field(None, alias="exclusiveMaximum")  # noqa: UP045
@@ -41,6 +48,8 @@ class Constraints(ConstraintsBase):
 
 
 class DataModelField(DataModelFieldBase):
+    """Field implementation for Pydantic v1 models."""
+
     _EXCLUDE_FIELD_KEYS: ClassVar[set[str]] = {
         "alias",
         "default",
@@ -62,16 +71,18 @@ class DataModelField(DataModelFieldBase):
 
     @property
     def method(self) -> str | None:
+        """Get the validation method name."""
         return self.validator
 
     @property
     def validator(self) -> str | None:
+        """Get the validator name."""
         return None
         # TODO refactor this method for other validation logic
 
     @property
     def field(self) -> str | None:
-        """for backwards compatibility"""
+        """For backwards compatibility."""
         result = str(self)
         if (
             self.use_default_kwarg
@@ -87,6 +98,7 @@ class DataModelField(DataModelFieldBase):
         return result
 
     def self_reference(self) -> bool:
+        """Check if this field references its parent model."""
         return isinstance(self.parent, BaseModelBase) and self.parent.reference.path in {
             d.reference.path for d in self.data_type.all_data_types if d.reference
         }
@@ -131,6 +143,7 @@ class DataModelField(DataModelFieldBase):
         return field_arguments
 
     def __str__(self) -> str:  # noqa: PLR0912
+        """Return Field() call with all constraints and metadata."""
         data: dict[str, Any] = {k: v for k, v in self.extras.items() if k not in self._EXCLUDE_FIELD_KEYS}
         if self.alias:
             data["alias"] = self.alias
@@ -186,18 +199,22 @@ class DataModelField(DataModelFieldBase):
 
     @property
     def annotated(self) -> str | None:
+        """Get the Annotated type hint if use_annotated is enabled."""
         if not self.use_annotated or not str(self):
             return None
         return f"Annotated[{self.type_hint}, {self!s}]"
 
     @property
     def imports(self) -> tuple[Import, ...]:
+        """Get all required imports including Field if needed."""
         if self.field:
             return chain_as_tuple(super().imports, (IMPORT_FIELD,))
         return super().imports
 
 
 class BaseModelBase(DataModel, ABC):
+    """Abstract base class for Pydantic BaseModel implementations."""
+
     def __init__(  # noqa: PLR0913
         self,
         *,
@@ -215,6 +232,7 @@ class BaseModelBase(DataModel, ABC):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize the BaseModel with fields and configuration."""
         methods: list[str] = [field.method for field in fields if field.method]
 
         super().__init__(
@@ -236,6 +254,7 @@ class BaseModelBase(DataModel, ABC):
 
     @cached_property
     def template_file_path(self) -> Path:
+        """Get the template file path with backward compatibility support."""
         # This property is for Backward compatibility
         # Current version supports '{custom_template_dir}/BaseModel.jinja'
         # But, Future version will support only '{custom_template_dir}/pydantic/BaseModel.jinja'
@@ -247,6 +266,8 @@ class BaseModelBase(DataModel, ABC):
 
 
 class BaseModel(BaseModelBase):
+    """Pydantic v1 BaseModel implementation."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "pydantic/BaseModel.jinja2"
     BASE_CLASS: ClassVar[str] = "pydantic.BaseModel"
 
@@ -267,6 +288,7 @@ class BaseModel(BaseModelBase):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize the BaseModel with Config and extra fields support."""
         super().__init__(
             reference=reference,
             fields=fields,

--- a/src/datamodel_code_generator/model/pydantic/custom_root_type.py
+++ b/src/datamodel_code_generator/model/pydantic/custom_root_type.py
@@ -1,3 +1,8 @@
+"""Pydantic v1 custom root type model.
+
+Generates models with __root__ field for wrapping single types.
+"""
+
 from __future__ import annotations
 
 from typing import ClassVar
@@ -6,5 +11,7 @@ from datamodel_code_generator.model.pydantic.base_model import BaseModel
 
 
 class CustomRootType(BaseModel):
+    """DataModel for Pydantic v1 custom root types (__root__ field)."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "pydantic/BaseModel_root.jinja2"
     BASE_CLASS: ClassVar[str] = "pydantic.BaseModel"

--- a/src/datamodel_code_generator/model/pydantic/dataclass.py
+++ b/src/datamodel_code_generator/model/pydantic/dataclass.py
@@ -1,3 +1,8 @@
+"""Pydantic v1 dataclass model.
+
+Generates pydantic.dataclasses.dataclass decorated classes.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
@@ -10,5 +15,7 @@ if TYPE_CHECKING:
 
 
 class DataClass(DataModel):
+    """DataModel for Pydantic v1 dataclasses."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "pydantic/dataclass.jinja2"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_DATACLASS,)

--- a/src/datamodel_code_generator/model/pydantic/imports.py
+++ b/src/datamodel_code_generator/model/pydantic/imports.py
@@ -1,3 +1,8 @@
+"""Import definitions for Pydantic v1 types.
+
+Provides pre-defined Import objects for Pydantic v1 types (constr, AnyUrl, etc.).
+"""
+
 from __future__ import annotations
 
 from datamodel_code_generator.imports import Import

--- a/src/datamodel_code_generator/model/pydantic/types.py
+++ b/src/datamodel_code_generator/model/pydantic/types.py
@@ -1,3 +1,8 @@
+"""Pydantic v1 type manager.
+
+Maps schema types to Pydantic v1 specific types (constr, conint, AnyUrl, etc.).
+"""
+
 from __future__ import annotations
 
 from decimal import Decimal
@@ -63,6 +68,7 @@ def type_map_factory(
     pattern_key: str,
     use_pendulum: bool,  # noqa: FBT001
 ) -> dict[Types, DataType]:
+    """Create a mapping of schema types to Pydantic v1 data types."""
     data_type_int = data_type(type="int")
     data_type_float = data_type(type="float")
     data_type_str = data_type(type="str")
@@ -121,6 +127,7 @@ def type_map_factory(
 
 
 def strict_type_map_factory(data_type: type[DataType]) -> dict[StrictTypes, DataType]:
+    """Create a mapping of strict types to Pydantic v1 strict data types."""
     return {
         StrictTypes.int: data_type.from_import(IMPORT_STRICT_INT, strict=True),
         StrictTypes.float: data_type.from_import(IMPORT_STRICT_FLOAT, strict=True),
@@ -153,6 +160,8 @@ escape_characters = str.maketrans({
 
 
 class DataTypeManager(_DataTypeManager):
+    """Manage data type mappings for Pydantic v1 models."""
+
     PATTERN_KEY: ClassVar[str] = "regex"
 
     def __init__(  # noqa: PLR0913, PLR0917
@@ -167,6 +176,7 @@ class DataTypeManager(_DataTypeManager):
         target_datetime_class: DatetimeClassType | None = None,
         treat_dot_as_module: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize the DataTypeManager with Pydantic v1 type mappings."""
         super().__init__(
             python_version,
             use_standard_collections,
@@ -209,6 +219,7 @@ class DataTypeManager(_DataTypeManager):
         pattern_key: str,
         target_datetime_class: DatetimeClassType | None,  # noqa: ARG002
     ) -> dict[Types, DataType]:
+        """Create type mapping with Pydantic v1 specific types."""
         return type_map_factory(
             data_type,
             strict_types,
@@ -217,6 +228,7 @@ class DataTypeManager(_DataTypeManager):
         )
 
     def transform_kwargs(self, kwargs: dict[str, Any], filter_: set[str]) -> dict[str, str]:
+        """Transform schema kwargs to Pydantic v1 field kwargs."""
         return {self.kwargs_schema_to_model.get(k, k): v for (k, v) in kwargs.items() if v is not None and k in filter_}
 
     def get_data_int_type(  # noqa: PLR0911
@@ -224,6 +236,7 @@ class DataTypeManager(_DataTypeManager):
         types: Types,
         **kwargs: Any,
     ) -> DataType:
+        """Get int data type with constraints (conint, PositiveInt, etc.)."""
         data_type_kwargs: dict[str, Any] = self.transform_kwargs(kwargs, number_kwargs)
         strict = StrictTypes.int in self.strict_types
         if data_type_kwargs:
@@ -249,6 +262,7 @@ class DataTypeManager(_DataTypeManager):
         types: Types,
         **kwargs: Any,
     ) -> DataType:
+        """Get float data type with constraints (confloat, PositiveFloat, etc.)."""
         data_type_kwargs = self.transform_kwargs(kwargs, number_kwargs)
         strict = StrictTypes.float in self.strict_types
         if data_type_kwargs:
@@ -270,6 +284,7 @@ class DataTypeManager(_DataTypeManager):
         return self.type_map[types]
 
     def get_data_decimal_type(self, types: Types, **kwargs: Any) -> DataType:
+        """Get decimal data type with constraints (condecimal)."""
         data_type_kwargs = self.transform_kwargs(kwargs, number_kwargs)
         if data_type_kwargs:
             return self.data_type.from_import(
@@ -279,6 +294,7 @@ class DataTypeManager(_DataTypeManager):
         return self.type_map[types]
 
     def get_data_str_type(self, types: Types, **kwargs: Any) -> DataType:
+        """Get string data type with constraints (constr)."""
         data_type_kwargs: dict[str, Any] = self.transform_kwargs(kwargs, string_kwargs)
         strict = StrictTypes.str in self.strict_types
         if data_type_kwargs:
@@ -294,6 +310,7 @@ class DataTypeManager(_DataTypeManager):
         return self.type_map[types]
 
     def get_data_bytes_type(self, types: Types, **kwargs: Any) -> DataType:
+        """Get bytes data type with constraints (conbytes)."""
         data_type_kwargs: dict[str, Any] = self.transform_kwargs(kwargs, bytes_kwargs)
         strict = StrictTypes.bytes in self.strict_types
         if data_type_kwargs and not strict:
@@ -309,6 +326,7 @@ class DataTypeManager(_DataTypeManager):
         types: Types,
         **kwargs: Any,
     ) -> DataType:
+        """Get data type with appropriate constraints for the given type."""
         if types == Types.string:
             return self.get_data_str_type(types, **kwargs)
         if types in {Types.int32, Types.int64, Types.integer}:

--- a/src/datamodel_code_generator/model/pydantic_v2/__init__.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/__init__.py
@@ -1,3 +1,9 @@
+"""Pydantic v2 model generator.
+
+Provides BaseModel, RootModel, and DataModelField for generating
+Pydantic v2 compatible data models with ConfigDict support.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional
@@ -13,10 +19,13 @@ if TYPE_CHECKING:
 
 
 def dump_resolve_reference_action(class_names: Iterable[str]) -> str:
+    """Generate model_rebuild() calls for Pydantic v2 models."""
     return "\n".join(f"{class_name}.model_rebuild()" for class_name in class_names)
 
 
 class ConfigDict(_BaseModel):
+    """Pydantic v2 model_config options."""
+
     extra: Optional[str] = None  # noqa: UP045
     title: Optional[str] = None  # noqa: UP045
     populate_by_name: Optional[bool] = None  # noqa: UP045

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -1,3 +1,9 @@
+"""Pydantic v2 BaseModel implementation.
+
+Provides Constraints, DataModelField, and BaseModel for Pydantic v2
+with support for Field() constraints and ConfigDict.
+"""
+
 from __future__ import annotations
 
 import re
@@ -28,17 +34,22 @@ if TYPE_CHECKING:
 
 
 class UnionMode(Enum):
+    """Union discriminator mode for Pydantic v2."""
+
     smart = "smart"
     left_to_right = "left_to_right"
 
 
 class Constraints(_Constraints):
+    """Pydantic v2 field constraints with pattern support."""
+
     # To override existing pattern alias
     regex: Optional[str] = Field(None, alias="regex")  # noqa: UP045
     pattern: Optional[str] = Field(None, alias="pattern")  # noqa: UP045
 
     @model_validator(mode="before")
     def validate_min_max_items(cls, values: Any) -> dict[str, Any]:  # noqa: N805
+        """Validate and convert minItems/maxItems to minLength/maxLength."""
         if not isinstance(values, dict):  # pragma: no cover
             return values
         min_items = values.pop("minItems", None)
@@ -51,6 +62,8 @@ class Constraints(_Constraints):
 
 
 class DataModelField(DataModelFieldV1):
+    """Pydantic v2 field with Field() constraints and json_schema_extra support."""
+
     _EXCLUDE_FIELD_KEYS: ClassVar[set[str]] = {
         "alias",
         "default",
@@ -101,6 +114,7 @@ class DataModelField(DataModelFieldV1):
 
     @field_validator("extras")
     def validate_extras(cls, values: Any) -> dict[str, Any]:  # noqa: N805
+        """Validate and convert example to examples list."""
         if not isinstance(values, dict):  # pragma: no cover
             return values
         if "examples" in values:
@@ -111,6 +125,7 @@ class DataModelField(DataModelFieldV1):
         return values
 
     def process_const(self) -> None:
+        """Process const field by converting it to a literal type with default value."""
         if "const" not in self.extras:
             return
         self.const = True
@@ -149,12 +164,16 @@ class DataModelField(DataModelFieldV1):
 
 
 class ConfigAttribute(NamedTuple):
+    """Configuration attribute mapping for ConfigDict conversion."""
+
     from_: str
     to: str
     invert: bool
 
 
 class BaseModel(BaseModelBase):
+    """Pydantic v2 BaseModel with ConfigDict and pattern-based regex_engine support."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "pydantic_v2/BaseModel.jinja2"
     BASE_CLASS: ClassVar[str] = "pydantic.BaseModel"
     CONFIG_ATTRIBUTES: ClassVar[list[ConfigAttribute]] = [
@@ -181,6 +200,7 @@ class BaseModel(BaseModelBase):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize BaseModel with ConfigDict generation from template data."""
         super().__init__(
             reference=reference,
             fields=fields,

--- a/src/datamodel_code_generator/model/pydantic_v2/imports.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/imports.py
@@ -1,3 +1,8 @@
+"""Import definitions for Pydantic v2 types.
+
+Provides pre-defined Import objects for Pydantic v2 types (ConfigDict, AwareDatetime, etc.).
+"""
+
 from __future__ import annotations
 
 from datamodel_code_generator.imports import Import
@@ -6,6 +11,4 @@ IMPORT_CONFIG_DICT = Import.from_full_path("pydantic.ConfigDict")
 IMPORT_AWARE_DATETIME = Import.from_full_path("pydantic.AwareDatetime")
 IMPORT_NAIVE_DATETIME = Import.from_full_path("pydantic.NaiveDatetime")
 IMPORT_BASE64STR = Import.from_full_path("pydantic.Base64Str")
-"""
-Used for OpenAPI strings with format "byte" (base64 encoded characters).
-"""
+# IMPORT_BASE64STR: Used for OpenAPI strings with format "byte" (base64 encoded characters).

--- a/src/datamodel_code_generator/model/pydantic_v2/root_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/root_model.py
@@ -1,3 +1,8 @@
+"""Pydantic v2 RootModel implementation.
+
+Generates models inheriting from pydantic.RootModel for wrapping single types.
+"""
+
 from __future__ import annotations
 
 from typing import Any, ClassVar, Literal
@@ -6,6 +11,8 @@ from datamodel_code_generator.model.pydantic_v2.base_model import BaseModel
 
 
 class RootModel(BaseModel):
+    """DataModel for Pydantic v2 RootModel."""
+
     TEMPLATE_FILE_PATH: ClassVar[str] = "pydantic_v2/RootModel.jinja2"
     BASE_CLASS: ClassVar[str] = "pydantic.RootModel"
 
@@ -13,8 +20,11 @@ class RootModel(BaseModel):
         self,
         **kwargs: Any,
     ) -> None:
-        # Remove custom_base_class for Pydantic V2 models; behaviour is different from Pydantic V1 as it will not
-        # be treated as a root model. custom_base_class cannot both implement BaseModel and RootModel!
+        """Initialize RootModel and remove custom_base_class if present.
+
+        Remove custom_base_class for Pydantic V2 models; behaviour is different from Pydantic V1 as it will not
+        be treated as a root model. custom_base_class cannot both implement BaseModel and RootModel!
+        """
         if "custom_base_class" in kwargs:
             kwargs.pop("custom_base_class")
 

--- a/src/datamodel_code_generator/model/pydantic_v2/types.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/types.py
@@ -1,3 +1,8 @@
+"""Pydantic v2 type manager.
+
+Maps schema types to Pydantic v2 specific types with AwareDatetime, NaiveDatetime, etc.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
@@ -17,6 +22,8 @@ if TYPE_CHECKING:
 
 
 class DataTypeManager(_DataTypeManager):
+    """Type manager for Pydantic v2 with pattern key support."""
+
     PATTERN_KEY: ClassVar[str] = "pattern"
 
     def type_map_factory(
@@ -26,6 +33,7 @@ class DataTypeManager(_DataTypeManager):
         pattern_key: str,
         target_datetime_class: DatetimeClassType | None = None,
     ) -> dict[Types, DataType]:
+        """Create type mapping with Pydantic v2 specific types and datetime classes."""
         result = {
             **super().type_map_factory(
                 data_type,

--- a/src/datamodel_code_generator/model/scalar.py
+++ b/src/datamodel_code_generator/model/scalar.py
@@ -1,3 +1,8 @@
+"""Scalar type model generator.
+
+Generates type aliases for GraphQL scalar types.
+"""
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -35,7 +40,7 @@ DEFAULT_GRAPHQL_SCALAR_TYPES: dict[str, str] = {
 
 
 class _DataTypeScalarBase(DataModel):
-    """Base class for GraphQL scalar types with shared __init__ logic"""
+    """Base class for GraphQL scalar types with shared __init__ logic."""
 
     def __init__(  # noqa: PLR0913
         self,
@@ -55,6 +60,7 @@ class _DataTypeScalarBase(DataModel):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize GraphQL scalar type with Python type mapping."""
         extra_template_data = extra_template_data or defaultdict(dict)
 
         scalar_name = reference.name
@@ -87,7 +93,7 @@ class _DataTypeScalarBase(DataModel):
 
 
 class DataTypeScalar(_DataTypeScalarBase):
-    """GraphQL scalar using TypeAlias annotation for Python 3.10+ (Name: TypeAlias = type)"""
+    """GraphQL scalar using TypeAlias annotation for Python 3.10+ (Name: TypeAlias = type)."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "ScalarTypeAliasAnnotation.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -95,7 +101,7 @@ class DataTypeScalar(_DataTypeScalarBase):
 
 
 class DataTypeScalarBackport(_DataTypeScalarBase):
-    """GraphQL scalar using TypeAlias annotation for Python 3.9 (Name: TypeAlias = type)"""
+    """GraphQL scalar using TypeAlias annotation for Python 3.9 (Name: TypeAlias = type)."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "ScalarTypeAliasAnnotation.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -103,7 +109,7 @@ class DataTypeScalarBackport(_DataTypeScalarBase):
 
 
 class DataTypeScalarTypeBackport(_DataTypeScalarBase):
-    """GraphQL scalar using TypeAliasType for Python 3.9-3.11 (Name = TypeAliasType("Name", type))"""
+    """GraphQL scalar using TypeAliasType for Python 3.9-3.11 (Name = TypeAliasType("Name", type))."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "ScalarTypeAliasType.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -111,7 +117,7 @@ class DataTypeScalarTypeBackport(_DataTypeScalarBase):
 
 
 class DataTypeScalarTypeStatement(_DataTypeScalarBase):
-    """GraphQL scalar using type statement for Python 3.12+ (type Name = type)"""
+    """GraphQL scalar using type statement for Python 3.12+ (type Name = type)."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "ScalarTypeStatement.jinja2"
     BASE_CLASS: ClassVar[str] = ""

--- a/src/datamodel_code_generator/model/type_alias.py
+++ b/src/datamodel_code_generator/model/type_alias.py
@@ -1,3 +1,9 @@
+"""Type alias model generators.
+
+Provides classes for generating type aliases using different Python syntax:
+TypeAlias annotation, TypeAliasType, and type statement (Python 3.12+).
+"""
+
 from __future__ import annotations
 
 from typing import ClassVar
@@ -18,6 +24,7 @@ class TypeAliasBase(DataModel):
 
     @property
     def imports(self) -> tuple[Import, ...]:
+        """Get imports including Annotated if needed."""
         imports = super().imports
         if self.fields and (self.fields[0].annotated or self.fields[0].field):
             imports = chain_as_tuple(imports, (IMPORT_ANNOTATED,))
@@ -26,7 +33,7 @@ class TypeAliasBase(DataModel):
 
 
 class TypeAlias(TypeAliasBase):
-    """TypeAlias annotation for Python 3.10+ (Name: TypeAlias = type)"""
+    """TypeAlias annotation for Python 3.10+ (Name: TypeAlias = type)."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "TypeAliasAnnotation.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -34,7 +41,7 @@ class TypeAlias(TypeAliasBase):
 
 
 class TypeAliasBackport(TypeAliasBase):
-    """TypeAlias annotation for Python 3.9 (Name: TypeAlias = type) using typing_extensions"""
+    """TypeAlias annotation for Python 3.9 (Name: TypeAlias = type) using typing_extensions."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "TypeAliasAnnotation.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -42,7 +49,7 @@ class TypeAliasBackport(TypeAliasBase):
 
 
 class TypeAliasTypeBackport(TypeAliasBase):
-    """TypeAliasType for Python 3.9-3.11 (Name = TypeAliasType("Name", type))"""
+    """TypeAliasType for Python 3.9-3.11 (Name = TypeAliasType("Name", type))."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "TypeAliasType.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -50,7 +57,7 @@ class TypeAliasTypeBackport(TypeAliasBase):
 
 
 class TypeStatement(TypeAliasBase):
-    """Type statement for Python 3.12+ (type Name = type)"""
+    """Type statement for Python 3.12+ (type Name = type)."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "TypeStatement.jinja2"
     BASE_CLASS: ClassVar[str] = ""

--- a/src/datamodel_code_generator/model/types.py
+++ b/src/datamodel_code_generator/model/types.py
@@ -1,3 +1,8 @@
+"""Base type manager for model modules.
+
+Provides DataTypeManager implementation with type mapping factory.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -16,6 +21,7 @@ if TYPE_CHECKING:
 
 
 def type_map_factory(data_type: type[DataType]) -> dict[Types, DataType]:
+    """Create type mapping for common schema types to Python types."""
     data_type_int = data_type(type="int")
     data_type_float = data_type(type="float")
     data_type_str = data_type(type="str")
@@ -58,6 +64,8 @@ def type_map_factory(data_type: type[DataType]) -> dict[Types, DataType]:
 
 
 class DataTypeManager(_DataTypeManager):
+    """Base type manager for model modules."""
+
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         python_version: PythonVersion = PythonVersionMin,
@@ -70,6 +78,7 @@ class DataTypeManager(_DataTypeManager):
         target_datetime_class: DatetimeClassType | None = None,
         treat_dot_as_module: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize type manager with basic type mapping."""
         super().__init__(
             python_version,
             use_standard_collections,
@@ -89,4 +98,5 @@ class DataTypeManager(_DataTypeManager):
         types: Types,
         **_: Any,
     ) -> DataType:
+        """Get data type for schema type."""
         return self.type_map[types]

--- a/src/datamodel_code_generator/model/union.py
+++ b/src/datamodel_code_generator/model/union.py
@@ -1,3 +1,8 @@
+"""Union type model generators.
+
+Provides classes for generating union type aliases for GraphQL union types.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -20,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class _DataTypeUnionBase(DataModel):
-    """Base class for GraphQL union types with shared __init__ logic"""
+    """Base class for GraphQL union types with shared __init__ logic."""
 
     def __init__(  # noqa: PLR0913
         self,
@@ -40,6 +45,7 @@ class _DataTypeUnionBase(DataModel):
         keyword_only: bool = False,
         treat_dot_as_module: bool = False,
     ) -> None:
+        """Initialize GraphQL union type."""
         super().__init__(
             reference=reference,
             fields=fields,
@@ -59,7 +65,7 @@ class _DataTypeUnionBase(DataModel):
 
 
 class DataTypeUnion(_DataTypeUnionBase):
-    """GraphQL union using TypeAlias annotation for Python 3.10+ (Name: TypeAlias = Union[...])"""
+    """GraphQL union using TypeAlias annotation for Python 3.10+ (Name: TypeAlias = Union[...])."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "UnionTypeAliasAnnotation.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -70,7 +76,7 @@ class DataTypeUnion(_DataTypeUnionBase):
 
 
 class DataTypeUnionBackport(_DataTypeUnionBase):
-    """GraphQL union using TypeAlias annotation for Python 3.9 (Name: TypeAlias = Union[...])"""
+    """GraphQL union using TypeAlias annotation for Python 3.9 (Name: TypeAlias = Union[...])."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "UnionTypeAliasAnnotation.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -81,7 +87,7 @@ class DataTypeUnionBackport(_DataTypeUnionBase):
 
 
 class DataTypeUnionTypeBackport(_DataTypeUnionBase):
-    """GraphQL union using TypeAliasType for Python 3.9-3.11 (Name = TypeAliasType("Name", Union[...]))"""
+    """GraphQL union using TypeAliasType for Python 3.9-3.11 (Name = TypeAliasType("Name", Union[...]))."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "UnionTypeAliasType.jinja2"
     BASE_CLASS: ClassVar[str] = ""
@@ -92,7 +98,7 @@ class DataTypeUnionTypeBackport(_DataTypeUnionBase):
 
 
 class DataTypeUnionTypeStatement(_DataTypeUnionBase):
-    """GraphQL union using type statement for Python 3.12+ (type Name = Union[...])"""
+    """GraphQL union using type statement for Python 3.12+ (type Name = Union[...])."""
 
     TEMPLATE_FILE_PATH: ClassVar[str] = "UnionTypeStatement.jinja2"
     BASE_CLASS: ClassVar[str] = ""

--- a/src/datamodel_code_generator/parser/__init__.py
+++ b/src/datamodel_code_generator/parser/__init__.py
@@ -1,3 +1,9 @@
+"""Parser utilities and base types for schema parsing.
+
+Provides LiteralType enum for literal parsing options and DefaultPutDict
+for caching remote schema content.
+"""
+
 from __future__ import annotations
 
 from collections import UserDict
@@ -9,17 +15,22 @@ TV = TypeVar("TV")
 
 
 class LiteralType(Enum):
+    """Options for handling enum fields as literals."""
+
     All = "all"
     One = "one"
 
 
 class DefaultPutDict(UserDict[TK, TV]):
+    """Dict that can lazily compute and cache missing values."""
+
     def get_or_put(
         self,
         key: TK,
         default: TV | None = None,
         default_factory: Callable[[TK], TV] | None = None,
     ) -> TV:
+        """Get value for key, or compute and store it if missing."""
         if key in self:
             return self[key]
         if default:  # pragma: no cover

--- a/src/datamodel_code_generator/parser/graphql.py
+++ b/src/datamodel_code_generator/parser/graphql.py
@@ -1,3 +1,9 @@
+"""GraphQL schema parser implementation.
+
+Parses GraphQL schema files to generate Python data models including
+objects, interfaces, enums, scalars, inputs, and union types.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -58,6 +64,8 @@ def build_graphql_schema(schema_str: str) -> graphql.GraphQLSchema:
 
 @snooper_to_methods()
 class GraphQLParser(Parser):
+    """Parser for GraphQL schema files."""
+
     # raw graphql schema as `graphql-core` object
     raw_obj: graphql.GraphQLSchema
     # all processed graphql objects
@@ -166,6 +174,7 @@ class GraphQLParser(Parser):
         formatters: list[Formatter] = DEFAULT_FORMATTERS,
         parent_scoped_naming: bool = False,
     ) -> None:
+        """Initialize the GraphQL parser with configuration options."""
         super().__init__(
             source=source,
             data_model_type=data_model_type,
@@ -338,6 +347,7 @@ class GraphQLParser(Parser):
         return None
 
     def parse_scalar(self, scalar_graphql_object: graphql.GraphQLScalarType) -> None:
+        """Parse a GraphQL scalar type and add it to results."""
         self.results.append(
             self.data_model_scalar_type(
                 reference=self.references[scalar_graphql_object.name],
@@ -349,6 +359,7 @@ class GraphQLParser(Parser):
         )
 
     def parse_enum(self, enum_object: graphql.GraphQLEnumType) -> None:
+        """Parse a GraphQL enum type and add it to results."""
         enum_fields: list[DataModelFieldBase] = []
         exclude_field_names: set[str] = set()
 
@@ -400,6 +411,7 @@ class GraphQLParser(Parser):
         alias: str | None,
         field: graphql.GraphQLField | graphql.GraphQLInputField,
     ) -> DataModelFieldBase:
+        """Parse a GraphQL field and return a data model field."""
         final_data_type = DataType(
             is_optional=True,
             use_union_operator=self.use_union_operator,
@@ -461,6 +473,7 @@ class GraphQLParser(Parser):
         self,
         obj: graphql.GraphQLInterfaceType | graphql.GraphQLObjectType | graphql.GraphQLInputObjectType,
     ) -> None:
+        """Parse a GraphQL object-like type and add it to results."""
         fields = []
         exclude_field_names: set[str] = set()
 
@@ -494,15 +507,19 @@ class GraphQLParser(Parser):
         self.results.append(data_model_type)
 
     def parse_interface(self, interface_graphql_object: graphql.GraphQLInterfaceType) -> None:
+        """Parse a GraphQL interface type and add it to results."""
         self.parse_object_like(interface_graphql_object)
 
     def parse_object(self, graphql_object: graphql.GraphQLObjectType) -> None:
+        """Parse a GraphQL object type and add it to results."""
         self.parse_object_like(graphql_object)
 
     def parse_input_object(self, input_graphql_object: graphql.GraphQLInputObjectType) -> None:
+        """Parse a GraphQL input object type and add it to results."""
         self.parse_object_like(input_graphql_object)  # pragma: no cover
 
     def parse_union(self, union_object: graphql.GraphQLUnionType) -> None:
+        """Parse a GraphQL union type and add it to results."""
         fields = [self.data_model_field_type(name=type_.name, data_type=DataType()) for type_ in union_object.types]
 
         data_model_type = self.data_model_union_type(
@@ -517,6 +534,7 @@ class GraphQLParser(Parser):
         self.results.append(data_model_type)
 
     def parse_raw(self) -> None:
+        """Parse the raw GraphQL schema and generate all data models."""
         self.all_graphql_objects = {}
         self.references: dict[str, Reference] = {}
 

--- a/src/datamodel_code_generator/pydantic_patch.py
+++ b/src/datamodel_code_generator/pydantic_patch.py
@@ -1,3 +1,9 @@
+"""Pydantic compatibility patches for Python 3.12+.
+
+Patches pydantic.typing.evaluate_forwardref for forward reference evaluation
+compatibility with newer Python versions.
+"""
+
 from __future__ import annotations
 
 import sys
@@ -9,6 +15,7 @@ import pydantic.typing
 def patched_evaluate_forwardref(
     forward_ref: Any, globalns: dict[str, Any], localns: dict[str, Any] | None = None
 ) -> None:  # pragma: no cover
+    """Evaluate a forward reference with Python 3.12+ compatibility."""
     try:
         return forward_ref._evaluate(globalns, localns or None, set())  # pragma: no cover  # noqa: SLF001
     except TypeError:

--- a/src/datamodel_code_generator/reference.py
+++ b/src/datamodel_code_generator/reference.py
@@ -1,3 +1,10 @@
+"""Reference resolution and model tracking system.
+
+Provides Reference for tracking model references across schemas, ModelResolver
+for managing class names and field names, and FieldNameResolver for converting
+schema field names to valid Python identifiers.
+"""
+
 from __future__ import annotations
 
 import re
@@ -27,6 +34,8 @@ if TYPE_CHECKING:
 
 
 class _BaseModel(BaseModel):
+    """Base model with field exclusion and pass-through support."""
+
     _exclude_fields: ClassVar[set[str]] = set()
     _pass_fields: ClassVar[set[str]] = set()
 
@@ -85,6 +94,11 @@ class _BaseModel(BaseModel):
 
 
 class Reference(_BaseModel):
+    """Represents a reference to a model in the schema.
+
+    Tracks path, name, and relationships between models for resolution.
+    """
+
     path: str
     original_name: str = ""
     name: str
@@ -96,9 +110,7 @@ class Reference(_BaseModel):
 
     @model_validator(mode="before")
     def validate_original_name(cls, values: Any) -> Any:  # noqa: N805
-        """
-        If original_name is empty then, `original_name` is assigned `name`
-        """
+        """Assign name to original_name if original_name is empty."""
         if not isinstance(values, dict):  # pragma: no cover
             return values
         original_name = values.get("original_name")
@@ -119,12 +131,15 @@ class Reference(_BaseModel):
     else:
 
         class Config:
+            """Pydantic v1 configuration for Reference model."""
+
             arbitrary_types_allowed = True
             keep_untouched = (cached_property,)
             copy_on_model_validation = False if version.parse(pydantic.VERSION) < version.parse("1.9.2") else "none"
 
     @property
     def short_name(self) -> str:
+        """Return the last component of the dotted name."""
         return self.name.rsplit(".", 1)[-1]
 
 
@@ -137,6 +152,7 @@ T = TypeVar("T")
 
 @contextmanager
 def context_variable(setter: Callable[[T], None], current_value: T, new_value: T) -> Generator[None, None, None]:
+    """Context manager that temporarily sets a value and restores it on exit."""
     previous_value: T = current_value
     setter(new_value)
     try:
@@ -151,11 +167,14 @@ _UNDER_SCORE_2: Pattern[str] = re.compile(r"([a-z0-9])([A-Z])")
 
 @lru_cache
 def camel_to_snake(string: str) -> str:
+    """Convert camelCase or PascalCase to snake_case."""
     subbed = _UNDER_SCORE_1.sub(r"\1_\2", string)
     return _UNDER_SCORE_2.sub(r"\1_\2", subbed).lower()
 
 
 class FieldNameResolver:
+    """Converts schema field names to valid Python identifiers."""
+
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         aliases: Mapping[str, str] | None = None,
@@ -167,6 +186,7 @@ class FieldNameResolver:
         capitalise_enum_members: bool = False,  # noqa: FBT001, FBT002
         no_alias: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize field name resolver with transformation options."""
         self.aliases: Mapping[str, str] = {} if aliases is None else {**aliases}
         self.empty_field_name: str = empty_field_name or "_"
         self.snake_case_field = snake_case_field
@@ -180,6 +200,7 @@ class FieldNameResolver:
 
     @classmethod
     def _validate_field_name(cls, field_name: str) -> bool:  # noqa: ARG003
+        """Check if a field name is valid. Subclasses may override."""
         return True
 
     def get_valid_name(  # noqa: PLR0912
@@ -189,6 +210,7 @@ class FieldNameResolver:
         ignore_snake_case_field: bool = False,  # noqa: FBT001, FBT002
         upper_camel: bool = False,  # noqa: FBT001, FBT002
     ) -> str:
+        """Convert a name to a valid Python identifier."""
         if not name:
             name = self.empty_field_name
         if name[0] == "#":
@@ -232,6 +254,7 @@ class FieldNameResolver:
     def get_valid_field_name_and_alias(
         self, field_name: str, excludes: set[str] | None = None
     ) -> tuple[str, str | None]:
+        """Get valid field name and original alias if different."""
         if field_name in self.aliases:
             return self.aliases[field_name], field_name
         valid_name = self.get_valid_name(field_name, excludes=excludes)
@@ -242,13 +265,18 @@ class FieldNameResolver:
 
 
 class PydanticFieldNameResolver(FieldNameResolver):
+    """Field name resolver that avoids Pydantic reserved names."""
+
     @classmethod
     def _validate_field_name(cls, field_name: str) -> bool:
+        """Check field name doesn't conflict with BaseModel attributes."""
         # TODO: Support Pydantic V2
         return not hasattr(BaseModel, field_name)
 
 
 class EnumFieldNameResolver(FieldNameResolver):
+    """Field name resolver for enum members with special handling for 'mro'."""
+
     def get_valid_name(
         self,
         name: str,
@@ -256,6 +284,7 @@ class EnumFieldNameResolver(FieldNameResolver):
         ignore_snake_case_field: bool = False,  # noqa: FBT001, FBT002
         upper_camel: bool = False,  # noqa: FBT001, FBT002
     ) -> str:
+        """Convert name to valid enum member, handling reserved names."""
         return super().get_valid_name(
             name="mro_" if name == "mro" else name,
             excludes={"mro"} | (excludes or set()),
@@ -265,6 +294,8 @@ class EnumFieldNameResolver(FieldNameResolver):
 
 
 class ModelType(Enum):
+    """Type of model for field name resolution strategy."""
+
     PYDANTIC = auto()
     ENUM = auto()
     CLASS = auto()
@@ -278,11 +309,14 @@ DEFAULT_FIELD_NAME_RESOLVERS: dict[ModelType, type[FieldNameResolver]] = {
 
 
 class ClassName(NamedTuple):
+    """A class name with optional duplicate name for disambiguation."""
+
     name: str
     duplicate_name: str | None
 
 
 def get_relative_path(base_path: PurePath, target_path: PurePath) -> PurePath:
+    """Calculate relative path from base to target."""
     if base_path == target_path:
         return Path()
     if not target_path.is_absolute():
@@ -300,6 +334,12 @@ def get_relative_path(base_path: PurePath, target_path: PurePath) -> PurePath:
 
 
 class ModelResolver:  # noqa: PLR0904
+    """Manages model references, class names, and field name resolution.
+
+    Central registry for all model references during parsing, handling
+    name uniqueness, path resolution, and field name transformations.
+    """
+
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         exclude_names: set[str] | None = None,
@@ -320,6 +360,7 @@ class ModelResolver:  # noqa: PLR0904
         remove_suffix_number: bool = False,  # noqa: FBT001, FBT002
         parent_scoped_naming: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize model resolver with naming and resolution options."""
         self.references: dict[str, Reference] = {}
         self._current_root: Sequence[str] = []
         self._root_id: str | None = None
@@ -356,20 +397,25 @@ class ModelResolver:  # noqa: PLR0904
 
     @property
     def current_base_path(self) -> Path | None:
+        """Return the current base path for file resolution."""
         return self._current_base_path
 
     def set_current_base_path(self, base_path: Path | None) -> None:
+        """Set the current base path for file resolution."""
         self._current_base_path = base_path
 
     @property
     def base_url(self) -> str | None:
+        """Return the base URL for reference resolution."""
         return self._base_url
 
     def set_base_url(self, base_url: str | None) -> None:
+        """Set the base URL for reference resolution."""
         self._base_url = base_url
 
     @contextmanager
     def current_base_path_context(self, base_path: Path | None) -> Generator[None, None, None]:
+        """Temporarily set the current base path within a context."""
         if base_path:
             base_path = (self._base_path / base_path).resolve()
         with context_variable(self.set_current_base_path, self.current_base_path, base_path):
@@ -377,6 +423,7 @@ class ModelResolver:  # noqa: PLR0904
 
     @contextmanager
     def base_url_context(self, base_url: str) -> Generator[None, None, None]:
+        """Temporarily set the base URL within a context."""
         if self._base_url:
             with context_variable(self.set_base_url, self.base_url, base_url):
                 yield
@@ -385,27 +432,33 @@ class ModelResolver:  # noqa: PLR0904
 
     @property
     def current_root(self) -> Sequence[str]:
+        """Return the current root path components."""
         if len(self._current_root) > 1:
             return self._current_root
         return self._current_root
 
     def set_current_root(self, current_root: Sequence[str]) -> None:
+        """Set the current root path components."""
         self._current_root = current_root
 
     @contextmanager
     def current_root_context(self, current_root: Sequence[str]) -> Generator[None, None, None]:
+        """Temporarily set the current root path within a context."""
         with context_variable(self.set_current_root, self.current_root, current_root):
             yield
 
     @property
     def root_id(self) -> str | None:
+        """Return the root identifier for the current schema."""
         return self._root_id
 
     @property
     def root_id_base_path(self) -> str | None:
+        """Return the base path component of the root identifier."""
         return self._root_id_base_path
 
     def set_root_id(self, root_id: str | None) -> None:
+        """Set the root identifier and extract its base path."""
         if root_id and "/" in root_id:
             self._root_id_base_path = root_id.rsplit("/", 1)[0]
         else:
@@ -414,9 +467,11 @@ class ModelResolver:  # noqa: PLR0904
         self._root_id = root_id
 
     def add_id(self, id_: str, path: Sequence[str]) -> None:
+        """Register an identifier mapping to a resolved reference path."""
         self.ids["/".join(self.current_root)][id_] = self.resolve_ref(path)
 
     def resolve_ref(self, path: Sequence[str] | str) -> str:  # noqa: PLR0911, PLR0912
+        """Resolve a reference path to its canonical form."""
         joined_path = path if isinstance(path, str) else self.join_path(path)
         if joined_path == "#":
             return f"{'/'.join(self.current_root)}#"
@@ -470,6 +525,7 @@ class ModelResolver:  # noqa: PLR0904
         return ref
 
     def is_after_load(self, ref: str) -> bool:
+        """Check if a reference points to a file loaded after the current one."""
         if is_url(ref) or not self.current_base_path:
             return False
         file_part, *_ = ref.split("#", 1)
@@ -480,20 +536,24 @@ class ModelResolver:  # noqa: PLR0904
 
     @staticmethod
     def is_external_ref(ref: str) -> bool:
+        """Check if a reference points to an external file."""
         return "#" in ref and ref[0] != "#"
 
     @staticmethod
     def is_external_root_ref(ref: str) -> bool:
+        """Check if a reference points to an external file root."""
         return ref[-1] == "#"
 
     @staticmethod
     def join_path(path: Sequence[str]) -> str:
+        """Join path components with slashes and normalize anchors."""
         joined_path = "/".join(p for p in path if p).replace("/#", "#")
         if "#" not in joined_path:
             joined_path += "#"
         return joined_path
 
     def add_ref(self, ref: str, resolved: bool = False) -> Reference:  # noqa: FBT001, FBT002
+        """Add a reference and return the Reference object."""
         path = self.resolve_ref(ref) if not resolved else ref
         reference = self.references.get(path)
         if reference:
@@ -538,6 +598,7 @@ class ModelResolver:  # noqa: PLR0904
         singular_name_suffix: str | None = None,
         loaded: bool = False,
     ) -> Reference:
+        """Add or update a model reference with the given path and name."""
         joined_path = self.join_path(path)
         reference: Reference | None = self.references.get(joined_path)
         if reference:
@@ -583,13 +644,16 @@ class ModelResolver:  # noqa: PLR0904
         return reference
 
     def get(self, path: Sequence[str] | str) -> Reference | None:
+        """Get a reference by path, returning None if not found."""
         return self.references.get(self.resolve_ref(path))
 
     def delete(self, path: Sequence[str] | str) -> None:
+        """Delete a reference by path if it exists."""
         if self.resolve_ref(path) in self.references:
             del self.references[self.resolve_ref(path)]
 
     def default_class_name_generator(self, name: str) -> str:
+        """Generate a valid class name from a string."""
         # TODO: create a validate for class name
         return self.field_name_resolvers[ModelType.CLASS].get_valid_name(
             name, ignore_snake_case_field=True, upper_camel=True
@@ -603,6 +667,7 @@ class ModelResolver:  # noqa: PLR0904
         singular_name: bool = False,  # noqa: FBT001, FBT002
         singular_name_suffix: str | None = None,
     ) -> ClassName:
+        """Generate a unique class name with optional singularization."""
         if "." in name:
             split_name = name.split(".")
             prefix = ".".join(
@@ -651,6 +716,7 @@ class ModelResolver:  # noqa: PLR0904
 
     @classmethod
     def validate_name(cls, name: str) -> bool:
+        """Check if a name is a valid Python identifier."""
         return name.isidentifier() and not iskeyword(name)
 
     def get_valid_field_name(
@@ -659,6 +725,7 @@ class ModelResolver:  # noqa: PLR0904
         excludes: set[str] | None = None,
         model_type: ModelType = ModelType.PYDANTIC,
     ) -> str:
+        """Get a valid field name for the specified model type."""
         return self.field_name_resolvers[model_type].get_valid_name(name, excludes)
 
     def get_valid_field_name_and_alias(
@@ -667,11 +734,13 @@ class ModelResolver:  # noqa: PLR0904
         excludes: set[str] | None = None,
         model_type: ModelType = ModelType.PYDANTIC,
     ) -> tuple[str, str | None]:
+        """Get a valid field name and alias for the specified model type."""
         return self.field_name_resolvers[model_type].get_valid_field_name_and_alias(field_name, excludes)
 
 
 @lru_cache
 def get_singular_name(name: str, suffix: str = SINGULAR_NAME_SUFFIX) -> str:
+    """Convert a plural name to singular form."""
     singular_name = inflect_engine.singular_noun(cast("inflect.Word", name))
     if singular_name is False:
         singular_name = f"{name}{suffix}"
@@ -680,6 +749,7 @@ def get_singular_name(name: str, suffix: str = SINGULAR_NAME_SUFFIX) -> str:
 
 @lru_cache
 def snake_to_upper_camel(word: str, delimiter: str = "_") -> str:
+    """Convert snake_case or delimited string to UpperCamelCase."""
     prefix = ""
     if word.startswith(delimiter):
         prefix = "_"
@@ -689,6 +759,7 @@ def snake_to_upper_camel(word: str, delimiter: str = "_") -> str:
 
 
 def is_url(ref: str) -> bool:
+    """Check if a reference string is a URL."""
     return ref.startswith(("https://", "http://"))
 
 

--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -1,3 +1,10 @@
+"""Core type system for data model generation.
+
+Provides DataType for representing types with references and constraints,
+DataTypeManager as the abstract base for type mappings, and supporting
+utilities for handling unions, optionals, and type hints.
+"""
+
 from __future__ import annotations
 
 import re
@@ -83,6 +90,8 @@ NOT_REQUIRED_PREFIX = f"{NOT_REQUIRED}["
 
 
 class StrictTypes(Enum):
+    """Strict type options for generated models."""
+
     str = "str"
     bytes = "bytes"
     int = "int"
@@ -91,26 +100,34 @@ class StrictTypes(Enum):
 
 
 class UnionIntFloat:
+    """Pydantic-compatible type that accepts both int and float values."""
+
     def __init__(self, value: float) -> None:
+        """Initialize with an int or float value."""
         self.value: int | float = value
 
     def __int__(self) -> int:
+        """Convert value to int."""
         return int(self.value)
 
     def __float__(self) -> float:
+        """Convert value to float."""
         return float(self.value)
 
     def __str__(self) -> str:
+        """Convert value to string."""
         return str(self.value)
 
     @classmethod
     def __get_validators__(cls) -> Iterator[Callable[[Any], Any]]:  # noqa: PLW3201
+        """Return Pydantic v1 validators."""
         yield cls.validate
 
     @classmethod
     def __get_pydantic_core_schema__(  # noqa: PLW3201
         cls, _source_type: Any, _handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
+        """Return Pydantic v2 core schema."""
         from_int_schema = core_schema.chain_schema(  # pyright: ignore[reportPossiblyUnboundVariable]
             [
                 core_schema.union_schema(  # pyright: ignore[reportPossiblyUnboundVariable]
@@ -136,6 +153,7 @@ class UnionIntFloat:
 
     @classmethod
     def validate(cls, v: Any) -> UnionIntFloat:
+        """Validate and convert value to UnionIntFloat."""
         if isinstance(v, UnionIntFloat):
             return v
         if not isinstance(v, (int, float)):  # pragma: no cover
@@ -156,11 +174,13 @@ class UnionIntFloat:
 
 
 def chain_as_tuple(*iterables: Iterable[T]) -> tuple[T, ...]:
+    """Chain multiple iterables and return as a tuple."""
     return tuple(chain(*iterables))
 
 
 @lru_cache
 def _remove_none_from_type(type_: str, split_pattern: Pattern[str], delimiter: str) -> list[str]:
+    """Remove None from a type string and return the remaining types."""
     types: list[str] = []
     split_type: str = ""
     inner_count: int = 0
@@ -182,6 +202,7 @@ def _remove_none_from_type(type_: str, split_pattern: Pattern[str], delimiter: s
 
 
 def _remove_none_from_union(type_: str, *, use_union_operator: bool) -> str:  # noqa: PLR0912
+    """Remove None from a Union type string, handling nested unions."""
     if use_union_operator:
         if " | " not in type_:
             return type_
@@ -248,6 +269,7 @@ def _remove_none_from_union(type_: str, *, use_union_operator: bool) -> str:  # 
 
 @lru_cache
 def get_optional_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT001
+    """Wrap a type string in Optional or add | None suffix."""
     type_ = _remove_none_from_union(type_, use_union_operator=use_union_operator)
 
     if not type_ or type_ == NONE:
@@ -259,19 +281,27 @@ def get_optional_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT
 
 @runtime_checkable
 class Modular(Protocol):
+    """Protocol for objects with a module name property."""
+
     @property
     def module_name(self) -> str:
+        """Return the module name."""
         raise NotImplementedError
 
 
 @runtime_checkable
 class Nullable(Protocol):
+    """Protocol for objects with a nullable property."""
+
     @property
     def nullable(self) -> bool:
+        """Return whether the type is nullable."""
         raise NotImplementedError
 
 
 class DataType(_BaseModel):
+    """Represents a type in generated code with imports and references."""
+
     if PYDANTIC_V2:
         # TODO[pydantic]: The following keys were removed: `copy_on_model_validation`.
         # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
@@ -284,9 +314,12 @@ class DataType(_BaseModel):
 
             @classmethod
             def model_rebuild(cls) -> None:
+                """Update forward references for Pydantic v1."""
                 cls.update_forward_refs()
 
         class Config:
+            """Pydantic v1 model configuration."""
+
             extra = "forbid"
             copy_on_model_validation = False if version.parse(pydantic.VERSION) < version.parse("1.9.2") else "none"
 
@@ -329,6 +362,7 @@ class DataType(_BaseModel):
         strict: bool = False,
         kwargs: dict[str, Any] | None = None,
     ) -> DataTypeT:
+        """Create a DataType from an Import object."""
         return cls(
             type=import_.import_,
             import_=import_,
@@ -344,12 +378,14 @@ class DataType(_BaseModel):
 
     @property
     def unresolved_types(self) -> frozenset[str]:
+        """Return set of unresolved type reference paths."""
         return frozenset(
             {t.reference.path for data_types in self.data_types for t in data_types.all_data_types if t.reference}
             | ({self.reference.path} if self.reference else set())
         )
 
     def replace_reference(self, reference: Reference | None) -> None:
+        """Replace this DataType's reference with a new one."""
         if not self.reference:  # pragma: no cover
             msg = f"`{self.__class__.__name__}.replace_reference()` can't be called when `reference` field is empty."
             raise Exception(msg)  # noqa: TRY002
@@ -360,16 +396,19 @@ class DataType(_BaseModel):
             reference.children.append(self)
 
     def remove_reference(self) -> None:
+        """Remove the reference from this DataType."""
         self.replace_reference(None)
 
     @property
     def module_name(self) -> str | None:
+        """Return the module name from the reference source."""
         if self.reference and isinstance(self.reference.source, Modular):
             return self.reference.source.module_name
         return None  # pragma: no cover
 
     @property
     def full_name(self) -> str:
+        """Return the fully qualified name including module."""
         module_name = self.module_name
         if module_name:
             return f"{module_name}.{self.reference.short_name if self.reference else ''}"
@@ -377,18 +416,21 @@ class DataType(_BaseModel):
 
     @property
     def all_data_types(self) -> Iterator[DataType]:
+        """Recursively yield all nested DataTypes including self."""
         for data_type in self.data_types:
             yield from data_type.all_data_types
         yield self
 
     @property
     def all_imports(self) -> Iterator[Import]:
+        """Recursively yield all imports from nested DataTypes and self."""
         for data_type in self.data_types:
             yield from data_type.all_imports
         yield from self.imports
 
     @property
     def imports(self) -> Iterator[Import]:
+        """Yield imports required by this DataType."""
         # Add base import if exists
         if self.import_:
             yield self.import_
@@ -433,6 +475,7 @@ class DataType(_BaseModel):
             yield from self.dict_key.imports
 
     def __init__(self, **values: Any) -> None:
+        """Initialize DataType with validation and reference setup."""
         if not TYPE_CHECKING:
             super().__init__(**values)
 
@@ -452,6 +495,7 @@ class DataType(_BaseModel):
 
     @property
     def type_hint(self) -> str:  # noqa: PLR0912, PLR0915
+        """Generate the Python type hint string for this DataType."""
         type_: str | None = self.alias or self.type
         if not type_:
             if self.is_union:
@@ -531,6 +575,7 @@ class DataType(_BaseModel):
 
     @property
     def is_union(self) -> bool:
+        """Return whether this DataType represents a union of multiple types."""
         return len(self.data_types) > 1
 
 
@@ -540,10 +585,12 @@ DataTypeT = TypeVar("DataTypeT", bound=DataType)
 
 
 class EmptyDataType(DataType):
-    pass
+    """A DataType placeholder for empty or unresolved types."""
 
 
 class Types(Enum):
+    """Standard type identifiers for schema type mapping."""
+
     integer = auto()
     int32 = auto()
     int64 = auto()
@@ -581,6 +628,11 @@ class Types(Enum):
 
 
 class DataTypeManager(ABC):
+    """Abstract base class for managing type mappings in code generation.
+
+    Subclasses implement get_data_type() to map schema types to DataType objects.
+    """
+
     def __init__(  # noqa: PLR0913, PLR0917
         self,
         python_version: PythonVersion = PythonVersionMin,
@@ -593,6 +645,7 @@ class DataTypeManager(ABC):
         target_datetime_class: DatetimeClassType | None = None,
         treat_dot_as_module: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
+        """Initialize DataTypeManager with code generation options."""
         self.python_version = python_version
         self.use_standard_collections: bool = use_standard_collections
         self.use_generic_container_types: bool = use_generic_container_types
@@ -617,12 +670,15 @@ class DataTypeManager(ABC):
 
     @abstractmethod
     def get_data_type(self, types: Types, **kwargs: Any) -> DataType:
+        """Map a Types enum value to a DataType. Must be implemented by subclasses."""
         raise NotImplementedError
 
     def get_data_type_from_full_path(self, full_path: str, is_custom_type: bool) -> DataType:  # noqa: FBT001
+        """Create a DataType from a fully qualified Python path."""
         return self.data_type.from_import(Import.from_full_path(full_path), is_custom_type=is_custom_type)
 
     def get_data_type_from_value(self, value: Any) -> DataType:
+        """Infer a DataType from a Python value."""
         type_: Types | None = None
         if isinstance(value, str):
             type_ = Types.string

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for datamodel-code-generator."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Test configuration and shared fixtures."""
+
 from __future__ import annotations
 
 import inspect
@@ -32,13 +34,17 @@ def _assert_with_external_file(content: str, expected_path: Path) -> None:
 
 
 class AssertFileContent(Protocol):
+    """Protocol for file content assertion callable."""
+
     def __call__(
         self,
         output_file: Path,
         expected_name: str | Path | None = None,
         encoding: str = "utf-8",
         transform: Callable[[str], str] | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Assert file content matches expected output."""
+        ...
 
 
 def create_assert_file_content(
@@ -185,4 +191,5 @@ def _inline_snapshot_file_formats() -> None:
 
 @pytest.fixture(scope="session")
 def min_version() -> str:
+    """Return minimum Python version as string."""
     return f"3.{MIN_VERSION}"

--- a/tests/main/__init__.py
+++ b/tests/main/__init__.py
@@ -1,0 +1,1 @@
+"""Main integration tests package."""

--- a/tests/main/graphql/__init__.py
+++ b/tests/main/graphql/__init__.py
@@ -1,0 +1,1 @@
+"""GraphQL integration tests package."""

--- a/tests/main/graphql/test_annotated.py
+++ b/tests/main/graphql/test_annotated.py
@@ -1,3 +1,5 @@
+"""Tests for GraphQL annotated types generation."""
+
 from __future__ import annotations
 
 from argparse import Namespace
@@ -21,6 +23,7 @@ assert_file_content = create_assert_file_content(EXPECTED_GRAPHQL_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -28,6 +31,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @freeze_time("2019-07-26")
 def test_annotated(tmp_path: Path) -> None:
+    """Test GraphQL code generation with annotated types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -46,6 +50,7 @@ def test_annotated(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_annotated_use_standard_collections(tmp_path: Path) -> None:
+    """Test GraphQL annotated types with standard collections."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -65,6 +70,7 @@ def test_annotated_use_standard_collections(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_annotated_use_standard_collections_use_union_operator(tmp_path: Path) -> None:
+    """Test GraphQL annotated types with standard collections and union operator."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -85,6 +91,7 @@ def test_annotated_use_standard_collections_use_union_operator(tmp_path: Path) -
 
 @freeze_time("2019-07-26")
 def test_annotated_use_union_operator(tmp_path: Path) -> None:
+    """Test GraphQL annotated types with union operator."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -104,6 +111,7 @@ def test_annotated_use_union_operator(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_annotated_field_aliases(tmp_path: Path) -> None:
+    """Test GraphQL annotated types with field aliases."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",

--- a/tests/main/graphql/test_main_graphql.py
+++ b/tests/main/graphql/test_main_graphql.py
@@ -1,3 +1,5 @@
+"""Tests for GraphQL schema code generation."""
+
 from __future__ import annotations
 
 from argparse import Namespace
@@ -23,6 +25,7 @@ assert_file_content = create_assert_file_content(EXPECTED_GRAPHQL_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -47,6 +50,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_simple_star_wars(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test GraphQL code generation for simple Star Wars schema."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -68,6 +72,7 @@ def test_main_graphql_simple_star_wars(output_model: str, expected_output: str, 
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_different_types_of_fields(tmp_path: Path) -> None:
+    """Test GraphQL code generation with different field types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -83,6 +88,7 @@ def test_main_graphql_different_types_of_fields(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_use_default_kwarg(tmp_path: Path) -> None:
+    """Test GraphQL code generation with use-default-kwarg flag."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -103,6 +109,7 @@ def test_main_use_default_kwarg(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_custom_scalar_types(tmp_path: Path) -> None:
+    """Test GraphQL code generation with custom scalar types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -124,6 +131,7 @@ def test_main_graphql_custom_scalar_types(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_field_aliases(tmp_path: Path) -> None:
+    """Test GraphQL code generation with field aliases."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -145,6 +153,7 @@ def test_main_graphql_field_aliases(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_enums(tmp_path: Path) -> None:
+    """Test GraphQL code generation with enums."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -164,6 +173,7 @@ def test_main_graphql_enums(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_specialized_enums(tmp_path: Path) -> None:
+    """Test GraphQL code generation with specialized enums for Python 3.11+."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -185,6 +195,7 @@ def test_main_graphql_specialized_enums(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_specialized_enums_disabled(tmp_path: Path) -> None:
+    """Test GraphQL code generation with specialized enums disabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -207,6 +218,7 @@ def test_main_graphql_specialized_enums_disabled(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_enums_subclass(tmp_path: Path) -> None:
+    """Test GraphQL code generation with enum subclasses."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -227,6 +239,7 @@ def test_main_graphql_enums_subclass(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_union(tmp_path: Path) -> None:
+    """Test GraphQL code generation with union types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -246,6 +259,7 @@ def test_main_graphql_union(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_graphql_additional_imports_isort_4(tmp_path: Path) -> None:
+    """Test GraphQL code generation with additional imports using isort 4.x."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -273,6 +287,7 @@ def test_main_graphql_additional_imports_isort_4(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_additional_imports_isort_not_4(tmp_path: Path) -> None:
+    """Test GraphQL code generation with additional imports using not isort 4.x."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -296,6 +311,7 @@ def test_main_graphql_additional_imports_isort_not_4(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_custom_formatters(tmp_path: Path) -> None:
+    """Test GraphQL code generation with custom formatters."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -317,6 +333,7 @@ def test_main_graphql_custom_formatters(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_use_standard_collections(tmp_path: Path) -> None:
+    """Test GraphQL code generation with standard collections."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -337,6 +354,7 @@ def test_main_graphql_use_standard_collections(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_graphql_use_union_operator(tmp_path: Path) -> None:
+    """Test GraphQL code generation with union operator syntax."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -353,6 +371,7 @@ def test_main_graphql_use_union_operator(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_graphql_extra_fields_allow(tmp_path: Path) -> None:
+    """Test GraphQL code generation with extra fields allowed."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",

--- a/tests/main/jsonschema/__init__.py
+++ b/tests/main/jsonschema/__init__.py
@@ -1,0 +1,1 @@
+"""JSON Schema integration tests package."""

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -1,3 +1,5 @@
+"""Tests for JSON Schema input file code generation."""
+
 from __future__ import annotations
 
 import contextlib
@@ -45,6 +47,7 @@ assert_file_content = create_assert_file_content(EXPECTED_JSON_SCHEMA_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -53,6 +56,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_inheritance_forward_ref(tmp_path: Path) -> None:
+    """Test inheritance with forward references."""
     output_file: Path = tmp_path / "output.py"
     shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
     return_code: Exit = main([
@@ -68,6 +72,7 @@ def test_main_inheritance_forward_ref(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_inheritance_forward_ref_keep_model_order(tmp_path: Path) -> None:
+    """Test inheritance with forward references keeping model order."""
     output_file: Path = tmp_path / "output.py"
     shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
     return_code: Exit = main([
@@ -84,6 +89,7 @@ def test_main_inheritance_forward_ref_keep_model_order(tmp_path: Path) -> None:
 @pytest.mark.skip(reason="pytest-xdist does not support the test")
 @freeze_time("2019-07-26")
 def test_main_without_arguments() -> None:
+    """Test main function without arguments raises SystemExit."""
     with pytest.raises(SystemExit):
         main()
 
@@ -91,6 +97,7 @@ def test_main_without_arguments() -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_autodetect(tmp_path: Path) -> None:
+    """Test automatic input file type detection."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -106,6 +113,7 @@ def test_main_autodetect(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_autodetect_failed(tmp_path: Path) -> None:
+    """Test autodetect failure with invalid input."""
     input_file: Path = tmp_path / "input.yaml"
     output_file: Path = tmp_path / "output.py"
 
@@ -124,6 +132,7 @@ def test_main_autodetect_failed(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema(tmp_path: Path) -> None:
+    """Test JSON Schema file code generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -140,6 +149,7 @@ def test_main_jsonschema(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_nested_deep(tmp_path: Path) -> None:
+    """Test deeply nested JSON Schema generation."""
     output_init_file: Path = tmp_path / "__init__.py"
     output_nested_file: Path = tmp_path / "nested/deep.py"
     output_empty_parent_nested_file: Path = tmp_path / "empty_parent/nested/deep.py"
@@ -164,6 +174,7 @@ def test_main_jsonschema_nested_deep(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_nested_skip(tmp_path: Path) -> None:
+    """Test nested JSON Schema with skipped items."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "nested_skip.json"),
@@ -180,6 +191,7 @@ def test_main_jsonschema_nested_skip(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_external_files(tmp_path: Path) -> None:
+    """Test JSON Schema with external file references."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -196,6 +208,7 @@ def test_main_jsonschema_external_files(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_collapsed_external_references(tmp_path: Path) -> None:
+    """Test collapsed external references in JSON Schema."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "external_reference"),
@@ -213,6 +226,7 @@ def test_main_jsonschema_collapsed_external_references(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_multiple_files(tmp_path: Path) -> None:
+    """Test JSON Schema generation from multiple files."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "multiple_files"),
@@ -229,6 +243,7 @@ def test_main_jsonschema_multiple_files(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_no_empty_collapsed_external_model(tmp_path: Path) -> None:
+    """Test no empty files with collapsed external models."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "external_collapse"),
@@ -258,6 +273,7 @@ def test_main_jsonschema_no_empty_collapsed_external_model(tmp_path: Path) -> No
 )
 @freeze_time("2019-07-26")
 def test_main_null_and_array(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test handling of null and array types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -275,6 +291,7 @@ def test_main_null_and_array(output_model: str, expected_output: str, tmp_path: 
 
 @freeze_time("2019-07-26")
 def test_use_default_pydantic_v2_with_json_schema_const(tmp_path: Path) -> None:
+    """Test use-default with const in Pydantic v2."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -313,6 +330,7 @@ def test_use_default_pydantic_v2_with_json_schema_const(tmp_path: Path) -> None:
 def test_main_complicated_enum_default_member(
     output_model: str, expected_output: str, option: str | None, tmp_path: Path
 ) -> None:
+    """Test complicated enum with default member."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         a
@@ -334,6 +352,7 @@ def test_main_complicated_enum_default_member(
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_json_reuse_enum_default_member(tmp_path: Path) -> None:
+    """Test enum reuse with default member."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -351,6 +370,7 @@ def test_main_json_reuse_enum_default_member(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_invalid_model_name_failed(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    """Test invalid model name error handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -369,6 +389,7 @@ def test_main_invalid_model_name_failed(capsys: pytest.CaptureFixture, tmp_path:
 
 @freeze_time("2019-07-26")
 def test_main_invalid_model_name_converted(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    """Test invalid model name conversion error."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -385,6 +406,7 @@ def test_main_invalid_model_name_converted(capsys: pytest.CaptureFixture, tmp_pa
 
 @freeze_time("2019-07-26")
 def test_main_invalid_model_name(tmp_path: Path) -> None:
+    """Test invalid model name with custom class name."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -402,6 +424,7 @@ def test_main_invalid_model_name(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_root_id_jsonschema_with_local_file(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test root ID JSON Schema with local file reference."""
     root_id_response = mocker.Mock()
     root_id_response.text = "dummy"
     person_response = mocker.Mock()
@@ -424,6 +447,7 @@ def test_main_root_id_jsonschema_with_local_file(mocker: MockerFixture, tmp_path
 
 @freeze_time("2019-07-26")
 def test_main_root_id_jsonschema_with_remote_file(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test root ID JSON Schema with remote file reference."""
     root_id_response = mocker.Mock()
     root_id_response.text = "dummy"
     person_response = mocker.Mock()
@@ -457,6 +481,7 @@ def test_main_root_id_jsonschema_with_remote_file(mocker: MockerFixture, tmp_pat
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_root_id_jsonschema_self_refs_with_local_file(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test root ID JSON Schema self-references with local file."""
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
@@ -482,6 +507,7 @@ def test_main_root_id_jsonschema_self_refs_with_local_file(mocker: MockerFixture
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_root_id_jsonschema_self_refs_with_remote_file(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test root ID JSON Schema self-references with remote file."""
     person_response = mocker.Mock()
     person_response.text = (JSON_SCHEMA_DATA_PATH / "person.json").read_text()
     httpx_get_mock = mocker.patch("httpx.get", side_effect=[person_response])
@@ -516,6 +542,7 @@ def test_main_root_id_jsonschema_self_refs_with_remote_file(mocker: MockerFixtur
 
 @freeze_time("2019-07-26")
 def test_main_root_id_jsonschema_with_absolute_remote_file(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test root ID JSON Schema with absolute remote file URL."""
     root_id_response = mocker.Mock()
     root_id_response.text = "dummy"
     person_response = mocker.Mock()
@@ -548,6 +575,7 @@ def test_main_root_id_jsonschema_with_absolute_remote_file(mocker: MockerFixture
 
 @freeze_time("2019-07-26")
 def test_main_root_id_jsonschema_with_absolute_local_file(tmp_path: Path) -> None:
+    """Test root ID JSON Schema with absolute local file path."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -564,6 +592,7 @@ def test_main_root_id_jsonschema_with_absolute_local_file(tmp_path: Path) -> Non
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_id(tmp_path: Path) -> None:
+    """Test JSON Schema with ID field."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -579,6 +608,7 @@ def test_main_jsonschema_id(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_id_as_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test JSON Schema ID handling from stdin."""
     output_file: Path = tmp_path / "output.py"
     monkeypatch.setattr("sys.stdin", (JSON_SCHEMA_DATA_PATH / "id.json").open())
     return_code: Exit = main([
@@ -592,6 +622,7 @@ def test_main_jsonschema_id_as_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: 
 
 
 def test_main_jsonschema_ids(tmp_path: Path) -> None:
+    """Test JSON Schema with multiple IDs."""
     input_filename = JSON_SCHEMA_DATA_PATH / "ids" / "Organization.schema.json"
     output_path = tmp_path / "model"
 
@@ -611,6 +642,7 @@ def test_main_jsonschema_ids(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_external_definitions(tmp_path: Path) -> None:
+    """Test external definitions in JSON Schema."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -626,6 +658,7 @@ def test_main_external_definitions(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_external_files_in_directory(tmp_path: Path) -> None:
+    """Test external files in directory structure."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -642,6 +675,7 @@ def test_main_external_files_in_directory(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_nested_directory(tmp_path: Path) -> None:
+    """Test nested directory structure generation."""
     output_path = tmp_path / "model"
     return_code: Exit = main([
         "--input",
@@ -658,6 +692,7 @@ def test_main_nested_directory(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_circular_reference(tmp_path: Path) -> None:
+    """Test circular reference handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -673,6 +708,7 @@ def test_main_circular_reference(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_invalid_enum_name(tmp_path: Path) -> None:
+    """Test invalid enum name handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -688,6 +724,7 @@ def test_main_invalid_enum_name(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_invalid_enum_name_snake_case_field(tmp_path: Path) -> None:
+    """Test invalid enum name with snake case fields."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -704,6 +741,7 @@ def test_main_invalid_enum_name_snake_case_field(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_reuse_enum(tmp_path: Path) -> None:
+    """Test enum reuse in JSON generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -720,6 +758,7 @@ def test_main_json_reuse_enum(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_capitalise_enum_members(tmp_path: Path) -> None:
+    """Test enum member capitalization."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -736,6 +775,7 @@ def test_main_json_capitalise_enum_members(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_capitalise_enum_members_without_enum(tmp_path: Path) -> None:
+    """Test enum member capitalization without enum flag."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -752,6 +792,7 @@ def test_main_json_capitalise_enum_members_without_enum(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_similar_nested_array(tmp_path: Path) -> None:
+    """Test similar nested array structures."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -780,6 +821,7 @@ def test_main_similar_nested_array(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_require_referenced_field(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test required referenced fields."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
@@ -813,6 +855,7 @@ def test_main_require_referenced_field(output_model: str, expected_output: str, 
 )
 @freeze_time("2019-07-26")
 def test_main_require_referenced_field_naive_datetime(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test required referenced field with naive datetime."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
@@ -850,6 +893,7 @@ def test_main_require_referenced_field_naive_datetime(output_model: str, expecte
 )
 @freeze_time("2019-07-26")
 def test_main_require_referenced_field_datetime(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test required referenced field with datetime."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "require_referenced_field/"),
@@ -868,6 +912,7 @@ def test_main_require_referenced_field_datetime(output_model: str, expected_outp
 
 @freeze_time("2019-07-26")
 def test_main_json_pointer(tmp_path: Path) -> None:
+    """Test JSON pointer references."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -883,6 +928,7 @@ def test_main_json_pointer(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_nested_json_pointer(tmp_path: Path) -> None:
+    """Test nested JSON pointer references."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -898,6 +944,7 @@ def test_main_nested_json_pointer(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_multiple_files_json_pointer(tmp_path: Path) -> None:
+    """Test JSON pointer with multiple files."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "multiple_files_json_pointer"),
@@ -913,6 +960,7 @@ def test_main_jsonschema_multiple_files_json_pointer(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_root_model_with_additional_properties(tmp_path: Path) -> None:
+    """Test root model with additional properties."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -928,6 +976,7 @@ def test_main_root_model_with_additional_properties(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_root_model_with_additional_properties_use_generic_container_types(tmp_path: Path) -> None:
+    """Test root model additional properties with generic containers."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -944,6 +993,7 @@ def test_main_root_model_with_additional_properties_use_generic_container_types(
 
 @freeze_time("2019-07-26")
 def test_main_root_model_with_additional_properties_use_standard_collections(tmp_path: Path) -> None:
+    """Test root model additional properties with standard collections."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -960,6 +1010,7 @@ def test_main_root_model_with_additional_properties_use_standard_collections(tmp
 
 @freeze_time("2019-07-26")
 def test_main_root_model_with_additional_properties_literal(min_version: str, tmp_path: Path) -> None:
+    """Test root model additional properties with literal types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -979,6 +1030,7 @@ def test_main_root_model_with_additional_properties_literal(min_version: str, tm
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_multiple_files_ref(tmp_path: Path) -> None:
+    """Test multiple files with references."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref"),
@@ -994,6 +1046,7 @@ def test_main_jsonschema_multiple_files_ref(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_multiple_files_ref_test_json(tmp_path: Path) -> None:
+    """Test main jsonschema multiple files ref json."""
     output_file: Path = tmp_path / "output.py"
     with chdir(JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref"):
         return_code: Exit = main([
@@ -1010,6 +1063,7 @@ def test_main_jsonschema_multiple_files_ref_test_json(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_space_field_enum_snake_case_field(tmp_path: Path) -> None:
+    """Test enum with space in field name using snake case."""
     output_file: Path = tmp_path / "output.py"
     with chdir(JSON_SCHEMA_DATA_PATH / "space_field_enum.json"):
         return_code: Exit = main([
@@ -1030,6 +1084,7 @@ def test_main_space_field_enum_snake_case_field(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_all_of_ref(tmp_path: Path) -> None:
+    """Test allOf with references."""
     output_file: Path = tmp_path / "output.py"
     with chdir(JSON_SCHEMA_DATA_PATH / "all_of_ref"):
         return_code: Exit = main([
@@ -1048,6 +1103,7 @@ def test_main_all_of_ref(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_all_of_with_object(tmp_path: Path) -> None:
+    """Test allOf with object types."""
     output_file: Path = tmp_path / "output.py"
     with chdir(JSON_SCHEMA_DATA_PATH):
         return_code: Exit = main([
@@ -1068,6 +1124,7 @@ def test_main_all_of_with_object(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_combined_array(tmp_path: Path) -> None:
+    """Test combined array types."""
     output_file: Path = tmp_path / "output.py"
     with chdir(JSON_SCHEMA_DATA_PATH):
         return_code: Exit = main([
@@ -1084,6 +1141,7 @@ def test_main_combined_array(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_pattern(tmp_path: Path) -> None:
+    """Test JSON Schema pattern validation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1099,6 +1157,7 @@ def test_main_jsonschema_pattern(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_generate(tmp_path: Path) -> None:
+    """Test code generation function."""
     output_file: Path = tmp_path / "output.py"
     input_ = (JSON_SCHEMA_DATA_PATH / "person.json").relative_to(Path.cwd())
     assert not input_.is_absolute()
@@ -1113,9 +1172,7 @@ def test_main_generate(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_generate_non_pydantic_output(tmp_path: Path) -> None:
-    """
-    See https://github.com/koxudaxi/datamodel-code-generator/issues/1452.
-    """
+    """Test generation with non-Pydantic output models (see issue #1452)."""
     output_file: Path = tmp_path / "output.py"
     input_ = (JSON_SCHEMA_DATA_PATH / "simple_string.json").relative_to(Path.cwd())
     assert not input_.is_absolute()
@@ -1131,6 +1188,7 @@ def test_main_generate_non_pydantic_output(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_generate_from_directory(tmp_path: Path) -> None:
+    """Test generation from directory input."""
     input_ = (JSON_SCHEMA_DATA_PATH / "external_files_in_directory").relative_to(Path.cwd())
     assert not input_.is_absolute()
     assert input_.is_dir()
@@ -1146,6 +1204,8 @@ def test_main_generate_from_directory(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_generate_custom_class_name_generator(tmp_path: Path) -> None:
+    """Test custom class name generator."""
+
     def custom_class_name_generator(title: str) -> str:
         return f"Custom{title}"
 
@@ -1168,6 +1228,7 @@ def test_main_generate_custom_class_name_generator(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_generate_custom_class_name_generator_additional_properties(tmp_path: Path) -> None:
+    """Test custom class name generator with additional properties."""
     output_file = tmp_path / "models.py"
 
     def custom_class_name_generator(name: str) -> str:
@@ -1187,6 +1248,7 @@ def test_main_generate_custom_class_name_generator_additional_properties(tmp_pat
 
 @freeze_time("2019-07-26")
 def test_main_http_jsonschema(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test HTTP JSON Schema fetching."""
     external_directory = JSON_SCHEMA_DATA_PATH / "external_files_in_directory"
 
     def get_mock_response(path: str) -> mocker.Mock:
@@ -1320,6 +1382,7 @@ def test_main_http_jsonschema_with_http_headers_and_http_query_parameters_and_ig
     http_ignore_tls: bool,
     tmp_path: Path,
 ) -> None:
+    """Test HTTP JSON Schema with headers, query params, and TLS ignore."""
     external_directory = JSON_SCHEMA_DATA_PATH / "external_files_in_directory"
 
     def get_mock_response(path: str) -> mocker.Mock:
@@ -1428,6 +1491,7 @@ def test_main_http_jsonschema_with_http_headers_and_http_query_parameters_and_ig
 
 @freeze_time("2019-07-26")
 def test_main_self_reference(tmp_path: Path) -> None:
+    """Test self-referencing schemas."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1444,6 +1508,7 @@ def test_main_self_reference(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_strict_types(tmp_path: Path) -> None:
+    """Test strict type generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1463,6 +1528,7 @@ def test_main_strict_types(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_strict_types_all(tmp_path: Path) -> None:
+    """Test strict types for all fields."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1485,6 +1551,7 @@ def test_main_strict_types_all(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_strict_types_all_with_field_constraints(tmp_path: Path) -> None:
+    """Test strict types with field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1508,6 +1575,7 @@ def test_main_strict_types_all_with_field_constraints(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_special_enum(tmp_path: Path) -> None:
+    """Test special enum handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1523,6 +1591,7 @@ def test_main_jsonschema_special_enum(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_special_enum_special_field_name_prefix(tmp_path: Path) -> None:
+    """Test special enum with field name prefix."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1540,6 +1609,7 @@ def test_main_jsonschema_special_enum_special_field_name_prefix(tmp_path: Path) 
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_special_enum_special_field_name_prefix_keep_private(tmp_path: Path) -> None:
+    """Test special enum with prefix keeping private fields."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1557,6 +1627,7 @@ def test_main_jsonschema_special_enum_special_field_name_prefix_keep_private(tmp
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_special_model_remove_special_field_name_prefix(tmp_path: Path) -> None:
+    """Test removing special field name prefix from models."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1573,6 +1644,7 @@ def test_main_jsonschema_special_model_remove_special_field_name_prefix(tmp_path
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_subclass_enum(tmp_path: Path) -> None:
+    """Test enum subclassing."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1593,6 +1665,7 @@ def test_main_jsonschema_subclass_enum(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_jsonschema_specialized_enums(tmp_path: Path) -> None:
+    """Test specialized enum generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1614,6 +1687,7 @@ def test_main_jsonschema_specialized_enums(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_jsonschema_specialized_enums_disabled(tmp_path: Path) -> None:
+    """Test with specialized enums disabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1632,6 +1706,7 @@ def test_main_jsonschema_specialized_enums_disabled(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_special_enum_empty_enum_field_name(tmp_path: Path) -> None:
+    """Test special enum with empty field name."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1650,6 +1725,7 @@ def test_main_jsonschema_special_enum_empty_enum_field_name(tmp_path: Path) -> N
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_special_field_name(tmp_path: Path) -> None:
+    """Test special field name handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1665,6 +1741,7 @@ def test_main_jsonschema_special_field_name(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_complex_one_of(tmp_path: Path) -> None:
+    """Test complex oneOf schemas."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1681,6 +1758,7 @@ def test_main_jsonschema_complex_one_of(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_complex_any_of(tmp_path: Path) -> None:
+    """Test complex anyOf schemas."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1696,6 +1774,7 @@ def test_main_jsonschema_complex_any_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_combine_one_of_object(tmp_path: Path) -> None:
+    """Test combining oneOf with objects."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1729,6 +1808,7 @@ def test_main_jsonschema_combine_one_of_object(tmp_path: Path) -> None:
 def test_main_jsonschema_combine_any_of_object(
     union_mode: str | None, output_model: str, expected_output: str, tmp_path: Path
 ) -> None:
+    """Test combining anyOf with objects."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main(
         [
@@ -1750,6 +1830,7 @@ def test_main_jsonschema_combine_any_of_object(
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_field_include_all_keys(tmp_path: Path) -> None:
+    """Test field generation including all keys."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1781,6 +1862,7 @@ def test_main_jsonschema_field_include_all_keys(tmp_path: Path) -> None:
 def test_main_jsonschema_field_extras_field_include_all_keys(
     output_model: str, expected_output: str, tmp_path: Path
 ) -> None:
+    """Test field extras including all keys."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1814,6 +1896,7 @@ def test_main_jsonschema_field_extras_field_include_all_keys(
     ],
 )
 def test_main_jsonschema_field_extras_field_extra_keys(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test field extras with extra keys."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1849,6 +1932,7 @@ def test_main_jsonschema_field_extras_field_extra_keys(output_model: str, expect
     ],
 )
 def test_main_jsonschema_field_extras(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test field extras generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1883,6 +1967,7 @@ def test_main_jsonschema_field_extras(output_model: str, expected_output: str, t
 )
 @freeze_time("2019-07-26")
 def test_main_jsonschema_custom_type_path(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test custom type path handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1900,6 +1985,7 @@ def test_main_jsonschema_custom_type_path(output_model: str, expected_output: st
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_custom_base_path(tmp_path: Path) -> None:
+    """Test custom base path configuration."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1915,6 +2001,7 @@ def test_main_jsonschema_custom_base_path(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_long_description(tmp_path: Path) -> None:
+    """Test long description handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1934,6 +2021,7 @@ def test_long_description(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_long_description_wrap_string_literal(tmp_path: Path) -> None:
+    """Test long description with string literal wrapping."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1949,6 +2037,7 @@ def test_long_description_wrap_string_literal(tmp_path: Path) -> None:
 
 
 def test_version(capsys: pytest.CaptureFixture) -> None:
+    """Test version output."""
     with pytest.raises(SystemExit) as e:
         main(["--version"])
     assert e.value.code == Exit.OK
@@ -1959,6 +2048,7 @@ def test_version(capsys: pytest.CaptureFixture) -> None:
 
 @freeze_time("2019-07-26")
 def test_jsonschema_pattern_properties(tmp_path: Path) -> None:
+    """Test JSON Schema pattern properties."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1974,6 +2064,7 @@ def test_jsonschema_pattern_properties(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_jsonschema_pattern_properties_field_constraints(tmp_path: Path) -> None:
+    """Test pattern properties with field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1990,6 +2081,7 @@ def test_jsonschema_pattern_properties_field_constraints(tmp_path: Path) -> None
 
 @freeze_time("2019-07-26")
 def test_jsonschema_titles(tmp_path: Path) -> None:
+    """Test JSON Schema title handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2005,6 +2097,7 @@ def test_jsonschema_titles(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_jsonschema_titles_use_title_as_name(tmp_path: Path) -> None:
+    """Test using title as model name."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2021,6 +2114,7 @@ def test_jsonschema_titles_use_title_as_name(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_jsonschema_without_titles_use_title_as_name(tmp_path: Path) -> None:
+    """Test title as name without titles present."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2037,6 +2131,7 @@ def test_jsonschema_without_titles_use_title_as_name(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_has_default_value(tmp_path: Path) -> None:
+    """Test default value handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2052,6 +2147,7 @@ def test_main_jsonschema_has_default_value(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_boolean_property(tmp_path: Path) -> None:
+    """Test boolean property generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2069,6 +2165,7 @@ def test_main_jsonschema_boolean_property(tmp_path: Path) -> None:
 def test_main_jsonschema_modular_default_enum_member(
     tmp_path: Path,
 ) -> None:
+    """Test modular enum with default member."""
     input_filename = JSON_SCHEMA_DATA_PATH / "modular_default_enum_member"
     output_path = tmp_path / "model"
 
@@ -2090,6 +2187,7 @@ def test_main_jsonschema_modular_default_enum_member(
 )
 @freeze_time("2019-07-26")
 def test_main_use_union_operator(tmp_path: Path) -> None:
+    """Test union operator usage."""
     output_path = tmp_path / "model"
     return_code: Exit = main([
         "--input",
@@ -2108,6 +2206,7 @@ def test_main_use_union_operator(tmp_path: Path) -> None:
 @freeze_time("2019-07-26")
 @pytest.mark.parametrize("as_module", [True, False])
 def test_treat_dot_as_module(as_module: bool, tmp_path: Path) -> None:
+    """Test dot notation as module separator."""
     if as_module:
         return_code: Exit = main([
             "--input",
@@ -2131,6 +2230,7 @@ def test_treat_dot_as_module(as_module: bool, tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_duplicate_name(tmp_path: Path) -> None:
+    """Test duplicate name handling."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "duplicate_name"),
@@ -2146,6 +2246,7 @@ def test_main_jsonschema_duplicate_name(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_items_boolean(tmp_path: Path) -> None:
+    """Test items with boolean values."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2161,6 +2262,7 @@ def test_main_jsonschema_items_boolean(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_array_in_additional_properites(tmp_path: Path) -> None:
+    """Test array in additional properties."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2176,6 +2278,7 @@ def test_main_jsonschema_array_in_additional_properites(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_object_with_only_additional_properties(tmp_path: Path) -> None:
+    """Test object with only additional properties."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2191,6 +2294,7 @@ def test_main_jsonschema_object_with_only_additional_properties(tmp_path: Path) 
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_nullable_object(tmp_path: Path) -> None:
+    """Test nullable object handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2206,6 +2310,7 @@ def test_main_jsonschema_nullable_object(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_object_has_one_of(tmp_path: Path) -> None:
+    """Test object with oneOf constraint."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2221,6 +2326,7 @@ def test_main_jsonschema_object_has_one_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_json_pointer_array(tmp_path: Path) -> None:
+    """Test JSON pointer with arrays."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2236,6 +2342,7 @@ def test_main_jsonschema_json_pointer_array(tmp_path: Path) -> None:
 
 @pytest.mark.filterwarnings("error")
 def test_main_disable_warnings_config(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    """Test disable warnings configuration."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2256,6 +2363,7 @@ def test_main_disable_warnings_config(capsys: pytest.CaptureFixture, tmp_path: P
 
 @pytest.mark.filterwarnings("error")
 def test_main_disable_warnings(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    """Test disable warnings flag."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2273,6 +2381,7 @@ def test_main_disable_warnings(capsys: pytest.CaptureFixture, tmp_path: Path) ->
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_pattern_properties_by_reference(tmp_path: Path) -> None:
+    """Test pattern properties by reference."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2288,6 +2397,7 @@ def test_main_jsonschema_pattern_properties_by_reference(tmp_path: Path) -> None
 
 @freeze_time("2019-07-26")
 def test_main_dataclass_field(tmp_path: Path) -> None:
+    """Test dataclass field generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2307,6 +2417,7 @@ def test_main_dataclass_field(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_jsonschema_enum_root_literal(tmp_path: Path) -> None:
+    """Test enum root with literal type."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2334,6 +2445,7 @@ def test_main_jsonschema_enum_root_literal(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_nullable_any_of(tmp_path: Path) -> None:
+    """Test nullable anyOf schemas."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2348,6 +2460,7 @@ def test_main_nullable_any_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_nullable_any_of_use_union_operator(tmp_path: Path) -> None:
+    """Test nullable anyOf with union operator."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2363,6 +2476,7 @@ def test_main_nullable_any_of_use_union_operator(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_nested_all_of(tmp_path: Path) -> None:
+    """Test nested allOf schemas."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2376,6 +2490,7 @@ def test_main_nested_all_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_all_of_any_of(tmp_path: Path) -> None:
+    """Test combination of allOf and anyOf."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "all_of_any_of"),
@@ -2391,6 +2506,7 @@ def test_main_all_of_any_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_all_of_one_of(tmp_path: Path) -> None:
+    """Test combination of allOf and oneOf."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "all_of_one_of"),
@@ -2406,6 +2522,7 @@ def test_main_all_of_one_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_null(tmp_path: Path) -> None:
+    """Test null type handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2425,6 +2542,7 @@ def test_main_null(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_typed_dict_special_field_name_with_inheritance_model(tmp_path: Path) -> None:
+    """Test TypedDict special field names with inheritance."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2541,6 +2659,7 @@ def test_main_dataclass_const(tmp_path: Path) -> None:
 def test_main_jsonschema_discriminator_literals(
     output_model: str, expected_output: str, min_version: str, tmp_path: Path
 ) -> None:
+    """Test discriminator with literal types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2562,6 +2681,7 @@ def test_main_jsonschema_discriminator_literals(
     reason="Installed black doesn't support the new style",
 )
 def test_main_jsonschema_discriminator_literals_with_no_mapping(min_version: str, tmp_path: Path) -> None:
+    """Test discriminator literals without mapping."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2594,6 +2714,7 @@ def test_main_jsonschema_discriminator_literals_with_no_mapping(min_version: str
 def test_main_jsonschema_external_discriminator(
     output_model: str, expected_output: str, min_version: str, tmp_path: Path
 ) -> None:
+    """Test external discriminator references."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2626,6 +2747,7 @@ def test_main_jsonschema_external_discriminator(
 def test_main_jsonschema_external_discriminator_folder(
     output_model: str, expected_output: str, min_version: str, tmp_path: Path
 ) -> None:
+    """Test external discriminator in folder structure."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "discriminator_with_external_reference"),
@@ -2643,6 +2765,7 @@ def test_main_jsonschema_external_discriminator_folder(
 
 @freeze_time("2019-07-26")
 def test_main_duplicate_field_constraints(tmp_path: Path) -> None:
+    """Test duplicate field constraint handling."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "duplicate_field_constraints"),
@@ -2665,6 +2788,7 @@ def test_main_duplicate_field_constraints(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_duplicate_field_constraints_msgspec(min_version: str, tmp_path: Path) -> None:
+    """Test duplicate field constraints with msgspec."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "duplicate_field_constraints"),
@@ -2684,6 +2808,7 @@ def test_main_duplicate_field_constraints_msgspec(min_version: str, tmp_path: Pa
 
 @freeze_time("2019-07-26")
 def test_main_dataclass_field_defs(tmp_path: Path) -> None:
+    """Test dataclass field definitions."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2703,6 +2828,7 @@ def test_main_dataclass_field_defs(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_dataclass_default(tmp_path: Path) -> None:
+    """Test dataclass default values."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2718,6 +2844,7 @@ def test_main_dataclass_default(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_all_of_ref_self(tmp_path: Path) -> None:
+    """Test allOf with self-reference."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2737,6 +2864,7 @@ def test_main_all_of_ref_self(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_array_field_constraints(tmp_path: Path) -> None:
+    """Test array field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2756,6 +2884,7 @@ def test_main_array_field_constraints(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_all_of_use_default(tmp_path: Path) -> None:
+    """Test allOf with use-default option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2770,6 +2899,7 @@ def test_all_of_use_default(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_root_one_of(tmp_path: Path) -> None:
+    """Test root-level oneOf schemas."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "root_one_of"),
@@ -2785,6 +2915,7 @@ def test_main_root_one_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_one_of_with_sub_schema_array_item(tmp_path: Path) -> None:
+    """Test oneOf with sub-schema array items."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2802,6 +2933,7 @@ def test_one_of_with_sub_schema_array_item(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_with_custom_formatters(tmp_path: Path) -> None:
+    """Test custom formatter integration."""
     output_file: Path = tmp_path / "output.py"
     formatter_config = {
         "license_file": str(Path(__file__).parent.parent.parent / "data/python/custom_formatters/license_example.txt")
@@ -2826,6 +2958,7 @@ def test_main_jsonschema_with_custom_formatters(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_imports_correct(tmp_path: Path) -> None:
+    """Test correct import generation."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "imports_correct"),
@@ -2854,6 +2987,7 @@ def test_main_imports_correct(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_jsonschema_duration(output_model: str, expected_output: str, min_version: str, tmp_path: Path) -> None:
+    """Test duration type handling."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2875,6 +3009,7 @@ def test_main_jsonschema_duration(output_model: str, expected_output: str, min_v
     reason="Installed black doesn't support the new style",
 )
 def test_main_jsonschema_keyword_only_msgspec(min_version: str, tmp_path: Path) -> None:
+    """Test msgspec keyword-only arguments."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2899,6 +3034,7 @@ def test_main_jsonschema_keyword_only_msgspec(min_version: str, tmp_path: Path) 
     reason="Installed black doesn't support the new style",
 )
 def test_main_jsonschema_keyword_only_msgspec_with_extra_data(min_version: str, tmp_path: Path) -> None:
+    """Test msgspec keyword-only with extra data."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2925,6 +3061,7 @@ def test_main_jsonschema_keyword_only_msgspec_with_extra_data(min_version: str, 
     reason="Installed black doesn't support the new style",
 )
 def test_main_jsonschema_openapi_keyword_only_msgspec_with_extra_data(tmp_path: Path) -> None:
+    """Test OpenAPI msgspec keyword-only with extra data."""
     extra_data = json.loads((JSON_SCHEMA_DATA_PATH / "extra_data_msgspec.json").read_text())
     output_file: Path = tmp_path / "output.py"
     generate(
@@ -2944,6 +3081,7 @@ def test_main_jsonschema_openapi_keyword_only_msgspec_with_extra_data(tmp_path: 
 
 @freeze_time("2019-07-26")
 def test_main_invalid_import_name(tmp_path: Path) -> None:
+    """Test invalid import name handling."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "invalid_import_name"),
@@ -2972,6 +3110,7 @@ def test_main_invalid_import_name(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_jsonschema_field_has_same_name(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test field with same name as parent."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2990,6 +3129,7 @@ def test_main_jsonschema_field_has_same_name(output_model: str, expected_output:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_jsonschema_required_and_any_of_required(tmp_path: Path) -> None:
+    """Test required field with anyOf required."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -3005,6 +3145,7 @@ def test_main_jsonschema_required_and_any_of_required(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_pointer_escaped_segments(tmp_path: Path) -> None:
+    """Test JSON pointer with escaped segments."""
     schema = {
         "definitions": {
             "foo/bar": {"type": "object", "properties": {"value": {"type": "string"}}},
@@ -3049,6 +3190,7 @@ def test_main_json_pointer_escaped_segments(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_pointer_percent_encoded_segments(tmp_path: Path) -> None:
+    """Test JSON pointer with percent-encoded segments."""
     schema = {
         "definitions": {
             "foo/bar": {"type": "object", "properties": {"value": {"type": "string"}}},
@@ -3134,6 +3276,7 @@ def test_main_json_pointer_percent_encoded_segments(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_extra_fields(extra_fields: str, output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test extra fields configuration."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -3153,9 +3296,7 @@ def test_main_extra_fields(extra_fields: str, output_model: str, expected_output
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_same_name_objects(tmp_path: Path) -> None:
-    """
-    See: https://github.com/koxudaxi/datamodel-code-generator/issues/2460
-    """
+    """Test objects with same name (see issue #2460)."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -3171,9 +3312,7 @@ def test_main_jsonschema_same_name_objects(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_jsonschema_forwarding_reference_collapse_root(tmp_path: Path) -> None:
-    """
-    See: https://github.com/koxudaxi/datamodel-code-generator/issues/1466
-    """
+    """Test forwarding reference with collapsed root (see issue #1466)."""
     return_code: Exit = main([
         "--input",
         str(JSON_SCHEMA_DATA_PATH / "forwarding_reference"),

--- a/tests/main/openapi/__init__.py
+++ b/tests/main/openapi/__init__.py
@@ -1,0 +1,1 @@
+"""OpenAPI integration tests package."""

--- a/tests/main/openapi/test_main_openapi.py
+++ b/tests/main/openapi/test_main_openapi.py
@@ -1,3 +1,5 @@
+"""Tests for OpenAPI/Swagger input file code generation."""
+
 from __future__ import annotations
 
 import contextlib
@@ -47,6 +49,7 @@ assert_file_content = create_assert_file_content(EXPECTED_OPENAPI_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -55,6 +58,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main(tmp_path: Path) -> None:
+    """Test OpenAPI file code generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -72,6 +76,7 @@ def test_main(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_discriminator_enum(tmp_path: Path) -> None:
+    """Test OpenAPI generation with discriminator enum."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -95,6 +100,7 @@ def test_main_openapi_discriminator_enum(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_discriminator_enum_duplicate(tmp_path: Path) -> None:
+    """Test OpenAPI generation with duplicate discriminator enum."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -114,6 +120,7 @@ def test_main_openapi_discriminator_enum_duplicate(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_discriminator_with_properties(tmp_path: Path) -> None:
+    """Test OpenAPI generation with discriminator properties."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -130,6 +137,7 @@ def test_main_openapi_discriminator_with_properties(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_pydantic_basemodel(tmp_path: Path) -> None:
+    """Test OpenAPI generation with Pydantic BaseModel output."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -145,6 +153,7 @@ def test_main_pydantic_basemodel(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_base_class(tmp_path: Path) -> None:
+    """Test OpenAPI generation with custom base class."""
     output_file: Path = tmp_path / "output.py"
     shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
     return_code: Exit = main([
@@ -161,6 +170,7 @@ def test_main_base_class(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_target_python_version(tmp_path: Path) -> None:
+    """Test OpenAPI generation with target Python version."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -205,7 +215,6 @@ def test_main_modular_reuse_model(tmp_path: Path) -> None:
 
 def test_main_modular_no_file() -> None:
     """Test main function on modular file with no output name."""
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
 
     assert main(["--input", str(input_filename)]) == Exit.ERROR
@@ -257,7 +266,6 @@ def test_main_openapi_extra_template_data_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test main function with custom config data in extra template."""
-
     monkeypatch.chdir(tmp_path)
     input_filename = OPEN_API_DATA_PATH / "api.yaml"
     extra_template_data = OPEN_API_DATA_PATH / "extra_data.json"
@@ -281,7 +289,6 @@ def test_main_custom_template_dir_old_style(
     capsys: pytest.CaptureFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test main function with custom template directory."""
-
     monkeypatch.chdir(tmp_path)
     input_filename = OPEN_API_DATA_PATH / "api.yaml"
     custom_template_dir = DATA_PATH / "templates_old_style"
@@ -305,8 +312,8 @@ def test_main_custom_template_dir_old_style(
 def test_main_openapi_custom_template_dir(
     capsys: pytest.CaptureFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.chdir(tmp_path)
     """Test main function with custom template directory."""
+    monkeypatch.chdir(tmp_path)
 
     input_filename = OPEN_API_DATA_PATH / "api.yaml"
     custom_template_dir = DATA_PATH / "templates"
@@ -333,6 +340,7 @@ def test_main_openapi_custom_template_dir(
 )
 @freeze_time("2019-07-26")
 def test_pyproject(tmp_path: Path) -> None:
+    """Test code generation using pyproject.toml configuration."""
     if platform.system() == "Windows":
 
         def get_path(path: str) -> str:
@@ -366,6 +374,7 @@ def test_pyproject(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_pyproject_not_found(tmp_path: Path) -> None:
+    """Test code generation when pyproject.toml is not found."""
     with chdir(tmp_path):
         output_file: Path = tmp_path / "output.py"
         return_code: Exit = main([
@@ -380,6 +389,7 @@ def test_pyproject_not_found(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test OpenAPI code generation from stdin input."""
     output_file: Path = tmp_path / "output.py"
     monkeypatch.setattr("sys.stdin", (OPEN_API_DATA_PATH / "api.yaml").open())
     return_code: Exit = main([
@@ -392,6 +402,7 @@ def test_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_validation(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test OpenAPI code generation with validation enabled."""
     mock_prance = mocker.patch("prance.BaseParser")
 
     output_file: Path = tmp_path / "output.py"
@@ -409,6 +420,7 @@ def test_validation(mocker: MockerFixture, tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_validation_failed(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test OpenAPI code generation with validation failure."""
     mock_prance = mocker.patch("prance.BaseParser", side_effect=Exception("error"))
     output_file: Path = tmp_path / "output.py"
     assert (
@@ -462,6 +474,7 @@ def test_validation_failed(mocker: MockerFixture, tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_with_field_constraints(output_model: str, expected_output: str, args: list[str], tmp_path: Path) -> None:
+    """Test OpenAPI generation with field constraints enabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -492,6 +505,7 @@ def test_main_with_field_constraints(output_model: str, expected_output: str, ar
 )
 @freeze_time("2019-07-26")
 def test_main_without_field_constraints(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation without field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -524,6 +538,7 @@ def test_main_without_field_constraints(output_model: str, expected_output: str,
     reason="Installed black doesn't support the old style",
 )
 def test_main_with_aliases(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with type aliases."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -542,6 +557,7 @@ def test_main_with_aliases(output_model: str, expected_output: str, tmp_path: Pa
 
 
 def test_main_with_bad_aliases(tmp_path: Path) -> None:
+    """Test OpenAPI generation with invalid aliases file."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -555,6 +571,7 @@ def test_main_with_bad_aliases(tmp_path: Path) -> None:
 
 
 def test_main_with_more_bad_aliases(tmp_path: Path) -> None:
+    """Test OpenAPI generation with malformed aliases file."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -568,6 +585,7 @@ def test_main_with_more_bad_aliases(tmp_path: Path) -> None:
 
 
 def test_main_with_bad_extra_data(tmp_path: Path) -> None:
+    """Test OpenAPI generation with invalid extra template data file."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -583,6 +601,7 @@ def test_main_with_bad_extra_data(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_with_snake_case_field(tmp_path: Path) -> None:
+    """Test OpenAPI generation with snake case field naming."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -598,6 +617,7 @@ def test_main_with_snake_case_field(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_with_strip_default_none(tmp_path: Path) -> None:
+    """Test OpenAPI generation with strip default none option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -611,6 +631,7 @@ def test_main_with_strip_default_none(tmp_path: Path) -> None:
 
 
 def test_disable_timestamp(tmp_path: Path) -> None:
+    """Test OpenAPI generation with timestamp disabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -625,6 +646,7 @@ def test_disable_timestamp(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_enable_version_header(tmp_path: Path) -> None:
+    """Test OpenAPI generation with version header enabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -660,6 +682,7 @@ def test_enable_version_header(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_allow_population_by_field_name(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with allow population by field name."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -693,6 +716,7 @@ def test_allow_population_by_field_name(output_model: str, expected_output: str,
     reason="Installed black doesn't support the old style",
 )
 def test_allow_extra_fields(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with allow extra fields option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -726,6 +750,7 @@ def test_allow_extra_fields(output_model: str, expected_output: str, tmp_path: P
     reason="Installed black doesn't support the old style",
 )
 def test_enable_faux_immutability(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with faux immutability enabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -743,6 +768,7 @@ def test_enable_faux_immutability(output_model: str, expected_output: str, tmp_p
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_use_default(tmp_path: Path) -> None:
+    """Test OpenAPI generation with use default option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -758,6 +784,7 @@ def test_use_default(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_force_optional(tmp_path: Path) -> None:
+    """Test OpenAPI generation with force optional enabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -772,6 +799,7 @@ def test_force_optional(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_with_exclusive(tmp_path: Path) -> None:
+    """Test OpenAPI generation with exclusive keywords."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -785,6 +813,7 @@ def test_main_with_exclusive(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_subclass_enum(tmp_path: Path) -> None:
+    """Test OpenAPI generation with subclass enum."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -802,6 +831,7 @@ def test_main_subclass_enum(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_specialized_enum(tmp_path: Path) -> None:
+    """Test OpenAPI generation with specialized enum."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -821,6 +851,7 @@ def test_main_specialized_enum(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_specialized_enums_disabled(tmp_path: Path) -> None:
+    """Test OpenAPI generation with specialized enums disabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -836,6 +867,7 @@ def test_main_specialized_enums_disabled(tmp_path: Path) -> None:
 
 
 def test_main_use_standard_collections(tmp_path: Path) -> None:
+    """Test OpenAPI generation with standard collections."""
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = tmp_path / "model"
 
@@ -856,6 +888,7 @@ def test_main_use_standard_collections(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_use_generic_container_types(tmp_path: Path) -> None:
+    """Test OpenAPI generation with generic container types."""
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = tmp_path / "model"
 
@@ -879,6 +912,7 @@ def test_main_use_generic_container_types(tmp_path: Path) -> None:
 def test_main_use_generic_container_types_standard_collections(
     tmp_path: Path,
 ) -> None:
+    """Test OpenAPI generation with generic container types and standard collections."""
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = tmp_path / "model"
 
@@ -898,6 +932,7 @@ def test_main_use_generic_container_types_standard_collections(
 
 
 def test_main_original_field_name_delimiter_without_snake_case_field(capsys: pytest.CaptureFixture) -> None:
+    """Test OpenAPI generation with original field name delimiter error."""
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
 
     return_code: Exit = main([
@@ -923,6 +958,7 @@ def test_main_original_field_name_delimiter_without_snake_case_field(capsys: pyt
     ],
 )
 def test_main_openapi_aware_datetime(output_model: str, expected_output: str, date_type: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with aware datetime types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -955,6 +991,7 @@ def test_main_openapi_aware_datetime(output_model: str, expected_output: str, da
     ],
 )
 def test_main_openapi_datetime(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with datetime types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -972,6 +1009,7 @@ def test_main_openapi_datetime(output_model: str, expected_output: str, tmp_path
 
 @freeze_time("2019-07-26")
 def test_main_models_not_found(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    """Test OpenAPI generation with models not found error."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -992,6 +1030,7 @@ def test_main_models_not_found(capsys: pytest.CaptureFixture, tmp_path: Path) ->
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_enum_models_as_literal_one(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with one enum model as literal."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1015,6 +1054,7 @@ def test_main_openapi_enum_models_as_literal_one(min_version: str, tmp_path: Pat
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_use_one_literal_as_default(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with one literal as default."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1043,6 +1083,7 @@ def test_main_openapi_use_one_literal_as_default(min_version: str, tmp_path: Pat
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_enum_models_as_literal_all(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with all enum models as literal."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1070,6 +1111,7 @@ def test_main_openapi_enum_models_as_literal_all(min_version: str, tmp_path: Pat
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_enum_models_as_literal(tmp_path: Path) -> None:
+    """Test OpenAPI generation with enum models as literal."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1091,6 +1133,7 @@ def test_main_openapi_enum_models_as_literal(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_openapi_all_of_required(tmp_path: Path) -> None:
+    """Test OpenAPI generation with allOf required fields."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1107,6 +1150,7 @@ def test_main_openapi_all_of_required(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_openapi_nullable(tmp_path: Path) -> None:
+    """Test OpenAPI generation with nullable types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1122,6 +1166,7 @@ def test_main_openapi_nullable(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_nullable_strict_nullable(tmp_path: Path) -> None:
+    """Test OpenAPI generation with strict nullable types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1159,6 +1204,7 @@ def test_main_openapi_nullable_strict_nullable(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_pattern(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with pattern validation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1198,6 +1244,7 @@ def test_main_openapi_pattern(output_model: str, expected_output: str, tmp_path:
 def test_main_openapi_pattern_with_lookaround_pydantic_v2(
     expected_output: str, args: list[str], tmp_path: Path
 ) -> None:
+    """Test OpenAPI generation with pattern lookaround for Pydantic v2."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1220,6 +1267,7 @@ def test_main_openapi_pattern_with_lookaround_pydantic_v2(
 def test_main_generate_custom_class_name_generator_modular(
     tmp_path: Path,
 ) -> None:
+    """Test OpenAPI generation with custom class name generator in modular mode."""
     output_path = tmp_path / "model"
     main_modular_custom_class_name_dir = EXPECTED_OPENAPI_PATH / "modular_custom_class_name"
 
@@ -1241,6 +1289,8 @@ def test_main_generate_custom_class_name_generator_modular(
 
 @freeze_time("2019-07-26")
 def test_main_http_openapi(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test OpenAPI code generation from HTTP URL."""
+
     def get_mock_response(path: str) -> Mock:
         mock = mocker.Mock()
         mock.text = (OPEN_API_DATA_PATH / path).read_text()
@@ -1285,6 +1335,7 @@ def test_main_http_openapi(mocker: MockerFixture, tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_disable_appending_item_suffix(tmp_path: Path) -> None:
+    """Test OpenAPI generation with item suffix disabled."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1300,6 +1351,7 @@ def test_main_disable_appending_item_suffix(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_body_and_parameters(tmp_path: Path) -> None:
+    """Test OpenAPI generation with body and parameters."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1318,6 +1370,7 @@ def test_main_openapi_body_and_parameters(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_body_and_parameters_remote_ref(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test OpenAPI generation with body and parameters remote reference."""
     input_path = OPEN_API_DATA_PATH / "body_and_parameters_remote_ref.yaml"
     person_response = mocker.Mock()
     person_response.text = input_path.read_text()
@@ -1350,6 +1403,7 @@ def test_main_openapi_body_and_parameters_remote_ref(mocker: MockerFixture, tmp_
 
 @freeze_time("2019-07-26")
 def test_main_openapi_body_and_parameters_only_paths(tmp_path: Path) -> None:
+    """Test OpenAPI generation with only paths scope."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1367,6 +1421,7 @@ def test_main_openapi_body_and_parameters_only_paths(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_body_and_parameters_only_schemas(tmp_path: Path) -> None:
+    """Test OpenAPI generation with only schemas scope."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1384,6 +1439,7 @@ def test_main_openapi_body_and_parameters_only_schemas(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_content_in_parameters(tmp_path: Path) -> None:
+    """Test OpenAPI generation with content in parameters."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1399,6 +1455,7 @@ def test_main_openapi_content_in_parameters(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_oas_response_reference(tmp_path: Path) -> None:
+    """Test OpenAPI generation with OAS response reference."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1417,6 +1474,7 @@ def test_main_openapi_oas_response_reference(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_json_pointer(tmp_path: Path) -> None:
+    """Test OpenAPI generation with JSON pointer references."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1448,6 +1506,7 @@ def test_main_openapi_json_pointer(tmp_path: Path) -> None:
 def test_main_use_annotated_with_field_constraints(
     output_model: str, expected_output: str, min_version: str, tmp_path: Path
 ) -> None:
+    """Test OpenAPI generation with Annotated and field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1467,6 +1526,7 @@ def test_main_use_annotated_with_field_constraints(
 
 @freeze_time("2019-07-26")
 def test_main_nested_enum(tmp_path: Path) -> None:
+    """Test OpenAPI generation with nested enum."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1482,6 +1542,7 @@ def test_main_nested_enum(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_openapi_special_yaml_keywords(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test OpenAPI generation with special YAML keywords."""
     mock_prance = mocker.patch("prance.BaseParser")
 
     output_file: Path = tmp_path / "output.py"
@@ -1503,6 +1564,7 @@ def test_openapi_special_yaml_keywords(mocker: MockerFixture, tmp_path: Path) ->
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_nullable_use_union_operator(tmp_path: Path) -> None:
+    """Test OpenAPI generation with nullable using union operator."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1520,6 +1582,7 @@ def test_main_openapi_nullable_use_union_operator(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_external_relative_ref(tmp_path: Path) -> None:
+    """Test OpenAPI generation with external relative references."""
     return_code: Exit = main([
         "--input",
         str(OPEN_API_DATA_PATH / "external_relative_ref" / "model_b"),
@@ -1534,6 +1597,7 @@ def test_external_relative_ref(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_collapse_root_models(tmp_path: Path) -> None:
+    """Test OpenAPI generation with collapsed root models."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1548,6 +1612,7 @@ def test_main_collapse_root_models(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_collapse_root_models_field_constraints(tmp_path: Path) -> None:
+    """Test OpenAPI generation with collapsed root models and field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1563,6 +1628,7 @@ def test_main_collapse_root_models_field_constraints(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_collapse_root_models_with_references_to_flat_types(tmp_path: Path) -> None:
+    """Test OpenAPI generation with collapsed root models referencing flat types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1578,6 +1644,7 @@ def test_main_collapse_root_models_with_references_to_flat_types(tmp_path: Path)
 
 @freeze_time("2019-07-26")
 def test_main_openapi_max_items_enum(tmp_path: Path) -> None:
+    """Test OpenAPI generation with max items enum."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1606,6 +1673,7 @@ def test_main_openapi_max_items_enum(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_const(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with const values."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1648,6 +1716,7 @@ def test_main_openapi_const(output_model: str, expected_output: str, tmp_path: P
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_const_field(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with const field."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1666,6 +1735,7 @@ def test_main_openapi_const_field(output_model: str, expected_output: str, tmp_p
 
 @freeze_time("2019-07-26")
 def test_main_openapi_complex_reference(tmp_path: Path) -> None:
+    """Test OpenAPI generation with complex references."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1681,6 +1751,7 @@ def test_main_openapi_complex_reference(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_reference_to_object_properties(tmp_path: Path) -> None:
+    """Test OpenAPI generation with reference to object properties."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1696,6 +1767,7 @@ def test_main_openapi_reference_to_object_properties(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_reference_to_object_properties_collapse_root_models(tmp_path: Path) -> None:
+    """Test OpenAPI generation with reference to object properties and collapsed root models."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1712,6 +1784,7 @@ def test_main_openapi_reference_to_object_properties_collapse_root_models(tmp_pa
 
 @freeze_time("2019-07-26")
 def test_main_openapi_override_required_all_of_field(tmp_path: Path) -> None:
+    """Test OpenAPI generation with override required allOf field."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1728,6 +1801,7 @@ def test_main_openapi_override_required_all_of_field(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_use_default_kwarg(tmp_path: Path) -> None:
+    """Test OpenAPI generation with use default kwarg."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1757,6 +1831,7 @@ def test_main_use_default_kwarg(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_discriminator(input_: str, output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with discriminator."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1789,6 +1864,7 @@ def test_main_openapi_discriminator(input_: str, output: str, tmp_path: Path) ->
     ],
 )
 def test_main_openapi_discriminator_in_array(kind: str, option: str | None, expected: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with discriminator in array."""
     output_file: Path = tmp_path / "output.py"
     input_file = f"discriminator_in_array_{kind.lower()}.yaml"
     return_code: Exit = main([
@@ -1835,6 +1911,7 @@ def test_main_openapi_discriminator_in_array(kind: str, option: str | None, expe
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_default_object(output_model: str, expected_output: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with default object values."""
     return_code: Exit = main([
         "--input",
         str(OPEN_API_DATA_PATH / "default_object.yaml"),
@@ -1855,6 +1932,7 @@ def test_main_openapi_default_object(output_model: str, expected_output: str, tm
 
 @freeze_time("2019-07-26")
 def test_main_dataclass(tmp_path: Path) -> None:
+    """Test OpenAPI generation with dataclass output."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1870,6 +1948,7 @@ def test_main_dataclass(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_dataclass_base_class(tmp_path: Path) -> None:
+    """Test OpenAPI generation with dataclass base class."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1887,6 +1966,7 @@ def test_main_dataclass_base_class(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_reference_same_hierarchy_directory(tmp_path: Path) -> None:
+    """Test OpenAPI generation with reference in same hierarchy directory."""
     with chdir(OPEN_API_DATA_PATH / "reference_same_hierarchy_directory"):
         output_file: Path = tmp_path / "output.py"
         return_code: Exit = main([
@@ -1903,6 +1983,7 @@ def test_main_openapi_reference_same_hierarchy_directory(tmp_path: Path) -> None
 
 @freeze_time("2019-07-26")
 def test_main_multiple_required_any_of(tmp_path: Path) -> None:
+    """Test OpenAPI generation with multiple required anyOf."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1917,6 +1998,7 @@ def test_main_multiple_required_any_of(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_max_min(tmp_path: Path) -> None:
+    """Test OpenAPI generation with max and min constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1930,6 +2012,7 @@ def test_main_openapi_max_min(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_use_operation_id_as_name(tmp_path: Path) -> None:
+    """Test OpenAPI generation with operation ID as name."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1950,6 +2033,7 @@ def test_main_openapi_use_operation_id_as_name(tmp_path: Path) -> None:
 def test_main_openapi_use_operation_id_as_name_not_found_operation_id(
     capsys: pytest.CaptureFixture, tmp_path: Path
 ) -> None:
+    """Test OpenAPI generation with operation ID as name when ID not found."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1974,6 +2058,7 @@ def test_main_openapi_use_operation_id_as_name_not_found_operation_id(
 
 @freeze_time("2019-07-26")
 def test_main_unsorted_optional_fields(tmp_path: Path) -> None:
+    """Test OpenAPI generation with unsorted optional fields."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -1989,6 +2074,7 @@ def test_main_unsorted_optional_fields(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_typed_dict(tmp_path: Path) -> None:
+    """Test OpenAPI generation with TypedDict output."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2004,6 +2090,7 @@ def test_main_typed_dict(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_typed_dict_py(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with TypedDict for specific Python version."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2025,7 +2112,6 @@ def test_main_typed_dict_py(min_version: str, tmp_path: Path) -> None:
 )
 def test_main_modular_typed_dict(tmp_path: Path) -> None:
     """Test main function on modular file."""
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_path = tmp_path / "model"
 
@@ -2050,6 +2136,7 @@ def test_main_modular_typed_dict(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_typed_dict_nullable(tmp_path: Path) -> None:
+    """Test OpenAPI generation with nullable TypedDict."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2071,6 +2158,7 @@ def test_main_typed_dict_nullable(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_typed_dict_nullable_strict_nullable(tmp_path: Path) -> None:
+    """Test OpenAPI generation with strict nullable TypedDict."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2090,6 +2178,7 @@ def test_main_typed_dict_nullable_strict_nullable(tmp_path: Path) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_openapi_nullable_31(tmp_path: Path) -> None:
+    """Test OpenAPI 3.1 generation with nullable types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2109,6 +2198,7 @@ def test_main_openapi_nullable_31(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_custom_file_header_path(tmp_path: Path) -> None:
+    """Test OpenAPI generation with custom file header path."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2124,6 +2214,7 @@ def test_main_custom_file_header_path(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_custom_file_header_duplicate_options(capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
+    """Test OpenAPI generation with duplicate custom file header options."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2143,6 +2234,7 @@ def test_main_custom_file_header_duplicate_options(capsys: pytest.CaptureFixture
 
 @freeze_time("2019-07-26")
 def test_main_pydantic_v2(tmp_path: Path) -> None:
+    """Test OpenAPI generation with Pydantic v2 output."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2158,6 +2250,7 @@ def test_main_pydantic_v2(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_custom_id_pydantic_v2(tmp_path: Path) -> None:
+    """Test OpenAPI generation with custom ID for Pydantic v2."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2177,6 +2270,7 @@ def test_main_openapi_custom_id_pydantic_v2(tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_openapi_custom_id_pydantic_v2_custom_base(tmp_path: Path) -> None:
+    """Test OpenAPI generation with custom ID and base for Pydantic v2."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2198,6 +2292,7 @@ def test_main_openapi_custom_id_pydantic_v2_custom_base(tmp_path: Path) -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_all_of_with_relative_ref(tmp_path: Path) -> None:
+    """Test OpenAPI generation with allOf and relative reference."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2221,6 +2316,7 @@ def test_main_openapi_all_of_with_relative_ref(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_msgspec_struct(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with msgspec Struct output."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2238,6 +2334,7 @@ def test_main_openapi_msgspec_struct(min_version: str, tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_msgspec_struct_snake_case(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with msgspec Struct and snake case."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2260,6 +2357,7 @@ def test_main_openapi_msgspec_struct_snake_case(min_version: str, tmp_path: Path
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_msgspec_use_annotated_with_field_constraints(tmp_path: Path) -> None:
+    """Test OpenAPI generation with msgspec using Annotated and field constraints."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2278,6 +2376,7 @@ def test_main_openapi_msgspec_use_annotated_with_field_constraints(tmp_path: Pat
 
 @freeze_time("2019-07-26")
 def test_main_openapi_discriminator_one_literal_as_default(tmp_path: Path) -> None:
+    """Test OpenAPI generation with discriminator one literal as default."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2296,6 +2395,7 @@ def test_main_openapi_discriminator_one_literal_as_default(tmp_path: Path) -> No
 
 @freeze_time("2019-07-26")
 def test_main_openapi_discriminator_one_literal_as_default_dataclass(tmp_path: Path) -> None:
+    """Test OpenAPI generation with discriminator one literal as default for dataclass."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2320,6 +2420,7 @@ def test_main_openapi_discriminator_one_literal_as_default_dataclass(tmp_path: P
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_keyword_only_dataclass(tmp_path: Path) -> None:
+    """Test OpenAPI generation with keyword-only dataclass."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2340,6 +2441,7 @@ def test_main_openapi_keyword_only_dataclass(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_keyword_only_dataclass_with_python_3_9(capsys: pytest.CaptureFixture) -> None:
+    """Test OpenAPI generation with keyword-only dataclass for Python 3.9."""
     return_code = main([
         "--input",
         str(OPEN_API_DATA_PATH / "inheritance.yaml"),
@@ -2359,6 +2461,7 @@ def test_main_openapi_keyword_only_dataclass_with_python_3_9(capsys: pytest.Capt
 
 @freeze_time("2019-07-26")
 def test_main_openapi_dataclass_with_naive_datetime(capsys: pytest.CaptureFixture) -> None:
+    """Test OpenAPI generation with dataclass using naive datetime."""
     return_code = main([
         "--input",
         str(OPEN_API_DATA_PATH / "inheritance.yaml"),
@@ -2384,6 +2487,7 @@ def test_main_openapi_dataclass_with_naive_datetime(capsys: pytest.CaptureFixtur
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_keyword_only_msgspec(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with keyword-only msgspec."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2408,6 +2512,7 @@ def test_main_openapi_keyword_only_msgspec(min_version: str, tmp_path: Path) -> 
     reason="Installed black doesn't support the old style",
 )
 def test_main_openapi_keyword_only_msgspec_with_extra_data(min_version: str, tmp_path: Path) -> None:
+    """Test OpenAPI generation with keyword-only msgspec and extra data."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2434,6 +2539,7 @@ def test_main_openapi_keyword_only_msgspec_with_extra_data(min_version: str, tmp
     reason="Installed black doesn't support the old style",
 )
 def test_main_generate_openapi_keyword_only_msgspec_with_extra_data(tmp_path: Path) -> None:
+    """Test OpenAPI generation with keyword-only msgspec using generate function."""
     extra_data = json.loads((OPEN_API_DATA_PATH / "extra_data_msgspec.json").read_text())
     output_file: Path = tmp_path / "output.py"
     generate(
@@ -2455,6 +2561,7 @@ def test_main_generate_openapi_keyword_only_msgspec_with_extra_data(tmp_path: Pa
 
 @freeze_time("2019-07-26")
 def test_main_openapi_referenced_default(tmp_path: Path) -> None:
+    """Test OpenAPI generation with referenced default values."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2472,6 +2579,7 @@ def test_main_openapi_referenced_default(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_duplicate_models(tmp_path: Path) -> None:
+    """Test OpenAPI generation with duplicate models."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2493,6 +2601,7 @@ def test_duplicate_models(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_shadowed_imports(tmp_path: Path) -> None:
+    """Test OpenAPI generation with shadowed imports."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2510,6 +2619,7 @@ def test_main_openapi_shadowed_imports(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_extra_fields_forbid(tmp_path: Path) -> None:
+    """Test OpenAPI generation with extra fields forbidden."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2527,6 +2637,7 @@ def test_main_openapi_extra_fields_forbid(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_same_name_objects(tmp_path: Path) -> None:
+    """Test OpenAPI generation with same name objects."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2584,6 +2695,7 @@ def test_main_openapi_type_alias_py312(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_byte_format(tmp_path: Path) -> None:
+    """Test OpenAPI generation with byte format."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -2601,6 +2713,7 @@ def test_main_openapi_byte_format(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_openapi_unquoted_null(tmp_path: Path) -> None:
+    """Test OpenAPI generation with unquoted null values."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",

--- a/tests/main/test_main_csv.py
+++ b/tests/main/test_main_csv.py
@@ -1,3 +1,5 @@
+"""Tests for CSV input file code generation."""
+
 from __future__ import annotations
 
 from argparse import Namespace
@@ -21,6 +23,7 @@ assert_file_content = create_assert_file_content(EXPECTED_CSV_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -28,6 +31,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @freeze_time("2019-07-26")
 def test_csv_file(tmp_path: Path) -> None:
+    """Test CSV file input code generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -43,6 +47,7 @@ def test_csv_file(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_csv_stdin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Test CSV stdin input code generation."""
     output_file: Path = tmp_path / "output.py"
     monkeypatch.setattr("sys.stdin", (CSV_DATA_PATH / "simple.csv").open())
     return_code: Exit = main([

--- a/tests/main/test_main_general.py
+++ b/tests/main/test_main_general.py
@@ -1,3 +1,5 @@
+"""General integration tests for main code generation functionality."""
+
 from __future__ import annotations
 
 from argparse import Namespace
@@ -31,12 +33,14 @@ TIMESTAMP = "1985-10-26T01:21:00-07:00"
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
 
 
 def test_debug(mocker: MockerFixture) -> None:
+    """Test debug flag functionality."""
     with pytest.raises(expected_exception=SystemExit):
         main(["--debug", "--help"])
 
@@ -47,6 +51,7 @@ def test_debug(mocker: MockerFixture) -> None:
 
 @freeze_time("2019-07-26")
 def test_snooper_to_methods_without_pysnooper(mocker: MockerFixture) -> None:
+    """Test snooper_to_methods function without pysnooper installed."""
     mocker.patch("datamodel_code_generator.pysnooper", None)
     mock = mocker.Mock()
     assert snooper_to_methods()(mock) == mock
@@ -54,6 +59,7 @@ def test_snooper_to_methods_without_pysnooper(mocker: MockerFixture) -> None:
 
 @pytest.mark.parametrize(argnames="no_color", argvalues=[False, True])
 def test_show_help(no_color: bool, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test help output with and without color."""
     args = ["--no-color"] if no_color else []
     args += ["--help"]
 
@@ -66,6 +72,7 @@ def test_show_help(no_color: bool, capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_show_help_when_no_input(mocker: MockerFixture) -> None:
+    """Test help display when no input is provided."""
     print_help_mock = mocker.patch("datamodel_code_generator.__main__.arg_parser.print_help")
     isatty_mock = mocker.patch("sys.stdin.isatty", return_value=True)
     return_code: Exit = main([])
@@ -89,6 +96,7 @@ def test_no_args_has_default(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @freeze_time("2019-07-26")
 def test_space_and_special_characters_dict(tmp_path: Path) -> None:
+    """Test dict input with space and special characters."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -104,6 +112,7 @@ def test_space_and_special_characters_dict(tmp_path: Path) -> None:
 
 @freeze_time("2024-12-14")
 def test_direct_input_dict(tmp_path: Path) -> None:
+    """Test direct dict input code generation."""
     output_file = tmp_path / "output.py"
     generate(
         {"foo": 1, "bar": {"baz": 2}},
@@ -132,7 +141,6 @@ def test_frozen_dataclasses(tmp_path: Path) -> None:
 @freeze_time(TIMESTAMP)
 def test_frozen_dataclasses_with_keyword_only(tmp_path: Path) -> None:
     """Test --frozen-dataclasses with --keyword-only flag combination."""
-
     output_file = tmp_path / "output.py"
     generate(
         DATA_PATH / "jsonschema" / "simple_frozen_test.json",
@@ -188,8 +196,7 @@ def test_frozen_dataclasses_with_keyword_only_command_line(tmp_path: Path) -> No
 
 
 def test_filename_with_newline_injection(tmp_path: Path) -> None:
-    """Test that filenames with newlines cannot inject code into generated files"""
-
+    """Test that filenames with newlines cannot inject code into generated files."""
     schema_content = """{"type": "object", "properties": {"name": {"type": "string"}}}"""
 
     malicious_filename = """schema.json
@@ -223,8 +230,7 @@ os.system('echo INJECTED')
 
 
 def test_filename_with_various_control_characters(tmp_path: Path) -> None:
-    """Test that various control characters in filenames are properly sanitized"""
-
+    """Test that various control characters in filenames are properly sanitized."""
     schema_content = """{"type": "object", "properties": {"test": {"type": "string"}}}"""
 
     test_cases = [

--- a/tests/main/test_main_json.py
+++ b/tests/main/test_main_json.py
@@ -1,3 +1,5 @@
+"""Tests for JSON input file code generation."""
+
 from __future__ import annotations
 
 from argparse import Namespace
@@ -32,6 +34,7 @@ assert_file_content = create_assert_file_content(EXPECTED_JSON_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -39,6 +42,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json(tmp_path: Path) -> None:
+    """Test JSON input file code generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -54,6 +58,7 @@ def test_main_json(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_space_and_special_characters_json(tmp_path: Path) -> None:
+    """Test JSON code generation with space and special characters."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -69,6 +74,7 @@ def test_space_and_special_characters_json(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_failed(tmp_path: Path) -> None:
+    """Test JSON code generation with broken input file."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -83,6 +89,7 @@ def test_main_json_failed(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_array_include_null(tmp_path: Path) -> None:
+    """Test JSON code generation with arrays including null values."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -98,6 +105,7 @@ def test_main_json_array_include_null(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_reuse_model(tmp_path: Path) -> None:
+    """Test JSON code generation with model reuse."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -114,6 +122,7 @@ def test_main_json_reuse_model(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_reuse_model_pydantic2(tmp_path: Path) -> None:
+    """Test JSON code generation with model reuse and Pydantic v2."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -132,6 +141,7 @@ def test_main_json_reuse_model_pydantic2(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_simple_json_snake_case_field(tmp_path: Path) -> None:
+    """Test JSON code generation with snake case field naming."""
     output_file: Path = tmp_path / "output.py"
     with chdir(JSON_DATA_PATH / "simple.json"):
         return_code: Exit = main([
@@ -149,6 +159,8 @@ def test_simple_json_snake_case_field(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_http_json(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test JSON code generation from HTTP URL."""
+
     def get_mock_response(path: str) -> mocker.Mock:
         mock = mocker.Mock()
         mock.text = (JSON_DATA_PATH / path).read_text()
@@ -195,6 +207,7 @@ def test_main_http_json(mocker: MockerFixture, tmp_path: Path) -> None:
 )
 @freeze_time("2019-07-26")
 def test_main_typed_dict_space_and_special_characters(tmp_path: Path) -> None:
+    """Test TypedDict generation with space and special characters."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -212,6 +225,7 @@ def test_main_typed_dict_space_and_special_characters(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_json_snake_case_field(tmp_path: Path) -> None:
+    """Test JSON code generation with snake case field naming."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",

--- a/tests/main/test_main_yaml.py
+++ b/tests/main/test_main_yaml.py
@@ -1,3 +1,5 @@
+"""Tests for YAML input file code generation."""
+
 from __future__ import annotations
 
 from argparse import Namespace
@@ -20,6 +22,7 @@ assert_file_content = create_assert_file_content(EXPECTED_MAIN_PATH)
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -28,6 +31,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.benchmark
 @freeze_time("2019-07-26")
 def test_main_yaml(tmp_path: Path) -> None:
+    """Test YAML input file code generation."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",

--- a/tests/main/test_types.py
+++ b/tests/main/test_types.py
@@ -1,3 +1,5 @@
+"""Tests for DataType import generation."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.format import PythonVersionMin
@@ -9,7 +11,7 @@ from datamodel_code_generator.types import DataType
 
 
 def test_imports_with_literal_one() -> None:
-    """Test imports for a DataType with single literal value"""
+    """Test imports for a DataType with single literal value."""
     data_type = DataType(literals=[""], python_version=PythonVersionMin)
 
     # Convert iterator to list for assertion
@@ -19,7 +21,7 @@ def test_imports_with_literal_one() -> None:
 
 
 def test_imports_with_literal_one_and_optional() -> None:
-    """Test imports for an optional DataType with single literal value"""
+    """Test imports for an optional DataType with single literal value."""
     data_type = DataType(literals=[""], is_optional=True, python_version=PythonVersionMin)
 
     imports = list(data_type.imports)
@@ -29,7 +31,7 @@ def test_imports_with_literal_one_and_optional() -> None:
 
 
 def test_imports_with_literal_empty() -> None:
-    """Test imports for a DataType with no literal values"""
+    """Test imports for a DataType with no literal values."""
     data_type = DataType(literals=[], python_version=PythonVersionMin)
 
     imports = list(data_type.imports)
@@ -37,7 +39,7 @@ def test_imports_with_literal_empty() -> None:
 
 
 def test_imports_with_nested_dict_key() -> None:
-    """Test imports for a DataType with dict_key containing literals"""
+    """Test imports for a DataType with dict_key containing literals."""
     dict_key_type = DataType(literals=["key"], python_version=PythonVersionMin)
 
     data_type = DataType(python_version=PythonVersionMin, dict_key=dict_key_type)
@@ -48,7 +50,7 @@ def test_imports_with_nested_dict_key() -> None:
 
 
 def test_imports_without_duplicate_literals() -> None:
-    """Test that literal import is not duplicated"""
+    """Test that literal import is not duplicated."""
     dict_key_type = DataType(literals=["key1"], python_version=PythonVersionMin)
 
     data_type = DataType(

--- a/tests/model/__init__.py
+++ b/tests/model/__init__.py
@@ -1,0 +1,1 @@
+"""Model unit tests package."""

--- a/tests/model/dataclass/__init__.py
+++ b/tests/model/dataclass/__init__.py
@@ -1,0 +1,1 @@
+"""Dataclass model unit tests package."""

--- a/tests/model/dataclass/test_param.py
+++ b/tests/model/dataclass/test_param.py
@@ -1,3 +1,5 @@
+"""Tests for dataclass parameter options (frozen, keyword_only)."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.model.dataclass import DataClass, DataModelField

--- a/tests/model/pydantic/__init__.py
+++ b/tests/model/pydantic/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic v1 model unit tests package."""

--- a/tests/model/pydantic/test_base_model.py
+++ b/tests/model/pydantic/test_base_model.py
@@ -1,3 +1,5 @@
+"""Tests for Pydantic v1 BaseModel generation."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -11,6 +13,7 @@ from datamodel_code_generator.types import DataType, Types
 
 
 def test_base_model() -> None:
+    """Test basic BaseModel generation with required field."""
     field = DataModelField(name="a", data_type=DataType(type="str"), required=True)
 
     base_model = BaseModel(
@@ -25,6 +28,7 @@ def test_base_model() -> None:
 
 
 def test_base_model_optional() -> None:
+    """Test BaseModel generation with optional field and default value."""
     field = DataModelField(name="a", data_type=DataType(type="str"), default="abc", required=False)
 
     base_model = BaseModel(
@@ -39,6 +43,7 @@ def test_base_model_optional() -> None:
 
 
 def test_base_model_nullable_required() -> None:
+    """Test BaseModel generation with nullable required field."""
     field = DataModelField(
         name="a",
         data_type=DataType(type="str"),
@@ -59,6 +64,7 @@ def test_base_model_nullable_required() -> None:
 
 
 def test_base_model_strict_non_nullable_required() -> None:
+    """Test BaseModel generation with strict non-nullable required field."""
     field = DataModelField(
         name="a",
         data_type=DataType(type="str"),
@@ -79,6 +85,7 @@ def test_base_model_strict_non_nullable_required() -> None:
 
 
 def test_base_model_decorator() -> None:
+    """Test BaseModel generation with decorators and base classes."""
     field = DataModelField(name="a", data_type=DataType(type="str"), default="abc", required=False)
 
     base_model = BaseModel(
@@ -96,6 +103,7 @@ def test_base_model_decorator() -> None:
 
 
 def test_base_model_get_data_type() -> None:
+    """Test data type retrieval for BaseModel fields."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_type(Types.integer) == data_type_manager.data_type(type="int")
 
@@ -138,4 +146,5 @@ def test_base_model_get_data_type() -> None:
     ],
 )
 def test_data_model_field(kwargs: dict[str, Any], expected: str | None) -> None:
+    """Test DataModelField generation with various field attributes."""
     assert DataModelField(**kwargs, data_type=DataType()).field == expected

--- a/tests/model/pydantic/test_constraint.py
+++ b/tests/model/pydantic/test_constraint.py
@@ -1,3 +1,5 @@
+"""Tests for Pydantic constraint detection."""
+
 from __future__ import annotations
 
 import pytest
@@ -16,6 +18,7 @@ from datamodel_code_generator.types import UnionIntFloat
     ],
 )
 def test_constraint(gt: float | None, expected: bool) -> None:
+    """Test constraint detection with greater-than values."""
     constraints = Constraints()
     constraints.gt = UnionIntFloat(gt) if gt is not None else None
     assert constraints.has_constraints == expected

--- a/tests/model/pydantic/test_custom_root_type.py
+++ b/tests/model/pydantic/test_custom_root_type.py
@@ -1,3 +1,5 @@
+"""Tests for Pydantic v1 CustomRootType generation."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.model import DataModelFieldBase
@@ -8,6 +10,7 @@ from datamodel_code_generator.types import DataType, Types
 
 
 def test_custom_root_type() -> None:
+    """Test CustomRootType generation with optional field."""
     custom_root_type = CustomRootType(
         fields=[
             DataModelFieldBase(
@@ -35,6 +38,7 @@ def test_custom_root_type() -> None:
 
 
 def test_custom_root_type_required() -> None:
+    """Test CustomRootType generation with required field."""
     custom_root_type = CustomRootType(
         fields=[DataModelFieldBase(data_type=DataType(type="str"), required=True)],
         reference=Reference(name="test_model", path="test_model"),
@@ -49,6 +53,7 @@ def test_custom_root_type_required() -> None:
 
 
 def test_custom_root_type_decorator() -> None:
+    """Test CustomRootType generation with decorators and base classes."""
     custom_root_type = CustomRootType(
         fields=[DataModelFieldBase(data_type=DataType(type="str"), required=True)],
         decorators=["@validate"],
@@ -65,5 +70,6 @@ def test_custom_root_type_decorator() -> None:
 
 
 def test_custom_root_type_get_data_type() -> None:
+    """Test data type retrieval for CustomRootType fields."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_type(Types.integer) == data_type_manager.data_type(type="int")

--- a/tests/model/pydantic/test_data_class.py
+++ b/tests/model/pydantic/test_data_class.py
@@ -1,3 +1,5 @@
+"""Tests for Pydantic dataclass generation."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.model import DataModelFieldBase
@@ -8,6 +10,7 @@ from datamodel_code_generator.types import DataType, Types
 
 
 def test_data_class() -> None:
+    """Test basic DataClass generation with required field."""
     field = DataModelFieldBase(name="a", data_type=DataType(type="str"), required=True)
 
     data_class = DataClass(
@@ -22,6 +25,7 @@ def test_data_class() -> None:
 
 
 def test_data_class_base_class() -> None:
+    """Test DataClass generation with base class inheritance."""
     field = DataModelFieldBase(name="a", data_type=DataType(type="str"), required=True)
 
     data_class = DataClass(
@@ -37,6 +41,7 @@ def test_data_class_base_class() -> None:
 
 
 def test_data_class_optional() -> None:
+    """Test DataClass generation with field default value."""
     field = DataModelFieldBase(name="a", data_type=DataType(type="str"), default="'abc'", required=True)
 
     data_class = DataClass(
@@ -51,5 +56,6 @@ def test_data_class_optional() -> None:
 
 
 def test_data_class_get_data_type() -> None:
+    """Test data type retrieval for DataClass fields."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_type(Types.integer) == data_type_manager.data_type(type="int")

--- a/tests/model/pydantic/test_types.py
+++ b/tests/model/pydantic/test_types.py
@@ -1,3 +1,5 @@
+"""Tests for Pydantic type generation and constraints."""
+
 from __future__ import annotations
 
 from decimal import Decimal
@@ -137,6 +139,7 @@ def test_get_data_int_type(
     params: dict[str, Any],
     data_type: dict[str, Any],
 ) -> None:
+    """Test integer data type generation with various constraints."""
     data_type_manager = DataTypeManager(
         use_non_positive_negative_number_constrained_types=use_non_positive_negative_number_constrained_types
     )
@@ -258,6 +261,7 @@ def test_get_data_float_type(
     params: dict[str, Any],
     data_type: dict[str, Any],
 ) -> None:
+    """Test float data type generation with various constraints."""
     data_type_manager = DataTypeManager(
         use_non_positive_negative_number_constrained_types=use_non_positive_negative_number_constrained_types
     )
@@ -335,6 +339,7 @@ def test_get_data_float_type(
     ],
 )
 def test_get_data_decimal_type(types: Types, params: dict[str, Any], data_type: dict[str, Any]) -> None:
+    """Test decimal data type generation with various constraints."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_decimal_type(types, **params) == data_type_manager.data_type(**data_type)
 
@@ -376,6 +381,7 @@ def test_get_data_decimal_type(types: Types, params: dict[str, Any], data_type: 
     ],
 )
 def test_get_data_str_type(types: Types, params: dict[str, Any], data_type: dict[str, Any]) -> None:
+    """Test string data type generation with various constraints."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_str_type(types, **params) == data_type_manager.data_type(**data_type)
 
@@ -394,11 +400,13 @@ def test_get_data_str_type(types: Types, params: dict[str, Any], data_type: dict
     ],
 )
 def test_get_data_type(types: Types, data_type: dict[str, str]) -> None:
+    """Test basic data type retrieval for common types."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_type(types) == data_type_manager.data_type(**data_type)
 
 
 def test_data_type_type_hint() -> None:
+    """Test type hint generation for DataType objects."""
     assert DataType(type="str").type_hint == "str"
     assert DataType(type="constr", is_func=True).type_hint == "constr()"
     assert DataType(type="constr", is_func=True, kwargs={"min_length": 10}).type_hint == "constr(min_length=10)"
@@ -414,6 +422,7 @@ def test_data_type_type_hint() -> None:
     ],
 )
 def test_get_data_type_from_value(types: Any, data_type: dict[str, str]) -> None:
+    """Test data type inference from Python values."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_type_from_value(types) == data_type_manager.data_type(**data_type)
 
@@ -433,6 +442,7 @@ def test_get_data_type_from_value(types: Any, data_type: dict[str, str]) -> None
     ],
 )
 def test_get_data_type_from_full_path(types: Any, data_type: tuple[str, bool]) -> None:
+    """Test data type generation from full module paths."""
     data_type_manager = DataTypeManager()
     assert data_type_manager.get_data_type_from_value(types) == data_type_manager.get_data_type_from_full_path(
         *data_type

--- a/tests/model/pydantic_v2/__init__.py
+++ b/tests/model/pydantic_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic v2 model unit tests package."""

--- a/tests/model/pydantic_v2/test_root_model.py
+++ b/tests/model/pydantic_v2/test_root_model.py
@@ -1,3 +1,5 @@
+"""Tests for Pydantic v2 RootModel generation."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.model import DataModelFieldBase
@@ -7,6 +9,7 @@ from datamodel_code_generator.types import DataType
 
 
 def test_root_model() -> None:
+    """Test RootModel generation with optional field."""
     root_model = RootModel(
         fields=[
             DataModelFieldBase(
@@ -37,7 +40,6 @@ def test_root_model() -> None:
 
 def test_root_model_custom_base_class_is_ignored() -> None:
     """Verify that passing a custom_base_class is ignored."""
-
     root_model = RootModel(
         custom_base_class="test.Test",
         fields=[

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -1,3 +1,5 @@
+"""Tests for base model classes and utilities."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -18,31 +20,40 @@ from datamodel_code_generator.types import DataType, Types
 
 
 class A(TemplateBase):
+    """Test helper class for TemplateBase testing."""
+
     def __init__(self, path: Path) -> None:
+        """Initialize with template file path."""
         self._path = path
 
     @property
     def template_file_path(self) -> Path:
+        """Return the template file path."""
         return self._path
 
     def render(self) -> str:  # noqa: PLR6301
+        """Render the template."""
         return ""
 
 
 class B(DataModel):
+    """Test helper class for DataModel testing with template path."""
+
     @classmethod
-    def get_data_type(cls, types: Types, **kwargs: Any) -> DataType:
+    def get_data_type(cls, types: Types, **kwargs: Any) -> DataType:  # noqa: D102
         pass
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D107
         super().__init__(*args, **kwargs)
 
     TEMPLATE_FILE_PATH = ""
 
 
 class C(DataModel):
+    """Test helper class for DataModel testing without template path."""
+
     @classmethod
-    def get_data_type(cls, types: Types, **kwargs: Any) -> DataType:
+    def get_data_type(cls, types: Types, **kwargs: Any) -> DataType:  # noqa: D102
         pass
 
 
@@ -61,6 +72,7 @@ class {{ class_name }}:
 
 
 def test_template_base() -> None:
+    """Test TemplateBase rendering and file path handling."""
     with NamedTemporaryFile("w", delete=False, encoding="utf-8") as dummy_template:
         dummy_template.write("abc")
         dummy_template.seek(0)
@@ -72,6 +84,7 @@ def test_template_base() -> None:
 
 
 def test_data_model() -> None:
+    """Test DataModel rendering with fields and decorators."""
     field = DataModelFieldBase(name="a", data_type=DataType(type="str"), default="abc", required=True)
 
     with NamedTemporaryFile("w", delete=False, encoding="utf-8") as dummy_template:
@@ -94,6 +107,7 @@ def test_data_model() -> None:
 
 
 def test_data_model_exception() -> None:
+    """Test DataModel raises exception when TEMPLATE_FILE_PATH is undefined."""
     field = DataModelFieldBase(name="a", data_type=DataType(type="str"), default="abc", required=True)
     with pytest.raises(Exception, match="TEMPLATE_FILE_PATH is undefined"):
         C(
@@ -103,6 +117,7 @@ def test_data_model_exception() -> None:
 
 
 def test_data_field() -> None:
+    """Test DataModelFieldBase type hint generation for various configurations."""
     field = DataModelFieldBase(
         name="a",
         data_type=DataType(is_list=True),
@@ -279,6 +294,7 @@ def test_data_field() -> None:
 )
 @pytest.mark.parametrize("treat_dot_as_module", [True, False])
 def test_sanitize_module_name(name: str, expected_true: str, expected_false: str, treat_dot_as_module: bool) -> None:
+    """Test module name sanitization with different characters and options."""
     expected = expected_true if treat_dot_as_module else expected_false
     assert sanitize_module_name(name, treat_dot_as_module=treat_dot_as_module) == expected
 
@@ -291,6 +307,7 @@ def test_sanitize_module_name(name: str, expected_true: str, expected_false: str
     ],
 )
 def test_get_module_path_with_file_path(treat_dot_as_module: bool, expected: list[str]) -> None:
+    """Test module path generation with a file path."""
     file_path = Path("inputs/array-commons.schema.json")
     result = get_module_path("array-commons.schema", file_path, treat_dot_as_module=treat_dot_as_module)
     assert result == expected
@@ -298,6 +315,7 @@ def test_get_module_path_with_file_path(treat_dot_as_module: bool, expected: lis
 
 @pytest.mark.parametrize("treat_dot_as_module", [True, False])
 def test_get_module_path_without_file_path(treat_dot_as_module: bool) -> None:
+    """Test module path generation without a file path."""
     result = get_module_path("my_module.submodule", None, treat_dot_as_module=treat_dot_as_module)
     expected = ["my_module"]
     assert result == expected
@@ -317,5 +335,6 @@ def test_get_module_path_without_file_path(treat_dot_as_module: bool) -> None:
 def test_get_module_path_without_file_path_parametrized(
     treat_dot_as_module: bool, name: str, expected: list[str]
 ) -> None:
+    """Test module path generation without file path for various module names."""
     result = get_module_path(name, None, treat_dot_as_module=treat_dot_as_module)
     assert result == expected

--- a/tests/model/test_dataclass.py
+++ b/tests/model/test_dataclass.py
@@ -1,3 +1,5 @@
+"""Tests for dataclass model field generation."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.model.dataclass import DataModelField

--- a/tests/model/test_typed_dict.py
+++ b/tests/model/test_typed_dict.py
@@ -1,3 +1,5 @@
+"""Tests for TypedDict model field generation."""
+
 from __future__ import annotations
 
 from datamodel_code_generator.model.typed_dict import DataModelField

--- a/tests/parser/__init__.py
+++ b/tests/parser/__init__.py
@@ -1,0 +1,1 @@
+"""Parser unit tests package."""

--- a/tests/parser/test_base.py
+++ b/tests/parser/test_base.py
@@ -1,3 +1,5 @@
+"""Tests for base parser classes and utilities."""
+
 from __future__ import annotations
 
 from collections import OrderedDict
@@ -19,22 +21,26 @@ from datamodel_code_generator.types import DataType
 
 
 class A(DataModel):
-    pass
+    """Test data model class A."""
 
 
 class B(DataModel):
-    pass
+    """Test data model class B."""
 
 
 class C(Parser):
+    """Test parser class C."""
+
     def parse_raw(self, name: str, raw: dict[str, Any]) -> None:
-        pass
+        """Parse raw data into models."""
 
     def parse(self) -> str:  # noqa: PLR6301
+        """Parse and return results."""
         return "parsed"
 
 
 def test_parser() -> None:
+    """Test parser initialization."""
     c = C(
         data_model_type=D,
         data_model_root_type=B,
@@ -49,6 +55,7 @@ def test_parser() -> None:
 
 
 def test_sort_data_models() -> None:
+    """Test sorting data models by dependencies."""
     reference_a = Reference(path="A", original_name="A", name="A")
     reference_b = Reference(path="B", original_name="B", name="B")
     reference_c = Reference(path="C", original_name="C", name="C")
@@ -85,6 +92,7 @@ def test_sort_data_models() -> None:
 
 
 def test_sort_data_models_unresolved() -> None:
+    """Test sorting data models with unresolved references."""
     reference_a = Reference(path="A", original_name="A", name="A")
     reference_b = Reference(path="B", original_name="B", name="B")
     reference_c = Reference(path="C", original_name="C", name="C")
@@ -131,6 +139,7 @@ def test_sort_data_models_unresolved() -> None:
 
 
 def test_sort_data_models_unresolved_raise_recursion_error() -> None:
+    """Test sorting data models raises error on recursion limit."""
     reference_a = Reference(path="A", original_name="A", name="A")
     reference_b = Reference(path="B", original_name="B", name="B")
     reference_c = Reference(path="C", original_name="C", name="C")
@@ -188,6 +197,7 @@ def test_sort_data_models_unresolved_raise_recursion_error() -> None:
     ],
 )
 def test_relative(current_module: str, reference: str, val: tuple[str, str]) -> None:
+    """Test relative import calculation."""
     assert relative(current_module, reference) == val
 
 
@@ -202,6 +212,7 @@ def test_relative(current_module: str, reference: str, val: tuple[str, str]) -> 
     ],
 )
 def test_exact_import(from_: str, import_: str, name: str, val: tuple[str, str]) -> None:
+    """Test exact import formatting."""
     assert exact_import(from_, import_, name) == val
 
 
@@ -230,11 +241,15 @@ def test_snake_to_upper_camel(word: str, expected: str) -> None:
 
 
 class D(DataModel):
+    """Test data model class D with custom render."""
+
     def __init__(self, filename: str, data: str, fields: list[DataModelFieldBase]) -> None:  # noqa: ARG002
+        """Initialize data model with custom data."""
         super().__init__(fields=fields, reference=Reference(""))
         self._data = data
 
     def render(self) -> str:
+        """Render the data model."""
         return self._data
 
 
@@ -285,12 +300,13 @@ def test_no_additional_imports() -> None:
     ],
 )
 def test_postprocess_result_modules(input_data: Any, expected: Any) -> None:
+    """Test postprocessing of result modules."""
     result = Parser._Parser__postprocess_result_modules(input_data)
     assert result == expected
 
 
 def test_find_member_with_integer_enum() -> None:
-    """Test find_member method with integer enum values"""
+    """Test find_member method with integer enum values."""
     from datamodel_code_generator.model.enum import Enum  # noqa: PLC0415
     from datamodel_code_generator.model.pydantic.base_model import DataModelField  # noqa: PLC0415
     from datamodel_code_generator.reference import Reference  # noqa: PLC0415
@@ -337,6 +353,7 @@ def test_find_member_with_integer_enum() -> None:
 
 
 def test_find_member_with_string_enum() -> None:
+    """Test find_member method with string enum values."""
     from datamodel_code_generator.model.enum import Enum  # noqa: PLC0415
     from datamodel_code_generator.model.pydantic.base_model import DataModelField  # noqa: PLC0415
     from datamodel_code_generator.reference import Reference  # noqa: PLC0415
@@ -374,6 +391,7 @@ def test_find_member_with_string_enum() -> None:
 
 
 def test_find_member_with_mixed_enum() -> None:
+    """Test find_member method with mixed type enum values."""
     from datamodel_code_generator.model.enum import Enum  # noqa: PLC0415
     from datamodel_code_generator.model.pydantic.base_model import DataModelField  # noqa: PLC0415
     from datamodel_code_generator.reference import Reference  # noqa: PLC0415
@@ -416,6 +434,7 @@ def test_find_member_with_mixed_enum() -> None:
 
 @pytest.fixture
 def escape_map() -> dict[str, str]:
+    """Provide escape character mapping for tests."""
     return {
         "\u0000": r"\x00",  # Null byte
         "'": r"\'",
@@ -442,11 +461,13 @@ def escape_map() -> dict[str, str]:
     ],
 )
 def test_character_escaping(input_str: str, expected: str) -> None:
+    """Test character escaping in strings."""
     assert input_str.translate(escape_characters) == expected
 
 
 @pytest.mark.parametrize("flag", [True, False])
 def test_use_non_positive_negative_number_constrained_types(flag: bool) -> None:
+    """Test configuration of non-positive negative number constrained types."""
     instance = C(source="", use_non_positive_negative_number_constrained_types=flag)
 
     assert instance.data_type_manager.use_non_positive_negative_number_constrained_types == flag

--- a/tests/parser/test_graphql.py
+++ b/tests/parser/test_graphql.py
@@ -1,3 +1,5 @@
+"""Tests for GraphQL schema parser."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -19,6 +21,7 @@ assert_file_content = create_assert_file_content(EXPECTED_GRAPHQL_PATH)
 
 @freeze_time("2019-07-26")
 def test_graphql_field_enum(tmp_path: Path) -> None:
+    """Test parsing GraphQL field with enum default value."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -35,6 +38,7 @@ def test_graphql_field_enum(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_graphql_union_aliased_bug(tmp_path: Path) -> None:
+    """Test parsing GraphQL union with aliased types."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -50,6 +54,7 @@ def test_graphql_union_aliased_bug(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_graphql_union_commented(tmp_path: Path) -> None:
+    """Test parsing GraphQL union with comments."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -1,3 +1,5 @@
+"""Tests for JSON Schema parser."""
+
 from __future__ import annotations
 
 import json
@@ -39,10 +41,12 @@ EXPECTED_JSONSCHEMA_PATH = Path(__file__).parents[1] / "data" / "expected" / "pa
     ],
 )
 def test_get_model_by_path(schema: dict, path: str, model: dict) -> None:
+    """Test model retrieval by path."""
     assert get_model_by_path(schema, path.split("/") if path else []) == model
 
 
 def test_json_schema_object_ref_url_json(mocker: MockerFixture) -> None:
+    """Test JSON schema object reference with JSON URL."""
     parser = JsonSchemaParser("")
     obj = JsonSchemaObject.parse_obj({"$ref": "https://example.com/person.schema.json#/definitions/User"})
     mock_get = mocker.patch("httpx.get")
@@ -82,6 +86,7 @@ def test_json_schema_object_ref_url_json(mocker: MockerFixture) -> None:
 
 
 def test_json_schema_object_ref_url_yaml(mocker: MockerFixture) -> None:
+    """Test JSON schema object reference with YAML URL."""
     parser = JsonSchemaParser("")
     obj = JsonSchemaObject.parse_obj({"$ref": "https://example.org/schema.yaml#/definitions/User"})
     mock_get = mocker.patch("httpx.get")
@@ -109,6 +114,7 @@ class Pet(BaseModel):
 
 
 def test_json_schema_object_cached_ref_url_yaml(mocker: MockerFixture) -> None:
+    """Test JSON schema object cached reference with YAML URL."""
     parser = JsonSchemaParser("")
 
     obj = JsonSchemaObject.parse_obj({
@@ -142,6 +148,7 @@ class User(BaseModel):
 
 
 def test_json_schema_ref_url_json(mocker: MockerFixture) -> None:
+    """Test JSON schema reference with JSON URL."""
     parser = JsonSchemaParser("")
     obj = {
         "type": "object",
@@ -239,6 +246,7 @@ class Pet(BaseModel):
     ],
 )
 def test_parse_object(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing JSON schema objects."""
     parser = JsonSchemaParser(
         data_model_field_type=DataModelFieldBase,
         source="",
@@ -264,6 +272,7 @@ def test_parse_object(source_obj: dict[str, Any], generated_classes: str) -> Non
     ],
 )
 def test_parse_any_root_object(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing any root object."""
     parser = JsonSchemaParser("")
     parser.parse_root_type("AnyObject", JsonSchemaObject.parse_obj(source_obj), [])
     assert dump_templates(list(parser.results)) == generated_classes
@@ -279,6 +288,7 @@ def test_parse_any_root_object(source_obj: dict[str, Any], generated_classes: st
     ],
 )
 def test_parse_one_of_object(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing oneOf schema objects."""
     parser = JsonSchemaParser("")
     parser.parse_raw_obj("onOfObject", source_obj, [])
     assert dump_templates(list(parser.results)) == generated_classes
@@ -326,12 +336,14 @@ def test_parse_one_of_object(source_obj: dict[str, Any], generated_classes: str)
     ],
 )
 def test_parse_default(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing default values in schemas."""
     parser = JsonSchemaParser("")
     parser.parse_raw_obj("Defaults", source_obj, [])
     assert dump_templates(list(parser.results)) == generated_classes
 
 
 def test_parse_array_schema() -> None:
+    """Test parsing array schemas."""
     parser = JsonSchemaParser("")
     parser.parse_raw_obj("schema", {"type": "object", "properties": {"name": True}}, [])
     assert (
@@ -342,6 +354,7 @@ def test_parse_array_schema() -> None:
 
 
 def test_parse_nested_array(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing nested array schemas."""
     monkeypatch.chdir(tmp_path)
     parser = JsonSchemaParser(
         DATA_PATH / "nested_array.json",
@@ -399,6 +412,7 @@ def test_get_data_type(
     import_: str | None,
     use_pendulum: bool,
 ) -> None:
+    """Test data type resolution from schema type and format."""
     if from_ and import_:
         import_: Import | None = Import(from_=from_, import_=import_)
     else:
@@ -419,6 +433,7 @@ def test_get_data_type(
     ],
 )
 def test_get_data_type_array(schema_types: list[str], result_types: list[str]) -> None:
+    """Test data type resolution for array of types."""
     parser = JsonSchemaParser("")
     assert parser.get_data_type(JsonSchemaObject(type=schema_types)) == parser.data_type(
         data_types=[
@@ -489,10 +504,7 @@ def test_no_additional_imports() -> None:
 )
 @pytest.mark.skipif(pydantic.VERSION < "2.0.0", reason="Require Pydantic version 2.0.0 or later ")
 def test_json_schema_parser_extension(source_obj: dict[str, Any], generated_classes: str) -> None:
-    """
-    Contrived example to extend the JsonSchemaParser to support an alt_type, which
-    replaces the type if present.
-    """
+    """Test JSON schema parser extension with alt_type support."""
 
     class AltJsonSchemaObject(JsonSchemaObject):
         properties: Optional[dict[str, Union[AltJsonSchemaObject, bool]]] = None  # noqa: UP007, UP045

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -1,3 +1,5 @@
+"""Tests for OpenAPI/Swagger schema parser."""
+
 from __future__ import annotations
 
 import os
@@ -36,6 +38,7 @@ def get_expected_file(
     base_class: str | None = None,
     prefix: str | None = None,
 ) -> Path:
+    """Get expected output file path for test."""
     params: list[str] = []
     if with_import:
         params.append("with_import")
@@ -133,6 +136,7 @@ class Pets(BaseModel):
     ],
 )
 def test_parse_object(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing OpenAPI object schemas."""
     parser = OpenAPIParser("")
     parser.parse_object("Pets", JsonSchemaObject.parse_obj(source_obj), [])
     assert dump_templates(list(parser.results)) == generated_classes
@@ -176,6 +180,7 @@ class Pets(BaseModel):
     ],
 )
 def test_parse_array(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing OpenAPI array schemas."""
     parser = OpenAPIParser("")
     parser.parse_array("Pets", JsonSchemaObject.parse_obj(source_obj), [])
     assert dump_templates(list(parser.results)) == generated_classes
@@ -203,6 +208,7 @@ def test_parse_array(source_obj: dict[str, Any], generated_classes: str) -> None
     ],
 )
 def test_openapi_parser_parse(with_import: bool, format_: bool, base_class: str | None) -> None:
+    """Test OpenAPI parser with various configurations."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
         source=Path(DATA_PATH / "api.yaml"),
@@ -228,12 +234,14 @@ def test_openapi_parser_parse(with_import: bool, format_: bool, base_class: str 
     ],
 )
 def test_parse_root_type(source_obj: dict[str, Any], generated_classes: str) -> None:
+    """Test parsing OpenAPI root type schemas."""
     parser = OpenAPIParser("")
     parser.parse_root_type("Name", JsonSchemaObject.parse_obj(source_obj), [])
     assert dump_templates(list(parser.results)) == generated_classes
 
 
 def test_openapi_parser_parse_duplicate_models(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with duplicate model names."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "duplicate_models.yaml"),
@@ -242,6 +250,7 @@ def test_openapi_parser_parse_duplicate_models(tmp_path: Path, monkeypatch: pyte
 
 
 def test_openapi_parser_parse_duplicate_model_with_simplify(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with duplicate models and simplification."""
     monkeypatch.chdir(tmp_path)
     raw = Path(DATA_PATH / "duplicate_model_simplify.yaml")
     parser = OpenAPIParser(raw)
@@ -251,6 +260,7 @@ def test_openapi_parser_parse_duplicate_model_with_simplify(tmp_path: Path, monk
 
 
 def test_openapi_parser_parse_resolved_models(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with resolved model references."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "resolved_models.yaml"),
@@ -259,6 +269,7 @@ def test_openapi_parser_parse_resolved_models(tmp_path: Path, monkeypatch: pytes
 
 
 def test_openapi_parser_parse_lazy_resolved_models(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with lazy resolved model references."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "lazy_resolved_models.yaml"),
@@ -304,6 +315,7 @@ class Results(BaseModel):
 
 
 def test_openapi_parser_parse_x_enum_varnames(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with x-enum-varnames extension."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "x_enum_varnames.yaml"),
@@ -358,6 +370,7 @@ class UnknownTypeNumber(Enum):
 
 @pytest.mark.skipif(pydantic.VERSION < "1.9.0", reason="Require Pydantic version 1.9.0 or later ")
 def test_openapi_parser_parse_enum_models() -> None:
+    """Test parsing OpenAPI enum models."""
     parser = OpenAPIParser(
         Path(DATA_PATH / "enum_models.yaml").read_text(encoding="utf-8"),
         target_python_version=PythonVersionMin,
@@ -367,6 +380,7 @@ def test_openapi_parser_parse_enum_models() -> None:
 
 
 def test_openapi_parser_parse_anyof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with anyOf schemas."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "anyof.yaml"),
@@ -375,6 +389,7 @@ def test_openapi_parser_parse_anyof(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_openapi_parser_parse_anyof_required(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with anyOf and required fields."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "anyof_required.yaml"),
@@ -383,6 +398,7 @@ def test_openapi_parser_parse_anyof_required(tmp_path: Path, monkeypatch: pytest
 
 
 def test_openapi_parser_parse_nested_anyof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with nested anyOf schemas."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "nested_anyof.yaml").read_text(encoding="utf-8"),
@@ -391,6 +407,7 @@ def test_openapi_parser_parse_nested_anyof(tmp_path: Path, monkeypatch: pytest.M
 
 
 def test_openapi_parser_parse_oneof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with oneOf schemas."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "oneof.yaml"),
@@ -399,6 +416,7 @@ def test_openapi_parser_parse_oneof(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_openapi_parser_parse_nested_oneof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with nested oneOf schemas."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "nested_oneof.yaml").read_text(encoding="utf-8"),
@@ -407,6 +425,7 @@ def test_openapi_parser_parse_nested_oneof(tmp_path: Path, monkeypatch: pytest.M
 
 
 def test_openapi_parser_parse_allof_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with allOf references."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "allof_same_prefix_with_ref.yaml"),
@@ -417,6 +436,7 @@ def test_openapi_parser_parse_allof_ref(tmp_path: Path, monkeypatch: pytest.Monk
 
 
 def test_openapi_parser_parse_allof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with allOf schemas."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "allof.yaml"),
@@ -425,6 +445,7 @@ def test_openapi_parser_parse_allof(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_openapi_parser_parse_allof_required_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with allOf and required fields."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "allof_required_fields.yaml"),
@@ -433,6 +454,7 @@ def test_openapi_parser_parse_allof_required_fields(tmp_path: Path, monkeypatch:
 
 
 def test_openapi_parser_parse_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with field aliases."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         Path(DATA_PATH / "alias.yaml"),
@@ -443,6 +465,7 @@ def test_openapi_parser_parse_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_openapi_parser_parse_modular(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with modular structure."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(Path(DATA_PATH / "modular.yaml"), data_model_field_type=DataModelFieldBase)
     modules = parser.parse()
@@ -475,6 +498,7 @@ def test_openapi_parser_parse_modular(tmp_path: Path, monkeypatch: pytest.Monkey
     ],
 )
 def test_openapi_parser_parse_additional_properties(with_import: bool, format_: bool, base_class: str | None) -> None:
+    """Test parsing OpenAPI with additional properties."""
     parser = OpenAPIParser(
         Path(DATA_PATH / "additional_properties.yaml").read_text(encoding="utf-8"),
         base_class=base_class,
@@ -493,6 +517,7 @@ def test_openapi_parser_parse_additional_properties(with_import: bool, format_: 
 
 
 def test_openapi_parser_parse_array_enum(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with array enum types."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(source=Path(DATA_PATH / "array_enum.yaml"))
     expected_file = get_expected_file("openapi_parser_parse_array_enum", True, True)
@@ -500,6 +525,7 @@ def test_openapi_parser_parse_array_enum(tmp_path: Path, monkeypatch: pytest.Mon
 
 
 def test_openapi_parser_parse_remote_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with remote references."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
@@ -512,12 +538,14 @@ def test_openapi_parser_parse_remote_ref(tmp_path: Path, monkeypatch: pytest.Mon
 
 
 def test_openapi_parser_parse_required_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with required nullable fields."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(source=Path(DATA_PATH / "required_null.yaml"))
     assert_output(parser.parse(), EXPECTED_OPEN_API_PATH / "openapi_parser_parse_required_null" / "output.py")
 
 
 def test_openapi_model_resolver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test OpenAPI model resolver functionality."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(source=(DATA_PATH / "api.yaml"))
     parser.parse()
@@ -610,6 +638,7 @@ def test_openapi_model_resolver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
 
 def test_openapi_parser_parse_any(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI with any type schemas."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
@@ -619,6 +648,7 @@ def test_openapi_parser_parse_any(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
 
 def test_openapi_parser_responses_without_content(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI responses without content."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
@@ -630,6 +660,7 @@ def test_openapi_parser_responses_without_content(tmp_path: Path, monkeypatch: p
 
 
 def test_openapi_parser_responses_with_tag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test parsing OpenAPI responses with tags."""
     monkeypatch.chdir(tmp_path)
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
@@ -644,6 +675,7 @@ def test_openapi_parser_responses_with_tag(tmp_path: Path, monkeypatch: pytest.M
     reason="Installed black doesn't support the old style",
 )
 def test_openapi_parser_with_query_parameters() -> None:
+    """Test parsing OpenAPI with query parameters."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
         source=Path(DATA_PATH / "query_parameters.yaml"),
@@ -661,6 +693,7 @@ def test_openapi_parser_with_query_parameters() -> None:
     reason="Installed black doesn't support the old style",
 )
 def test_openapi_parser_with_include_path_parameters() -> None:
+    """Test parsing OpenAPI with included path parameters."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
         source=Path(DATA_PATH / "query_parameters.yaml"),
@@ -677,6 +710,7 @@ def test_openapi_parser_with_include_path_parameters() -> None:
 
 
 def test_parse_all_parameters_duplicate_names_exception() -> None:
+    """Test parsing parameters with duplicate names raises exception."""
     parser = OpenAPIParser("", include_path_parameters=True)
     parameters = [
         ParameterObject.parse_obj({"name": "duplicate_param", "in": "path", "schema": {"type": "string"}}),
@@ -694,6 +728,7 @@ def test_parse_all_parameters_duplicate_names_exception() -> None:
     reason="Require Pydantic version 2.0.0 or later ",
 )
 def test_openapi_parser_array_called_fields_with_one_of_items() -> None:
+    """Test parsing OpenAPI array fields with oneOf items."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelField,
         source=Path(DATA_PATH / "array_called_fields_with_oneOf_items.yaml"),
@@ -754,6 +789,7 @@ def test_no_additional_imports() -> None:
     ],
 )
 def test_parse_request_body_return(request_body_data: dict[str, Any], expected_type_hints: dict[str, str]) -> None:
+    """Test parsing request body returns correct type hints."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
         source="",
@@ -793,6 +829,7 @@ def test_parse_request_body_return(request_body_data: dict[str, Any], expected_t
     ],
 )
 def test_parse_all_parameters_return(parameters_data: list[dict[str, Any]], expected_type_hint: str | None) -> None:
+    """Test parsing parameters returns correct type hints."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
         source="",
@@ -856,6 +893,7 @@ def test_parse_responses_return(
     responses_data: dict[str, dict[str, Any]],
     expected_type_hints: dict[str, dict[str, str]],
 ) -> None:
+    """Test parsing responses returns correct type hints."""
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,
         source="",

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,3 +1,5 @@
+"""Tests for code formatting functionality."""
+
 from __future__ import annotations
 
 import sys
@@ -18,8 +20,7 @@ ADD_LICENSE_FORMATTER = "tests.data.python.custom_formatters.add_license"
 
 
 def test_python_version() -> None:
-    """Ensure that the python version used for the tests is properly listed"""
-
+    """Ensure that the python version used for the tests is properly listed."""
     _ = PythonVersion("{}.{}".format(*sys.version_info[:2]))
 
 
@@ -36,6 +37,7 @@ def test_format_code_with_skip_string_normalization(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Test code formatting with skip string normalization option."""
     monkeypatch.chdir(tmp_path)
     formatter = CodeFormatter(PythonVersionMin, skip_string_normalization=skip_string_normalization)
 
@@ -45,6 +47,7 @@ def test_format_code_with_skip_string_normalization(
 
 
 def test_format_code_un_exist_custom_formatter() -> None:
+    """Test error when custom formatter module doesn't exist."""
     with pytest.raises(ModuleNotFoundError):
         _ = CodeFormatter(
             PythonVersionMin,
@@ -53,6 +56,7 @@ def test_format_code_un_exist_custom_formatter() -> None:
 
 
 def test_format_code_invalid_formatter_name() -> None:
+    """Test error when custom formatter has no CodeFormatter class."""
     with pytest.raises(NameError):
         _ = CodeFormatter(
             PythonVersionMin,
@@ -61,6 +65,7 @@ def test_format_code_invalid_formatter_name() -> None:
 
 
 def test_format_code_is_not_subclass() -> None:
+    """Test error when custom formatter doesn't inherit CustomCodeFormatter."""
     with pytest.raises(TypeError):
         _ = CodeFormatter(
             PythonVersionMin,
@@ -69,6 +74,7 @@ def test_format_code_is_not_subclass() -> None:
 
 
 def test_format_code_with_custom_formatter_without_kwargs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test custom formatter that doesn't require kwargs."""
     monkeypatch.chdir(tmp_path)
     formatter = CodeFormatter(
         PythonVersionMin,
@@ -81,6 +87,7 @@ def test_format_code_with_custom_formatter_without_kwargs(tmp_path: Path, monkey
 
 
 def test_format_code_with_custom_formatter_with_kwargs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test custom formatter with kwargs."""
     monkeypatch.chdir(tmp_path)
     formatter = CodeFormatter(
         PythonVersionMin,
@@ -103,6 +110,7 @@ y = 2
 
 
 def test_format_code_with_two_custom_formatters(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test chaining multiple custom formatters."""
     monkeypatch.chdir(tmp_path)
     formatter = CodeFormatter(
         PythonVersionMin,
@@ -129,6 +137,7 @@ y = 2
 
 
 def test_format_code_ruff_format_formatter() -> None:
+    """Test ruff format formatter."""
     formatter = CodeFormatter(
         PythonVersionMin,
         formatters=[Formatter.RUFF_FORMAT],
@@ -142,6 +151,7 @@ def test_format_code_ruff_format_formatter() -> None:
 
 
 def test_format_code_ruff_check_formatter() -> None:
+    """Test ruff check formatter with auto-fix."""
     formatter = CodeFormatter(
         PythonVersionMin,
         formatters=[Formatter.RUFF_CHECK],

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,3 +1,5 @@
+"""Tests for import management functionality."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -24,7 +26,6 @@ if TYPE_CHECKING:
 )
 def test_dump(inputs: Sequence[tuple[str | None, str]], value: str) -> None:
     """Test creating import lines."""
-
     imports = Imports()
     imports.append(Import(from_=from_, import_=import_) for from_, import_ in inputs)
 

--- a/tests/test_infer_input_type.py
+++ b/tests/test_infer_input_type.py
@@ -1,3 +1,5 @@
+"""Tests for input type inference functionality."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -10,6 +12,8 @@ DATA_PATH: Path = Path(__file__).parent / "data"
 
 
 def test_infer_input_type() -> None:
+    """Test automatic input type detection for various file formats."""
+
     def assert_infer_input_type(file: Path, raw_data_type: InputFileType) -> None:
         __tracebackhide__ = True
         if file.is_dir():

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -1,3 +1,5 @@
+"""Tests for main CLI functionality with Korean locale settings."""
+
 from __future__ import annotations
 
 import shutil
@@ -24,6 +26,7 @@ TIMESTAMP = "1985-10-26T01:21:00-07:00"
 
 @pytest.fixture(autouse=True)
 def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset argument namespace before each test."""
     namespace_ = Namespace(no_color=False)
     monkeypatch.setattr("datamodel_code_generator.__main__.namespace", namespace_)
     monkeypatch.setattr("datamodel_code_generator.arguments.namespace", namespace_)
@@ -31,6 +34,7 @@ def reset_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @freeze_time("2019-07-26")
 def test_main(tmp_path: Path) -> None:
+    """Test basic main function with OpenAPI input."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -44,6 +48,7 @@ def test_main(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_main_base_class(tmp_path: Path) -> None:
+    """Test main function with custom base class."""
     output_file: Path = tmp_path / "output.py"
     shutil.copy(DATA_PATH / "pyproject.toml", tmp_path / "pyproject.toml")
     return_code: Exit = main([
@@ -60,6 +65,7 @@ def test_main_base_class(tmp_path: Path) -> None:
 
 @freeze_time("2019-07-26")
 def test_target_python_version(tmp_path: Path) -> None:
+    """Test main function with target Python version."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -85,7 +91,6 @@ def test_main_modular(tmp_path: Path) -> None:
 
 def test_main_modular_no_file() -> None:
     """Test main function on modular file with no output name."""
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
 
     assert main(["--input", str(input_filename)]) == Exit.ERROR
@@ -93,7 +98,6 @@ def test_main_modular_no_file() -> None:
 
 def test_main_modular_filename(tmp_path: Path) -> None:
     """Test main function on modular file with filename."""
-
     input_filename = OPEN_API_DATA_PATH / "modular.yaml"
     output_filename = tmp_path / "model.py"
 
@@ -101,8 +105,8 @@ def test_main_modular_filename(tmp_path: Path) -> None:
 
 
 def test_main_no_file(capsys: pytest.CaptureFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.chdir(tmp_path)
     """Test main function on non-modular file with no output name."""
+    monkeypatch.chdir(tmp_path)
 
     input_filename = OPEN_API_DATA_PATH / "api.yaml"
 
@@ -118,8 +122,8 @@ def test_main_no_file(capsys: pytest.CaptureFixture, tmp_path: Path, monkeypatch
 def test_main_custom_template_dir(
     capsys: pytest.CaptureFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.chdir(tmp_path)
     """Test main function with custom template directory."""
+    monkeypatch.chdir(tmp_path)
 
     input_filename = OPEN_API_DATA_PATH / "api.yaml"
     custom_template_dir = DATA_PATH / "templates"
@@ -146,6 +150,7 @@ def test_main_custom_template_dir(
 )
 @freeze_time("2019-07-26")
 def test_pyproject(tmp_path: Path) -> None:
+    """Test main function with pyproject.toml configuration."""
     pyproject_toml = DATA_PATH / "project" / "pyproject.toml"
     shutil.copy(pyproject_toml, tmp_path)
     output_file: Path = tmp_path / "output.py"
@@ -161,6 +166,7 @@ def test_pyproject(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("language", ["UK", "US"])
 def test_pyproject_respects_both_spellings_of_capitalize_enum_members_flag(language: str, tmp_path: Path) -> None:
+    """Test that both UK and US spellings of capitalise are accepted."""
     pyproject_toml_data = f"""
 [tool.datamodel-codegen]
 capitali{"s" if language == "UK" else "z"}e-enum-members = true
@@ -227,9 +233,7 @@ class MyEnum(Enum):
 )
 @freeze_time("2019-07-26")
 def test_pyproject_with_tool_section(tmp_path: Path) -> None:
-    """Test that a pyproject.toml with a [tool.datamodel-codegen] section is
-    found and its configuration applied.
-    """
+    """Test that a pyproject.toml with [tool.datamodel-codegen] section is found and applied."""
     pyproject_toml = """
 [tool.datamodel-codegen]
 target-python-version = "3.10"
@@ -255,6 +259,7 @@ strict-types = ["str"]
 
 @freeze_time("2019-07-26")
 def test_main_use_schema_description(tmp_path: Path) -> None:
+    """Test --use-schema-description option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -269,6 +274,7 @@ def test_main_use_schema_description(tmp_path: Path) -> None:
 
 @freeze_time("2022-11-11")
 def test_main_use_field_description(tmp_path: Path) -> None:
+    """Test --use-field-description option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -283,6 +289,7 @@ def test_main_use_field_description(tmp_path: Path) -> None:
 
 @freeze_time("2022-11-11")
 def test_main_use_inline_field_description(tmp_path: Path) -> None:
+    """Test --use-inline-field-description option."""
     output_file: Path = tmp_path / "output.py"
     return_code: Exit = main([
         "--input",
@@ -296,10 +303,7 @@ def test_main_use_inline_field_description(tmp_path: Path) -> None:
 
 
 def test_capitalise_enum_members(tmp_path: Path) -> None:
-    """capitalise-enum-members not working since v0.28.5
-
-    From https://github.com/koxudaxi/datamodel-code-generator/issues/2370
-    """
+    """Test capitalise-enum-members option (issue #2370)."""
     input_data = """
 openapi: 3.0.3
 info:
@@ -354,10 +358,7 @@ class EnumSystems(Enum):
 
 
 def test_capitalise_enum_members_and_use_subclass_enum(tmp_path: Path) -> None:
-    """Combination of capitalise-enum-members and use-subclass-enum not working since v0.28.5
-
-    From https://github.com/koxudaxi/datamodel-code-generator/issues/2395
-    """
+    """Test combination of capitalise-enum-members and use-subclass-enum (issue #2395)."""
     input_data = """
 openapi: 3.0.3
 info:

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,3 +1,5 @@
+"""Tests for reference resolution functionality."""
+
 from __future__ import annotations
 
 from pathlib import PurePosixPath, PureWindowsPath
@@ -22,6 +24,7 @@ from datamodel_code_generator.reference import ModelResolver, get_relative_path
     ],
 )
 def test_get_relative_path_posix(base_path: str, target_path: str, expected: str) -> None:
+    """Test get_relative_path function on POSIX paths."""
     assert PurePosixPath(get_relative_path(PurePosixPath(base_path), PurePosixPath(target_path))) == PurePosixPath(
         expected
     )
@@ -42,24 +45,28 @@ def test_get_relative_path_posix(base_path: str, target_path: str, expected: str
     ],
 )
 def test_get_relative_path_windows(base_path: str, target_path: str, expected: str) -> None:
+    """Test get_relative_path function on Windows paths."""
     assert PureWindowsPath(
         get_relative_path(PureWindowsPath(base_path), PureWindowsPath(target_path))
     ) == PureWindowsPath(expected)
 
 
 def test_model_resolver_add_ref_with_hash() -> None:
+    """Test adding reference with URL fragment."""
     model_resolver = ModelResolver()
     reference = model_resolver.add_ref("https://json-schema.org/draft/2020-12/meta/core#")
     assert reference.original_name == "core"
 
 
 def test_model_resolver_add_ref_without_hash() -> None:
+    """Test adding reference without URL fragment."""
     model_resolver = ModelResolver()
     reference = model_resolver.add_ref("meta/core")
     assert reference.original_name == "core"
 
 
 def test_model_resolver_add_ref_unevaluated() -> None:
+    """Test adding reference for unevaluated schema."""
     model_resolver = ModelResolver()
     reference = model_resolver.add_ref("meta/unevaluated")
     assert reference.original_name == "unevaluated"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,3 +1,5 @@
+"""Tests for field name resolver functionality."""
+
 from __future__ import annotations
 
 import pytest
@@ -14,5 +16,6 @@ from datamodel_code_generator.reference import FieldNameResolver
     ],
 )
 def test_get_valid_field_name(name: str, expected_resolved: str) -> None:
+    """Test field name resolution to valid Python identifiers."""
     resolver = FieldNameResolver()
     assert expected_resolved == resolver.get_valid_name(name)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,3 +1,5 @@
+"""Tests for type manipulation utilities."""
+
 from __future__ import annotations
 
 import pytest
@@ -40,6 +42,7 @@ from datamodel_code_generator.types import _remove_none_from_union, get_optional
     ],
 )
 def test_get_optional_type(input_: str, use_union_operator: bool, expected: str) -> None:
+    """Test get_optional_type function with various type strings."""
     assert get_optional_type(input_, use_union_operator) == expected
 
 
@@ -128,4 +131,5 @@ def test_get_optional_type(input_: str, use_union_operator: bool, expected: str)
     ],
 )
 def test_remove_none_from_union(type_str: str, use_union_operator: bool, expected: str) -> None:
+    """Test _remove_none_from_union function with various type strings."""
     assert _remove_none_from_union(type_str, use_union_operator=use_union_operator) == expected


### PR DESCRIPTION
I've decided to require minimal docstrings to lower the barrier for contributors.
Since ruff checks for this, any new functions need at least a one-line PEP 257 compliant docstring.