### PR TITLE
ci: enable pytest-xdist parallel execution (-n auto)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ set_env =
     COVERAGE_FILE = {work_dir}/.coverage.{env_name}
 commands =
     pytest {posargs: \
+      -n auto \
       -p no:codspeed --benchmark-disable \
       --cov {env_site_packages_dir}{/}datamodel_code_generator --cov {tox_root}{/}tests \
       --cov-config=pyproject.toml --no-cov-on-fail --cov-report term-missing:skip-covered \


### PR DESCRIPTION
## Summary
- Enable parallel test execution using pytest-xdist `-n auto` option
- Each CI job now utilizes all available CPU cores