### PR TITLE
Fix: Add pragma no cover for legacy version compatibility code in format.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ pkg-meta = [ "check-wheel-contents>=0.6.1", "twine>=6.1", "uv>=0.5.22" ]
 coverage = [
   "covdefaults>=2.3",
   "coverage[toml]>=7.6.1",
-  "diff-cover>=7.7",
+  "diff-cover>=9.7.2",
 ]
 
 [tool.hatch]

--- a/src/datamodel_code_generator/format.py
+++ b/src/datamodel_code_generator/format.py
@@ -131,8 +131,7 @@ def black_find_project_root(sources: Sequence[Path]) -> Path:
     project_root = _find_project_root(tuple(str(s) for s in sources))
     if isinstance(project_root, tuple):
         return project_root[0]
-    # pragma: no cover
-    return project_root
+    return project_root  # pragma: no cover
 
 
 class Formatter(Enum):
@@ -215,7 +214,7 @@ class CodeFormatter:
         if known_third_party:
             self.isort_config_kwargs["known_third_party"] = known_third_party
 
-        if isort.__version__.startswith("4."):
+        if isort.__version__.startswith("4."):  # pragma: no cover
             self.isort_config = None
         else:
             self.isort_config = isort.Config(settings_path=self.settings_path, **self.isort_config_kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -1257,13 +1257,13 @@ black24 = [{ name = "black", specifier = "==24.1" }]
 coverage = [
     { name = "covdefaults", specifier = ">=2.3" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },
-    { name = "diff-cover", specifier = ">=7.7" },
+    { name = "diff-cover", specifier = ">=9.7.2" },
 ]
 dev = [
     { name = "check-wheel-contents", specifier = ">=0.6.1" },
     { name = "covdefaults", specifier = ">=2.3" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },
-    { name = "diff-cover", specifier = ">=7.7" },
+    { name = "diff-cover", specifier = ">=9.7.2" },
     { name = "freezegun" },
     { name = "inline-snapshot", specifier = ">=0.31.1" },
     { name = "mkdocs", specifier = ">=1.6" },
@@ -1304,7 +1304,7 @@ pydantic1 = [{ name = "pydantic", specifier = "<2" }]
 test = [
     { name = "covdefaults", specifier = ">=2.3" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },
-    { name = "diff-cover", specifier = ">=7.7" },
+    { name = "diff-cover", specifier = ">=9.7.2" },
     { name = "freezegun" },
     { name = "inline-snapshot", specifier = ">=0.31.1" },
     { name = "pytest", specifier = ">=6.1" },
@@ -1321,7 +1321,7 @@ test = [
 type = [
     { name = "covdefaults", specifier = ">=2.3" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.1" },
-    { name = "diff-cover", specifier = ">=7.7" },
+    { name = "diff-cover", specifier = ">=9.7.2" },
     { name = "freezegun" },
     { name = "inline-snapshot", specifier = ">=0.31.1" },
     { name = "pyright", specifier = ">=1.1.393" },


### PR DESCRIPTION
## Summary
- Fix `# pragma: no cover` placement for legacy black version handling
- Add `# pragma: no cover` for isort v4 compatibility code
- Update diff-cover minimum version to 9.7.2