### PR TITLE
Resolve $ref to locally defined $id without network access

### DIFF
--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -2015,8 +2015,7 @@ class JsonSchemaParser(Parser):
 
         # https://swagger.io/docs/specification/using-ref/
         ref = self.model_resolver.resolve_ref(object_ref)
-        if get_ref_type(object_ref) == JSONReference.LOCAL:
-            # Local Reference: $ref: '#/definitions/myElement'
+        if get_ref_type(object_ref) == JSONReference.LOCAL or get_ref_type(ref) == JSONReference.LOCAL:
             self.reserved_refs[tuple(self.model_resolver.current_root)].add(ref)
             return reference
         if self.model_resolver.is_after_load(ref):

--- a/src/datamodel_code_generator/reference.py
+++ b/src/datamodel_code_generator/reference.py
@@ -567,6 +567,18 @@ class ModelResolver:  # noqa: PLR0904
             ):
                 ref = f"{self.root_id_base_path}/{ref}"
 
+        if is_url(ref):
+            file_part, path_part = ref.split("#", 1)
+            id_scope = "/".join(self.current_root)
+            scoped_ids = self.ids[id_scope]
+            if file_part in scoped_ids:
+                mapped_ref = scoped_ids[file_part]
+                if path_part:
+                    mapped_base, mapped_fragment = mapped_ref.split("#", 1) if "#" in mapped_ref else (mapped_ref, "")
+                    combined_fragment = f"{mapped_fragment.rstrip('/')}/{path_part.lstrip('/')}"
+                    return f"{mapped_base}#{combined_fragment}"
+                return mapped_ref
+
         if self.base_url:
             from .http import join_url  # noqa: PLC0415
 


### PR DESCRIPTION
 ## Summary
- Fix `$ref` resolution to check locally defined `$id` in `$defs` before attempting network requests
- Resolve URL-style `$ref` (e.g., `https://schemas.example.org/child`) against local `$id` mappings, avoiding unnecessary network access
- Preserve JSON Pointer empty tokens (`//`) when combining fragments

Fixes #1747
