### PR TITLE
Fix Python 3.9 compatibility regression in _scc.py

### DIFF
--- a/src/datamodel_code_generator/parser/_scc.py
+++ b/src/datamodel_code_generator/parser/_scc.py
@@ -7,7 +7,9 @@ circular import patterns in generated code.
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import NamedTuple, TypeAlias
+from typing import NamedTuple
+
+from typing_extensions import TypeAlias
 
 ModulePath: TypeAlias = tuple[str, ...]
 ModuleGraph: TypeAlias = dict[ModulePath, set[ModulePath]]


### PR DESCRIPTION
 ## Summary
- Fix `ImportError` when importing `TypeAlias` from `typing` module on Python 3.9
- `TypeAlias` was introduced in Python 3.10, so use `typing_extensions` for backward compatibility

Fixes https://github.com/koxudaxi/datamodel-code-generator/issues/2627