### PR TITLE
Fix extra blank line after custom file header with future imports

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -779,7 +779,7 @@ def generate(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915
                 if header_after:
                     content = header_before + "\n" + extracted_future + "\n\n" + header_after
                 else:
-                    content = header_before + "\n\n\n" + extracted_future
+                    content = header_before + "\n\n" + extracted_future
                 print(content, file=file)
                 print(file=file)
                 print(body_without_future.rstrip(), file=file)

--- a/tests/data/expected/main/openapi/custom_file_header.py
+++ b/tests/data/expected/main/openapi/custom_file_header.py
@@ -2,7 +2,6 @@
 # header ;
 # file ;
 
-
 from __future__ import annotations
 
 from typing import List, Optional

--- a/tests/data/expected/main/openapi/custom_file_header_comments_only.py
+++ b/tests/data/expected/main/openapi/custom_file_header_comments_only.py
@@ -1,7 +1,6 @@
 # Just a comment
 # Another comment
 
-
 from __future__ import annotations
 
 from typing import List, Optional

--- a/tests/data/expected/main/openapi/custom_file_header_with_docstring.py
+++ b/tests/data/expected/main/openapi/custom_file_header_with_docstring.py
@@ -3,7 +3,6 @@
 This module contains generated models.
 """
 
-
 from __future__ import annotations
 
 from typing import List, Optional

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/__init__.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/__init__.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from ._internal import DifferentTea, Error, Id, OptionalModel, Result, Source

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/_internal.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/_internal.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from typing import List, Optional

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/bar.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/bar.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from pydantic import BaseModel, Field

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/collections.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/collections.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from enum import Enum

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/foo/__init__.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/foo/__init__.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from .._internal import Cocoa, Tea

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/foo/bar.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/foo/bar.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/models.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/models.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from enum import Enum

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/nested/foo.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/nested/foo.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from .._internal import ListModel

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/woo/__init__.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/woo/__init__.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from .boo import Chocolate

--- a/tests/data/expected/main/openapi/modular_all_exports_children_docstring/woo/boo.py
+++ b/tests/data/expected/main/openapi/modular_all_exports_children_docstring/woo/boo.py
@@ -4,7 +4,6 @@ Custom module docstring header.
 This is a multi-line docstring used for testing.
 """
 
-
 from __future__ import annotations
 
 from typing import Optional


### PR DESCRIPTION
 ## Summary
  - Fix extra blank line being inserted between custom file header and `from __future__ import` statement
  - Bug was introduced in #2589 where `"\n\n\n"` (3 newlines = 2 blank lines) was used instead of `"\n\n"` (2 newlines = 1 blank line)
