### PR TITLE
docs: Clarify default encoding behavior in documentation

### DIFF
--- a/docs/cli-reference/model-customization.md
+++ b/docs/cli-reference/model-customization.md
@@ -4008,7 +4008,7 @@ The `--target-python-version` flag controls Python version-specific syntax:
 
 This affects import statements and type annotation syntax in generated code.
 
-**See also:** [Python Version Compatibility](../python-version-compatibility.md), [CI/CD Integration](../ci-cd.md), [Output Model Types](../what_is_the_difference_between_v1_and_v2.md)
+**See also:** [Output Model Types](../what_is_the_difference_between_v1_and_v2.md), [CI/CD Integration](../ci-cd.md), [Python Version Compatibility](../python-version-compatibility.md)
 
 !!! tip "Usage"
 

--- a/docs/cli-reference/template-customization.md
+++ b/docs/cli-reference/template-customization.md
@@ -2208,7 +2208,7 @@ the generated Python code. Available formatters are: black, isort,
 ruff, yapf, autopep8, autoflake. Default is [black, isort].
 Use this to customize formatting or disable formatters entirely.
 
-**See also:** [Code Formatting](../formatting.md), [CI/CD Integration](../ci-cd.md)
+**See also:** [CI/CD Integration](../ci-cd.md), [Code Formatting](../formatting.md)
 
 !!! tip "Usage"
 


### PR DESCRIPTION
Fixes: #339