### PR TITLE
fix: Update zensical dependency version to 0.0.13 for Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ type = [
   { include-group = "test" },
 ]
 docs = [
-  "zensical>=0.0.11; python_version>='3.10'",
+  "zensical>=0.0.13; python_version>='3.10'",
 ]
 black22 = [ "black==22.1" ]
 black23 = [ "black==23.12" ]

--- a/uv.lock
+++ b/uv.lock
@@ -987,9 +987,9 @@ dev = [
     { name = "types-toml" },
     { name = "uv", specifier = ">=0.5.22" },
     { name = "watchfiles", specifier = ">=1.1" },
-    { name = "zensical", marker = "python_full_version >= '3.10'", specifier = ">=0.0.11" },
+    { name = "zensical", marker = "python_full_version >= '3.10'", specifier = ">=0.0.13" },
 ]
-docs = [{ name = "zensical", marker = "python_full_version >= '3.10'", specifier = ">=0.0.11" }]
+docs = [{ name = "zensical", marker = "python_full_version >= '3.10'", specifier = ">=0.0.13" }]
 fix = [{ name = "pre-commit-uv", specifier = ">=4.1.4" }]
 isort5 = [{ name = "isort", specifier = ">=5,<6" }]
 isort6 = [{ name = "isort", specifier = ">=6,<7" }]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated zensical dependency minimum version from 0.0.11 to 0.0.13 for Python 3.10+ in documentation configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->