### PR TITLE
fix: update expected files to use modern union type syntax (`str | None`)

### DIFF
--- a/docs/cli-reference/field-customization.md
+++ b/docs/cli-reference/field-customization.md
@@ -1885,15 +1885,13 @@ With this flag, only Python-safe names are used without aliases.
         
         from __future__ import annotations
         
-        from typing import Optional
-        
         from pydantic import BaseModel, Field
         
         
         class Person(BaseModel):
             first_name: str = Field(..., alias='first-name')
             last_name: str = Field(..., alias='last-name')
-            email_address: Optional[str] = None
+            email_address: str | None = None
         ```
 
 ---

--- a/docs/cli-reference/general-options.md
+++ b/docs/cli-reference/general-options.md
@@ -1661,14 +1661,12 @@ testing without project configuration.
         
         from __future__ import annotations
         
-        from typing import Optional
-        
         from pydantic import BaseModel, Field
         
         
         class Model(BaseModel):
-            first_name: Optional[str] = Field(None, alias='firstName')
-            last_name: Optional[str] = Field(None, alias='lastName')
+            first_name: str | None = Field(None, alias='firstName')
+            last_name: str | None = Field(None, alias='lastName')
         ```
 
 ---

--- a/docs/cli-reference/template-customization.md
+++ b/docs/cli-reference/template-customization.md
@@ -174,15 +174,13 @@ headers, or other metadata to generated files.
         
         from __future__ import annotations
         
-        from typing import Optional
-        
         from pydantic import BaseModel, Field
         
         
         class Person(BaseModel):
             first_name: str = Field(..., alias='first-name')
             last_name: str = Field(..., alias='last-name')
-            email_address: Optional[str] = None
+            email_address: str | None = None
         ```
 
 ---

--- a/tests/data/expected/main_kr/custom_file_header/without_option.py
+++ b/tests/data/expected/main_kr/custom_file_header/without_option.py
@@ -4,12 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
 class Person(BaseModel):
     first_name: str = Field(..., alias='first-name')
     last_name: str = Field(..., alias='last-name')
-    email_address: Optional[str] = None
+    email_address: str | None = None

--- a/tests/data/expected/main_kr/custom_formatters_kwargs/output.py
+++ b/tests/data/expected/main_kr/custom_formatters_kwargs/output.py
@@ -4,12 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel
 
 
 class Pet(BaseModel):
-    id: Optional[int] = None
-    name: Optional[str] = None
-    tag: Optional[str] = None
+    id: int | None = None
+    name: str | None = None
+    tag: str | None = None

--- a/tests/data/expected/main_kr/ignore_pyproject/without_option.py
+++ b/tests/data/expected/main_kr/ignore_pyproject/without_option.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
 class Model(BaseModel):
-    first_name: Optional[str] = Field(None, alias='firstName')
-    last_name: Optional[str] = Field(None, alias='lastName')
+    first_name: str | None = Field(None, alias='firstName')
+    last_name: str | None = Field(None, alias='lastName')

--- a/tests/data/expected/main_kr/no_alias/without_option.py
+++ b/tests/data/expected/main_kr/no_alias/without_option.py
@@ -4,12 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
 class Person(BaseModel):
     first_name: str = Field(..., alias='first-name')
     last_name: str = Field(..., alias='last-name')
-    email_address: Optional[str] = None
+    email_address: str | None = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples to reflect modern Python type annotation syntax using PEP 604 union types (`str | None`) instead of the older `Optional[str]` format.

* **Refactor**
  * Modernized type annotations throughout generated models to use union type syntax, improving consistency with current Python best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->