### PR TITLE
Add schema path context to error messages

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -390,6 +390,29 @@ class InvalidFileFormatError(Error):
         super().__init__(message=message)
 
 
+class SchemaParseError(Error):
+    """Raised when an error occurs during schema parsing with path context."""
+
+    def __init__(
+        self,
+        message: str,
+        path: list[str] | None = None,
+        original_error: Exception | None = None,
+    ) -> None:
+        """Initialize with message, schema path, and optional original error."""
+        self.path = path or []
+        self.original_error = original_error
+        full_message = self._format_message(message)
+        super().__init__(message=full_message)
+
+    def _format_message(self, message: str) -> str:
+        """Format message with schema path context."""
+        if self.path:
+            path_str = "/".join(self.path)
+            return f"Error at schema path '{path_str}': {message}"
+        return message
+
+
 def get_first_file(path: Path) -> Path:  # pragma: no cover
     """Find and return the first file in a path (file or directory)."""
     if path.is_file():
@@ -996,6 +1019,7 @@ __all__ = [
     "NamingStrategy",
     "PythonVersion",
     "ReadOnlyWriteOnlyModelType",
+    "SchemaParseError",
     "TargetPydanticVersion",
     "generate",
 ]


### PR DESCRIPTION
Fixes: #1330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when schema parsing fails by including the schema path location, simplifying debugging and error identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->