### PR TITLE
Use UTF-8 as default encoding instead of locale-preferred

### DIFF
--- a/src/datamodel_code_generator/arguments.py
+++ b/src/datamodel_code_generator/arguments.py
@@ -8,7 +8,6 @@ template customization, OpenAPI-specific options, and general options.
 from __future__ import annotations
 
 import json
-import locale
 from argparse import ArgumentParser, ArgumentTypeError, BooleanOptionalAction, Namespace, RawDescriptionHelpFormatter
 from operator import attrgetter
 from pathlib import Path
@@ -40,7 +39,7 @@ if TYPE_CHECKING:
     from argparse import Action
     from collections.abc import Iterable
 
-DEFAULT_ENCODING = locale.getpreferredencoding()
+DEFAULT_ENCODING = "utf-8"
 
 namespace = Namespace(no_color=False)
 


### PR DESCRIPTION
Fixes: #1805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed encoding handling to consistently use UTF-8 across all systems, eliminating potential encoding inconsistencies caused by varying system locale settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->