### PR TITLE
Add input_model field support to cli_doc marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,12 @@ import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, Required, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
 
 import pytest
 import time_machine
 from inline_snapshot import external_file, register_format_alias
+from typing_extensions import Required
 
 from datamodel_code_generator import MIN_VERSION
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an `input_model` field as an accepted alternative in CLI documentation markers.
  * Validation now enforces `module:name` formatting for `input_model` when provided.

* **Tests**
  * Strengthened marker validation and updated error messages to reflect the new `input_model` requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->