### PR TITLE
Add missing path and ulid type mappings to TypedDict type manager

### DIFF
--- a/src/datamodel_code_generator/model/types.py
+++ b/src/datamodel_code_generator/model/types.py
@@ -62,12 +62,14 @@ def type_map_factory(data_type: type[DataType]) -> dict[Types, DataType]:
         Types.uuid3: data_type_str,
         Types.uuid4: data_type_str,
         Types.uuid5: data_type_str,
+        Types.ulid: data_type_str,
         Types.uri: data_type_str,
         Types.hostname: data_type_str,
         Types.ipv4: data_type_str,
         Types.ipv6: data_type_str,
         Types.ipv4_network: data_type_str,
         Types.ipv6_network: data_type_str,
+        Types.path: data_type_str,
         Types.boolean: data_type(type="bool"),
         Types.object: data_type.from_import(IMPORT_ANY, is_dict=True),
         Types.null: data_type(type="None"),
@@ -151,4 +153,10 @@ class DataTypeManager(_DataTypeManager):
         **_: Any,
     ) -> DataType:
         """Get data type for schema type."""
-        return self.type_map[types]
+        if types in self.type_map:
+            return self.type_map[types]
+        msg = (
+            f"Type mapping for {types.name!r} not implemented. "
+            f"Please report this at https://github.com/koxudaxi/datamodel-code-generator/issues"
+        )
+        raise NotImplementedError(msg)

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -426,3 +426,23 @@ def test_inline_field_docstring_escapes_triple_quotes() -> None:
         use_inline_field_description=True,
     )
     assert field.inline_field_docstring == r'"""Contains \"\"\"quotes\"\"\""""'
+
+
+def test_data_type_manager_unknown_type_raises_error() -> None:
+    """Test DataTypeManager raises NotImplementedError for unknown types."""
+    from datamodel_code_generator.model.types import DataTypeManager
+
+    manager = DataTypeManager()
+    del manager.type_map[Types.path]
+
+    with pytest.raises(NotImplementedError, match="Type mapping for 'path' not implemented"):
+        manager.get_data_type(Types.path)
+
+
+def test_data_type_manager_has_all_types() -> None:
+    """Test DataTypeManager has mappings for all Types enum members."""
+    from datamodel_code_generator.model.types import DataTypeManager
+
+    manager = DataTypeManager()
+    missing_types = [t for t in Types if t not in manager.type_map]
+    assert not missing_types, f"Missing type mappings: {[t.name for t in missing_types]}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ULID and path schema types.

* **Bug Fixes**
  * Improved error handling for unsupported data types with clear, actionable error messages.

* **Tests**
  * Added test coverage for error handling when data types are not implemented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->