### PR TITLE
Preserve Python types (Set, Mapping, Sequence) in --input-model

### DIFF
--- a/tests/data/python/input_model/dataclass_models.py
+++ b/tests/data/python/input_model/dataclass_models.py
@@ -1,6 +1,10 @@
 """Dataclass models for --input-model tests."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import FrozenSet, Set
 
 
 @dataclass
@@ -9,3 +13,13 @@ class User:
 
     name: str
     age: int
+
+
+@dataclass
+class DataclassWithPythonTypes:
+    """Dataclass with types that need x-python-type preservation."""
+
+    tags: Set[str]
+    frozen_tags: FrozenSet[int]
+    metadata: Mapping[str, int]
+    items: Sequence[str]

--- a/tests/data/python/input_model/pydantic_models.py
+++ b/tests/data/python/input_model/pydantic_models.py
@@ -1,5 +1,10 @@
 """Pydantic models for --input-model tests."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import FrozenSet, Optional, Set
+
 from pydantic import BaseModel
 
 
@@ -8,3 +13,29 @@ class User(BaseModel):
 
     name: str
     age: int
+
+
+class Tag(BaseModel):
+    """Nested model for testing x-python-type with nested models."""
+
+    values: FrozenSet[str]
+
+
+class ModelWithPythonTypes(BaseModel):
+    """Model with types that need x-python-type preservation."""
+
+    tags: Set[str]
+    frozen_tags: FrozenSet[int]
+    metadata: Mapping[str, int]
+    items: Sequence[str]
+    nested_mapping: Mapping[str, Set[int]]
+    tag_obj: Tag
+    nested_in_list: list[Set[int]]
+    optional_set: Optional[Set[str]]
+
+
+class RecursiveNode(BaseModel):
+    """Recursive model for testing cycle detection."""
+
+    value: Set[str]
+    children: Optional[list[RecursiveNode]] = None

--- a/tests/test_input_model.py
+++ b/tests/test_input_model.py
@@ -459,3 +459,100 @@ def test_input_model_module_import_error(
         capsys=capsys,
         expected_stderr_contains="Cannot import module",
     )
+
+
+# ============================================================================
+# x-python-type preservation tests
+# ============================================================================
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_preserves_set_type(tmp_path: Path) -> None:
+    """Test that Set[T] is preserved when converting Pydantic model."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["set[str]", "tags:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_preserves_frozenset_type(tmp_path: Path) -> None:
+    """Test that FrozenSet[T] is preserved when converting Pydantic model."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["frozenset[int]", "frozen_tags:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_preserves_mapping_type(tmp_path: Path) -> None:
+    """Test that Mapping[K, V] is preserved when converting Pydantic model."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Mapping[str, int]", "metadata:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_preserves_sequence_type(tmp_path: Path) -> None:
+    """Test that Sequence[T] is preserved when converting Pydantic model."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Sequence[str]", "items:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_preserves_nested_model_types(tmp_path: Path) -> None:
+    """Test that types in nested models are also preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["frozenset[str]", "values:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_x_python_type_to_typeddict(tmp_path: Path) -> None:
+    """Test that x-python-type works when outputting to TypedDict."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        extra_args=["--output-model-type", "typing.TypedDict"],
+        expected_output_contains=["TypedDict", "set[str]", "Mapping[str, int]"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_x_python_type_to_dataclass(tmp_path: Path) -> None:
+    """Test that x-python-type works when outputting to dataclass."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        extra_args=["--output-model-type", "dataclasses.dataclass"],
+        expected_output_contains=["@dataclass", "set[str]", "Mapping[str, int]"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_dataclass_with_python_types(tmp_path: Path) -> None:
+    """Test that Set/Mapping types are preserved from dataclass input."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.dataclass_models:DataclassWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["set[str]", "frozenset[int]", "Mapping[str, int]", "Sequence[str]"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_recursive_model_types(tmp_path: Path) -> None:
+    """Test that recursive models handle x-python-type correctly."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:RecursiveNode",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["set[str]", "value:"],
+    )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated models now preserve Python complex types (Set, FrozenSet, Mapping, Sequence) from JSON Schema definitions, improving code fidelity and preventing type information loss during conversion.

* **Tests**
  * Added comprehensive test coverage for type preservation across multiple output formats, nested models, and recursive structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->