### PR TITLE
Fix x-python-type for Optional container types in anyOf schemas

### DIFF
--- a/tests/data/python/input_model/pydantic_models.py
+++ b/tests/data/python/input_model/pydantic_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import FrozenSet, Optional, Set
+from typing import FrozenSet, Optional, Set, Union
 
 from pydantic import BaseModel
 
@@ -32,6 +32,7 @@ class ModelWithPythonTypes(BaseModel):
     tag_obj: Tag
     nested_in_list: list[Set[int]]
     optional_set: Optional[Set[str]]
+    nullable_frozenset: Union[None, FrozenSet[str]]
 
 
 class RecursiveNode(BaseModel):

--- a/tests/test_input_model.py
+++ b/tests/test_input_model.py
@@ -559,3 +559,34 @@ def test_input_model_recursive_model_types(tmp_path: Path) -> None:
         output_path=tmp_path / "output.py",
         expected_output_contains=["set[str]", "value:"],
     )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_optional_set_type(tmp_path: Path) -> None:
+    """Test that Optional[Set[str]] is preserved when converting Pydantic model."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["set[str] | None", "optional_set:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_optional_set_to_typeddict(tmp_path: Path) -> None:
+    """Test that Optional[Set[str]] works when outputting to TypedDict."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        extra_args=["--output-model-type", "typing.TypedDict"],
+        expected_output_contains=["TypedDict", "set[str] | None", "optional_set:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_union_none_frozenset(tmp_path: Path) -> None:
+    """Test that Union[None, FrozenSet[str]] is preserved (container not first arg)."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["frozenset[str] | None", "nullable_frozenset:"],
+    )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Union and Optional types when processing Python input models, ensuring more accurate type preservation for complex generic types like Optional[Set] and Union[None, FrozenSet].

* **Tests**
  * Added test coverage for Python type preservation with Union and Optional types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->