### PR TITLE
Handle types.UnionType in _serialize_python_type for Python 3.10-3.13

### DIFF
--- a/tests/data/python/input_model/pydantic_models.py
+++ b/tests/data/python/input_model/pydantic_models.py
@@ -33,6 +33,7 @@ class ModelWithPythonTypes(BaseModel):
     nested_in_list: list[Set[int]]
     optional_set: Optional[Set[str]]
     nullable_frozenset: Union[None, FrozenSet[str]]
+    optional_mapping: Mapping[str, str] | None
 
 
 class RecursiveNode(BaseModel):

--- a/tests/test_input_model.py
+++ b/tests/test_input_model.py
@@ -590,3 +590,17 @@ def test_input_model_union_none_frozenset(tmp_path: Path) -> None:
         output_path=tmp_path / "output.py",
         expected_output_contains=["frozenset[str] | None", "nullable_frozenset:"],
     )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_optional_mapping_union_syntax(tmp_path: Path) -> None:
+    """Test that Mapping[str, str] | None using | syntax is preserved correctly.
+
+    In Python 3.10-3.13, get_origin(X | Y) returns types.UnionType.
+    This test verifies that types.UnionType is handled correctly in those versions.
+    """
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithPythonTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Mapping[str, str] | None", "optional_mapping:"],
+    )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved serialization to properly support Python 3.10–3.13 native union type syntax (X | Y) for better type representation.
  * Enhanced optional mapping type handling by supporting modern union syntax while maintaining backward compatibility with older Python versions.

* **Tests**
  * Added test coverage to validate proper preservation and handling of union syntax in optional mapping type scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->