### PR TITLE
Fix set/frozenset duplicate output in x-python-type serialization

### DIFF
--- a/src/datamodel_code_generator/__main__.py
+++ b/src/datamodel_code_generator/__main__.py
@@ -608,8 +608,8 @@ def _init_preserved_type_origins() -> dict[type, str]:
     from collections.abc import Set as AbstractSet  # noqa: PLC0415
 
     return {
-        set: "Set",
-        frozenset: "FrozenSet",
+        set: "set",
+        frozenset: "frozenset",
         AbstractSet: "AbstractSet",
         ABCMutableSet: "MutableSet",
         ABCMapping: "Mapping",

--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -1287,7 +1287,9 @@ class JsonSchemaParser(Parser):
 
         type_to_flag: dict[str, dict[str, bool]] = {
             "Set": {"is_set": True},
+            "set": {"is_set": True},
             "FrozenSet": {"is_frozen_set": True},
+            "frozenset": {"is_frozen_set": True},
             "Mapping": {"is_mapping": True},
             "MutableMapping": {"is_mapping": True},
             "Sequence": {"is_sequence": True},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added proper support for lowercase Python container type aliases (set, frozenset) in JSON Schema parsing and type serialization.
  * Improved type origin mapping to handle both lowercase and capitalized versions of Python type names.
  * Enhanced compatibility with various Python type naming conventions in generated schemas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->