### PR TITLE
Add automatic handling of unserializable types in --input-model

### DIFF
--- a/tests/data/expected/main/jsonschema/x_python_type_no_schema_type.py
+++ b/tests/data/expected/main/jsonschema/x_python_type_no_schema_type.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from collections.abc import Callable
+from typing import TypedDict
 
 from typing_extensions import NotRequired
 
 
 class Model(TypedDict):
-    callback: NotRequired[Any]
+    callback: NotRequired[Callable[[str], str]]

--- a/tests/data/python/input_model/pydantic_models.py
+++ b/tests/data/python/input_model/pydantic_models.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import FrozenSet, Optional, Set, Union
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, FrozenSet, Optional, Set, Type, Union
 
 from pydantic import BaseModel
 
@@ -41,3 +41,48 @@ class RecursiveNode(BaseModel):
 
     value: Set[str]
     children: Optional[list[RecursiveNode]] = None
+
+
+class ModelWithCallableTypes(BaseModel):
+    """Model with Callable and other unserializable types."""
+
+    callback: Callable[[str], str]
+    multi_param_callback: Callable[[int, int], bool]
+    variadic_callback: Callable[..., Any]
+    no_param_callback: Callable[[], None]
+    optional_callback: Callable[[str], str] | None
+    type_field: Type[BaseModel]
+    nested_callable: list[Callable[[str], int]]
+
+
+class NestedCallableModel(BaseModel):
+    """Model with nested Callable types for $defs coverage."""
+
+    handler: Callable[[str], int]
+
+
+class ModelWithNestedCallable(BaseModel):
+    """Model referencing another model with Callable to test $defs processing."""
+
+    nested: NestedCallableModel
+    own_callback: Callable[[int], str]
+
+
+class CustomClass:
+    """Custom class for testing handle_invalid_for_json_schema."""
+
+    pass
+
+
+class ModelWithCustomClass(BaseModel):
+    """Model with a custom class that triggers handle_invalid_for_json_schema."""
+
+    model_config = {"arbitrary_types_allowed": True}
+    custom_obj: CustomClass
+
+
+class ModelWithUnionCallable(BaseModel):
+    """Model with Union of Callable and other types to test Union serialization."""
+
+    union_callback: Union[Callable[[str], str], int]
+    raw_callable: Callable  # Callable without type args

--- a/tests/test_input_model.py
+++ b/tests/test_input_model.py
@@ -607,6 +607,123 @@ def test_input_model_optional_mapping_union_syntax(tmp_path: Path) -> None:
 
 
 # ============================================================================
+# Callable and unserializable type tests
+# ============================================================================
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_callable_basic(tmp_path: Path) -> None:
+    """Test that Callable[[str], str] is preserved when converting Pydantic model."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Callable[[str], str]", "callback:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_callable_multi_param(tmp_path: Path) -> None:
+    """Test that Callable[[int, int], bool] is preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Callable[[int, int], bool]", "multi_param_callback:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_callable_variadic(tmp_path: Path) -> None:
+    """Test that Callable[..., Any] is preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Callable[..., Any]", "variadic_callback:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_callable_no_param(tmp_path: Path) -> None:
+    """Test that Callable[[], None] is preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Callable[[], None]", "no_param_callback:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_callable_optional(tmp_path: Path) -> None:
+    """Test that Callable[[str], str] | None is preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Callable[[str], str] | None", "optional_callback:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_type_field(tmp_path: Path) -> None:
+    """Test that Type[BaseModel] is preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["Type[pydantic.main.BaseModel]", "type_field:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_nested_callable(tmp_path: Path) -> None:
+    """Test that list[Callable[[str], int]] is preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=["list[Callable[[str], int]]", "nested_callable:"],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_nested_model_with_callable(tmp_path: Path) -> None:
+    """Test that nested models with Callable types in $defs are processed."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithNestedCallable",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=[
+            "Callable[[str], int]",
+            "Callable[[int], str]",
+            "NestedCallableModel",
+        ],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_custom_class(tmp_path: Path) -> None:
+    """Test that custom classes trigger handle_invalid_for_json_schema."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithCustomClass",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=[
+            "CustomClass",
+            "custom_obj:",
+        ],
+    )
+
+
+@SKIP_PYDANTIC_V1
+def test_input_model_union_callable(tmp_path: Path) -> None:
+    """Test that Union[Callable, int] and raw Callable are preserved."""
+    run_input_model_and_assert(
+        input_model="tests.data.python.input_model.pydantic_models:ModelWithUnionCallable",
+        output_path=tmp_path / "output.py",
+        expected_output_contains=[
+            "Callable[[str], str] | int",
+            "union_callback:",
+            "Callable",
+            "raw_callable:",
+        ],
+    )
+
+
+# ============================================================================
 # --input-model-ref-strategy tests
 # ============================================================================
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced input-model feature to properly preserve and serialize complex Python typing annotations, including Callable signatures and Type references, in generated schemas.

* **Tests**
  * Added extensive test coverage for various Callable patterns, Type fields, nested callables, and union types in input-model processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->