### PR TITLE
Fix reuse-model generating type aliases instead of class inheritance

### DIFF
--- a/src/datamodel_code_generator/model/template/pydantic_v2/BaseModel.jinja2
+++ b/src/datamodel_code_generator/model/template/pydantic_v2/BaseModel.jinja2
@@ -1,11 +1,3 @@
-{% if base_class != "BaseModel" and "," not in base_class and not fields and not config and not description -%}
-
-{# if this is just going to be `class Foo(Bar): pass`, then might as well just make Foo
-an alias for Bar: every pydantic model class consumes considerable memory. #}
-{{ class_name }} = {{ base_class }}
-
-{% else -%}
-
 {% for decorator in decorators -%}
 {{ decorator }}
 {% endfor -%}
@@ -53,5 +45,3 @@ class {{ class_name }}({{ base_class }}):{% if comment is defined %}  # {{ comme
     {{ method }}
 {%- endfor -%}
 {%- endfor -%}
-
-{%- endif %}

--- a/tests/data/expected/main/json/json_reuse_model_pydantic2.py
+++ b/tests/data/expected/main/json/json_reuse_model_pydantic2.py
@@ -13,7 +13,8 @@ class ArmRight(BaseModel):
     Joint_3: int = Field(..., alias='Joint 3')
 
 
-ArmLeft = ArmRight
+class ArmLeft(ArmRight):
+    pass
 
 
 class Head(BaseModel):

--- a/tests/data/expected/main/jsonschema/allof_root_model_constraints_merge_pydantic_v2.py
+++ b/tests/data/expected/main/jsonschema/allof_root_model_constraints_merge_pydantic_v2.py
@@ -94,7 +94,8 @@ class ObjectNoPropsDatatype(BaseModel):
     pass
 
 
-RefToObjectNoPropsAllOf = ObjectNoPropsDatatype
+class RefToObjectNoPropsAllOf(ObjectNoPropsDatatype):
+    pass
 
 
 class PatternPropsDatatype(RootModel[dict[constr(pattern=r'^S_'), str]]):
@@ -109,7 +110,8 @@ class NestedAllOfDatatype(BaseModel):
     pass
 
 
-RefToNestedAllOfAllOf = NestedAllOfDatatype
+class RefToNestedAllOfAllOf(NestedAllOfDatatype):
+    pass
 
 
 class ConstraintsOnlyDatatype(RootModel[Any]):


### PR DESCRIPTION
Fixes: #2639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type alias generation to produce explicit subclass declarations instead of simple aliases in generated models, improving type identity handling and compatibility with type checkers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->