### PR TITLE
Fix x-python-type qualified name imports

### DIFF
--- a/tests/test_input_model.py
+++ b/tests/test_input_model.py
@@ -663,11 +663,15 @@ def test_input_model_callable_optional(tmp_path: Path) -> None:
 
 @SKIP_PYDANTIC_V1
 def test_input_model_type_field(tmp_path: Path) -> None:
-    """Test that Type[BaseModel] is preserved."""
+    """Test that Type[BaseModel] is preserved with proper import."""
     run_input_model_and_assert(
         input_model="tests.data.python.input_model.pydantic_models:ModelWithCallableTypes",
         output_path=tmp_path / "output.py",
-        expected_output_contains=["Type[pydantic.main.BaseModel]", "type_field:"],
+        expected_output_contains=[
+            "Type[BaseModel]",
+            "type_field:",
+            "from pydantic.main import BaseModel",
+        ],
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of fully qualified and nested class paths in Python type overrides so imports and type resolution are generated properly for qualified types.
* **Tests**
  * Updated tests to expect preserved type annotations with proper imports (e.g., Type[BaseModel]) and corresponding import assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->