### PR TITLE
fix: handle type definitions from grand(grand...) parent schemas

### DIFF
--- a/tests/data/expected/main/openapi/allof_partial_override_array_items.py
+++ b/tests/data/expected/main/openapi/allof_partial_override_array_items.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 
-class Thing(BaseModel):
+class Entity(BaseModel):
+    type_list: list[str] | None = None
+
+
+class Thing(Entity):
     type: str | None = 'playground:Thing'
     type_list: list[str] | None = ['playground:Thing']
 

--- a/tests/data/openapi/allof_partial_override_array_items.yaml
+++ b/tests/data/openapi/allof_partial_override_array_items.yaml
@@ -1,7 +1,16 @@
 openapi: "3.0.0"
 components:
   schemas:
+    Entity:
+      type: object
+      properties:
+        type_list:
+          type: array
+          items:
+            type: string
     Thing:
+      allOf:
+        - $ref: "#/components/schemas/Entity"
       type: object
       properties:
         type:
@@ -12,7 +21,7 @@ components:
           default:
             - playground:Thing
           items:
-            type: string
+            title: A type entry (default playground:Thing)
     Person:
       allOf:
         - $ref: "#/components/schemas/Thing"
@@ -24,4 +33,4 @@ components:
               default:
                 - playground:Person
               items:
-                title: A type entry
+                title: A type entry (default playground:Person)


### PR DESCRIPTION
+ update related tests for Entity and Thing schemas

Handles the edge case where an array item schema gets annotated in a grand(-grand) child schema, see:
https://github.com/koxudaxi/datamodel-code-generator/issues/2087#issuecomment-3652683512
https://github.com/koxudaxi/datamodel-code-generator/issues/2087#issuecomment-3694907209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced field type resolution for inherited properties in JSON Schema parsing, ensuring correct type determination through multi-level inheritance hierarchies.

* **Tests**
  * Updated test fixtures to reflect improved handling of class inheritance and field resolution in generated code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->