### PR TITLE
Fix pre-commit hooks and pytest for Windows environments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,13 @@ repos:
   hooks:
   - id: readme
     name: Update README command help
-    entry: bash -c 'test -x .tox/fix/bin/python || tox run -e fix --notest -qq; .tox/fix/bin/python scripts/update_command_help_on_markdown.py'
+    entry: bash -c '[ -x .tox/fix/bin/python ] && PYTHON=.tox/fix/bin/python || PYTHON=.tox/fix/Scripts/python; test -x "$PYTHON" || tox run -e fix --notest -qq; "$PYTHON" scripts/update_command_help_on_markdown.py'
     language: system
     files: ^(src/datamodel_code_generator/arguments\.py|README\.md|docs/index\.md)$
     pass_filenames: false
   - id: config-types
     name: Generate config TypedDicts
-    entry: bash -c 'test -x .tox/dev/bin/python || tox run -e dev --notest -qq; .tox/dev/bin/datamodel-codegen --profile generate-config-dict && .tox/dev/bin/datamodel-codegen --profile parser-config-dict && .tox/dev/bin/datamodel-codegen --profile parse-config-dict'
+    entry: bash -c '[ -x .tox/dev/bin/python ] && PREFIX=.tox/dev/bin || PREFIX=.tox/dev/Scripts; test -x "$PREFIX/python" || tox run -e dev --notest -qq; "$PREFIX/datamodel-codegen" --profile generate-config-dict && "$PREFIX/datamodel-codegen" --profile parser-config-dict && "$PREFIX/datamodel-codegen" --profile parse-config-dict'
     language: system
     files: ^src/datamodel_code_generator/config\.py$
     pass_filenames: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -470,7 +470,8 @@ def _assert_with_external_file(content: str, expected_path: Path) -> None:
             msg = f"Content mismatch for {expected_path}\n{hint}\n{diff}"
             raise AssertionError(msg) from None
     else:
-        assert expected == normalized_content  # pragma: no cover
+        # we need to normalize the external_file object's content as well
+        assert _normalize_line_endings(expected._load_value()) == normalized_content  # pragma: no cover
 
 
 class AssertFileContent(Protocol):


### PR DESCRIPTION
Related PRs: https://github.com/koxudaxi/datamodel-code-generator/pull/2869