### PR TITLE
Fix _normalize_union_str to handle nested generic types

### DIFF
--- a/docs/cli-reference/model-customization.md
+++ b/docs/cli-reference/model-customization.md
@@ -1368,11 +1368,15 @@ model types (Pydantic v1/v2, dataclass, TypedDict, msgspec) handle const fields.
             
             from __future__ import annotations
             
+            from typing import Literal
+            
             from pydantic import BaseModel, Field
             
             
             class Api(BaseModel):
-                version: str = Field('v1', const=True, description='The version of this API')
+                version: Literal['v1'] = Field(
+                    'v1', const=True, description='The version of this API'
+                )
             ```
 
         === "Pydantic v2"

--- a/docs/cli-reference/template-customization.md
+++ b/docs/cli-reference/template-customization.md
@@ -2553,11 +2553,15 @@ helps maintain consistency with codebases that prefer double-quote formatting.
     
     from __future__ import annotations
     
+    from typing import Literal
+    
     from pydantic import BaseModel, Field, confloat
     
     
     class MapState1(BaseModel):
-        map_view_mode: str = Field("MODE_2D", alias="mapViewMode", const=True)
+        map_view_mode: Literal["MODE_2D"] = Field(
+            "MODE_2D", alias="mapViewMode", const=True
+        )
     
     
     class MapState2(BaseModel):
@@ -2567,8 +2571,10 @@ helps maintain consistency with codebases that prefer double-quote formatting.
         bearing: Bearing | None = None
         pitch: Pitch
         drag_rotate: DragRotate | None = Field(None, alias="dragRotate")
-        map_split_mode: str = Field("SWIPE_COMPARE", alias="mapSplitMode", const=True)
-        is_split: bool = Field(True, alias="isSplit", const=True)
+        map_split_mode: Literal["SWIPE_COMPARE"] = Field(
+            "SWIPE_COMPARE", alias="mapSplitMode", const=True
+        )
+        is_split: Literal[True] = Field(True, alias="isSplit", const=True)
     
     
     class MapState3(BaseModel):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples for model and template customization to use literal constant types for fixed fields and adjusted example imports accordingly.
* **Tests**
  * Enhanced test utilities for parsing union-type expressions to handle nested and complex union forms more reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->