### PR TITLE
Use class-name-suffix for parser config TypedDicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,7 @@ input-model = [
   "src/datamodel_code_generator/config.py:OpenAPIParserConfig",
 ]
 output = "src/datamodel_code_generator/_types/parser_config_dicts.py"
+class-name-suffix = "Dict"
 
 [tool.datamodel-codegen.profiles.parse-config-dict]
 extends = "config-types-base"

--- a/src/datamodel_code_generator/_types/__init__.py
+++ b/src/datamodel_code_generator/_types/__init__.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from datamodel_code_generator._types.generate_config_dict import GenerateConfigDict
 from datamodel_code_generator._types.parse_config_dict import ParseConfigDict
 from datamodel_code_generator._types.parser_config_dicts import (
-    GraphQLParserConfig as GraphQLParserConfigDict,
-    JSONSchemaParserConfig as JSONSchemaParserConfigDict,
-    OpenAPIParserConfig as OpenAPIParserConfigDict,
-    ParserConfig as ParserConfigDict,
+    GraphQLParserConfigDict,
+    JSONSchemaParserConfigDict,
+    OpenAPIParserConfigDict,
+    ParserConfigDict,
 )
 
 __all__ = [

--- a/src/datamodel_code_generator/_types/parser_config_dicts.py
+++ b/src/datamodel_code_generator/_types/parser_config_dicts.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from datamodel_code_generator.types import DataTypeManager
 
 
-class ParserConfig(TypedDict):
+class ParserConfigDict(TypedDict):
     data_model_type: NotRequired[type[DataModel]]
     data_model_root_type: NotRequired[type[DataModel]]
     data_type_manager_type: NotRequired[type[DataTypeManager]]
@@ -149,19 +149,19 @@ class ParserConfig(TypedDict):
     target_pydantic_version: NotRequired[TargetPydanticVersion | None]
 
 
-class GraphQLParserConfig(ParserConfig):
+class GraphQLParserConfigDict(ParserConfigDict):
     data_model_scalar_type: NotRequired[type[DataModel]]
     data_model_union_type: NotRequired[type[DataModel]]
 
 
-class JSONSchemaParserConfig(ParserConfig):
+class JSONSchemaParserConfigDict(ParserConfigDict):
     pass
 
 
-class OpenAPIParserConfig(JSONSchemaParserConfig):
+class OpenAPIParserConfigDict(JSONSchemaParserConfigDict):
     openapi_scopes: NotRequired[list[OpenAPIScope] | None]
     include_path_parameters: NotRequired[bool]
     use_status_code_in_response_name: NotRequired[bool]
 
 
-Model: TypeAlias = ParserConfig | GraphQLParserConfig | JSONSchemaParserConfig | OpenAPIParserConfig
+ModelDict: TypeAlias = ParserConfigDict | GraphQLParserConfigDict | JSONSchemaParserConfigDict | OpenAPIParserConfigDict


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated naming conventions for internal parser configuration classes and introduced a new configuration parameter to customize generated class name suffixes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->