### PR TITLE
Add deprecation warning for default output-model-type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ skip = '.git,*.lock,tests,docs/cli-reference,CHANGELOG.md,docs/changelog.md'
 filterwarnings = [
   "error",
   "ignore:^.*Pydantic v1 runtime support is deprecated.*:DeprecationWarning",
+  "ignore:^.*No --output-model-type specified.*:DeprecationWarning",
   "ignore:^.*`--validation` option is deprecated.*",
   "ignore:^.*--parent-scoped-naming is deprecated.*",
   "ignore:^.*Field name `name` is duplicated on Pet.*",

--- a/src/datamodel_code_generator/__main__.py
+++ b/src/datamodel_code_generator/__main__.py
@@ -1193,6 +1193,22 @@ def main(args: Sequence[str] | None = None) -> Exit:  # noqa: PLR0911, PLR0912, 
     if config.disable_warnings:
         warnings.simplefilter("ignore")
 
+    if (
+        namespace.output_model_type is None
+        and pyproject_config.get("output_model_type") is None
+        and config.output_model_type == DataModelType.PydanticBaseModel
+    ):
+        warnings.warn(
+            "No --output-model-type specified. "
+            "The current default (pydantic.BaseModel, Pydantic v1) is deprecated "
+            "and will be removed in a future version. "
+            "Please explicitly specify --output-model-type. "
+            "Example: --output-model-type pydantic_v2.BaseModel. "
+            "See https://github.com/koxudaxi/datamodel-code-generator/issues/2466",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
     if not is_pydantic_v2():
         warnings.warn(
             "Pydantic v1 runtime support is deprecated and will be removed in a future version. "


### PR DESCRIPTION
Fixes: #2466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation warning when output model type is not explicitly specified in configuration, encouraging users to explicitly set this option. Test suite updated to handle this new warning appropriately.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->