### PR TITLE
Separate pytest-benchmark into dedicated benchmark dependency group

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --group benchmark
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,6 @@ test = [
   "msgspec>=0.18",
   "pytest>=6.1",
   "pytest>=8.3.4",
-  "pytest-benchmark",
-  "pytest-codspeed>=2.2",
   "pytest-cov>=2.12.1",
   "pytest-cov>=5",
   "pytest-mock>=3.14",
@@ -105,6 +103,10 @@ type = [
 ]
 docs = [
   "zensical>=0.0.15; python_version>='3.10'",
+]
+benchmark = [
+  "pytest-benchmark",
+  "pytest-codspeed>=2.2",
 ]
 black22 = [ "black==22.1" ]
 black23 = [ "black==23.12" ]
@@ -230,7 +232,10 @@ filterwarnings = [
 ]
 norecursedirs = [ "tests/data/*", ".tox" ]
 verbosity_assertions = 2
-markers = [ "perf: marks tests as performance tests (excluded from CI benchmarks)" ]
+markers = [
+  "perf: marks tests as performance tests (excluded from CI benchmarks)",
+  "benchmark: marks tests as benchmark tests",
+]
 
 [tool.coverage]
 html.skip_covered = false

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ commands =
       parallel: -n auto \
       --color=yes \
       -m "not perf" \
-      -p no:codspeed --benchmark-disable \
       --cov {env_site_packages_dir}{/}datamodel_code_generator --cov {tox_root}{/}tests \
       --cov-config=pyproject.toml --cov-fail-under=0 --no-cov-on-fail --cov-report term-missing:skip-covered \
       --cov-report html:{env_tmp_dir}{/}htmlcov \
@@ -169,5 +168,7 @@ commands =
       --color=yes \
       --codspeed \
       tests/main/test_performance.py}
-dependency_groups = test
+dependency_groups =
+    test
+    benchmark
 platform = linux|darwin

--- a/uv.lock
+++ b/uv.lock
@@ -817,6 +817,10 @@ watch = [
 ]
 
 [package.dev-dependencies]
+benchmark = [
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
+]
 black22 = [
     { name = "black", version = "22.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
@@ -840,8 +844,6 @@ dev = [
     { name = "msgspec" },
     { name = "prek" },
     { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
@@ -886,8 +888,6 @@ test = [
     { name = "inline-snapshot" },
     { name = "msgspec" },
     { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
@@ -901,8 +901,6 @@ type = [
     { name = "inline-snapshot" },
     { name = "msgspec" },
     { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
@@ -945,6 +943,10 @@ requires-dist = [
 provides-extras = ["all", "debug", "graphql", "http", "ruff", "validation", "watch"]
 
 [package.metadata.requires-dev]
+benchmark = [
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed", specifier = ">=2.2" },
+]
 black22 = [{ name = "black", specifier = "==22.1" }]
 black23 = [{ name = "black", specifier = "==23.12" }]
 black24 = [{ name = "black", specifier = "==24.1" }]
@@ -963,8 +965,6 @@ dev = [
     { name = "prek", specifier = ">=0.2.22" },
     { name = "pytest", specifier = ">=6.1" },
     { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed", specifier = ">=2.2" },
     { name = "pytest-cov", specifier = ">=2.12.1" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-mock", specifier = ">=3.14" },
@@ -999,8 +999,6 @@ test = [
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pytest", specifier = ">=6.1" },
     { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed", specifier = ">=2.2" },
     { name = "pytest-cov", specifier = ">=2.12.1" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-mock", specifier = ">=3.14" },
@@ -1016,8 +1014,6 @@ type = [
     { name = "msgspec", specifier = ">=0.18" },
     { name = "pytest", specifier = ">=6.1" },
     { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed", specifier = ">=2.2" },
     { name = "pytest-cov", specifier = ">=2.12.1" },
     { name = "pytest-cov", specifier = ">=5" },
     { name = "pytest-mock", specifier = ">=3.14" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized benchmark testing dependencies into a dedicated dependency group
  * Updated CI/CD workflow to support benchmark test execution
  * Enabled benchmark tests in the project's test configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->