### PR TITLE
Ensure codecov upload runs even when coverage check fails

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -129,6 +129,7 @@ jobs:
           name: html-report
           path: .tox/htmlcov
       - name: Upload coverage to Codecov
+        if: success() || failure()
         uses: codecov/codecov-action@v5
         with:
           flags: unittests

--- a/tox.ini
+++ b/tox.ini
@@ -87,10 +87,10 @@ set_env =
     COVERAGE_FILE = {work_dir}/.coverage
 commands =
     coverage combine
-    coverage report --fail-under=100 --skip-covered --show-missing
     coverage xml -o {work_dir}/coverage.xml
     coverage html -d {work_dir}/htmlcov
     diff-cover --compare-branch {env:DIFF_AGAINST:origin/main} {work_dir}/coverage.xml
+    coverage report --fail-under=100 --skip-covered --show-missing
 depends =
     py314-parallel
     py313-parallel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to ensure coverage upload executes regardless of previous step outcomes.
  * Reordered test command execution sequence in the test configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->