### PR TITLE
fix(format): use communicate rathan than .stdin.write

### DIFF
--- a/src/datamodel_code_generator/format.py
+++ b/src/datamodel_code_generator/format.py
@@ -404,7 +404,7 @@ class CodeFormatter:
         )
         if check_proc.stdout:  # pragma: no branch
             check_proc.stdout.close()
-        check_proc.stdin.write(code.encode(self.encoding))  # type: ignore[union-attr]
+        check_proc.communicate(code.encode(self.encoding))
         check_proc.stdin.close()  # type: ignore[union-attr]
         stdout, _ = format_proc.communicate()
         check_proc.wait()


### PR DESCRIPTION
to avoid dealocks due to any of the other OS pipe buffers filling
up and blocking the child process

Example that hang:
```
import subprocess


def apply_ruff_check_and_format(code: str) -> str:
    """Run ruff check and format in a single pipeline for better performance."""
    check_proc = subprocess.Popen(  # noqa: S603
        ["ruff", "check", "--fix", "--unsafe-fixes", "-"],
        stdin=subprocess.PIPE,
        stdout=subprocess.PIPE,
        stderr=subprocess.PIPE,
    )
    format_proc = subprocess.Popen(  # noqa: S603
        ["ruff", "format", "-"],
        stdin=check_proc.stdout,
        stdout=subprocess.PIPE,
        stderr=subprocess.PIPE,
    )
    if check_proc.stdout:  # pragma: no branch
        check_proc.stdout.close()
    check_proc.stdin.write(code.encode("utf-8"))  # type: ignore[union-attr]
    check_proc.stdin.close()  # type: ignore[union-attr]
    stdout, _ = format_proc.communicate()
    check_proc.wait()
    return stdout.decode("utf-8")


if __name__ == "__main__":
    subprocess.run(["dd", "if=/dev/zero", "of=cactus.py", "bs=65000", "count=1"], check=True)
    with open('cactus.py', 'r') as f:
        code = "".join([line for line in f])
        apply_ruff_check_and_format(code)
``