### PR TITLE
fix: Apply enum default member conversion to Pydantic models

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -739,7 +739,7 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             else (LiteralType.All if config.output_model_type == DataModelType.TypingTypedDict else None)
         ),
         "set_default_enum_member": (
-            True if config.output_model_type in (DataModelType.DataclassesDataclass, DataModelType.PydanticBaseModel) else config.set_default_enum_member
+            True if config.output_model_type in (DataModelType.DataclassesDataclass, DataModelType.PydanticBaseModel, DataModelType.PydanticV2BaseModel) else config.set_default_enum_member
         ),
     }
 


### PR DESCRIPTION
## Problem

When processing OpenAPI schemas with enum fields that have default values, datamodel-codegen was not converting string literal defaults to enum member references for Pydantic models.

For example, given an OpenAPI schema:
```yaml
type: string
enum: [agent, human, service, device]
default: "agent"
```

It was generating:
```python
field: IdentityType | None = 'agent'  # Type mismatch - string instead of enum
```

This caused type-checking errors with Pyright/mypy because the default value type (string literal) didn't match the field type (Enum).

## Root Cause

The `set_default_enum_member` conversion was only applied to dataclass output models, not to Pydantic models. This was hardcoded in `/src/datamodel_code_generator/__init__.py` line 742.

## Solution

Extended the condition to also apply enum member conversion to Pydantic models:

**Before:**
\`\`\`python
\"set_default_enum_member\": (
    True if config.output_model_type == DataModelType.DataclassesDataclass else config.set_default_enum_member
),
\`\`\`

**After:**
\`\`\`python
\"set_default_enum_member\": (
    True if config.output_model_type in (DataModelType.DataclassesDataclass, DataModelType.PydanticBaseModel) else config.set_default_enum_member
),
\`\`\`

Now it correctly generates:
\`\`\`python
field: IdentityType | None = IdentityType.agent  # Correct!
\`\`\`

## Testing

This fix has been tested with OpenAPI schemas that include enum fields with defaults. The generated code now properly uses enum member references instead of string literals, resolving type-checking errors.

## Use Case

This is particularly important for enterprise APIs that define sensible defaults on enum fields (e.g., default severity level for audit logs, default identity type for authorization decisions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Default enum-member behavior now applies to additional output model formats, including Pydantic variants, ensuring consistent enum defaults across more generated model types and improving reliability of generated code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->