### PR TITLE
docs: remove final pydantic v1 traces

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -145,7 +145,7 @@ from model import Book
 response = {...}
 
 books = [
-    Book.parse_obj(book_raw) for book_raw in response["getAuthorBooks"]
+    Book.model_validate(book_raw) for book_raw in response["getAuthorBooks"]
 ]
 print(books)
 # [Book(author=Author(books=[], id='51341cdscwef14r13', name='J. K. Rowling', typename__='Author'), id='1321dfvrt211wdw', title='Harry Potter and the Prisoner of Azkaban', typename__='Book'), Book(author=Author(books=[], id='51341cdscwef14r13', name='J. K. Rowling', typename__='Author'), id='dvsmu12e19xmqacqw9', title='Fantastic Beasts: The Crimes of Grindelwald', typename__='Book')]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -24658,7 +24658,7 @@ from model import Book
 response = {...}
 
 books = [
-    Book.parse_obj(book_raw) for book_raw in response["getAuthorBooks"]
+    Book.model_validate(book_raw) for book_raw in response["getAuthorBooks"]
 ]
 print(books)
 # [Book(author=Author(books=[], id='51341cdscwef14r13', name='J. K. Rowling', typename__='Author'), id='1321dfvrt211wdw', title='Harry Potter and the Prisoner of Azkaban', typename__='Book'), Book(author=Author(books=[], id='51341cdscwef14r13', name='J. K. Rowling', typename__='Author'), id='dvsmu12e19xmqacqw9', title='Fantastic Beasts: The Crimes of Grindelwald', typename__='Book')]

--- a/src/datamodel_code_generator/input_model.py
+++ b/src/datamodel_code_generator/input_model.py
@@ -130,7 +130,7 @@ def _get_origin_name(origin: type) -> str:
 
 
 def _get_input_model_json_schema_class() -> type:
-    """Get the InputModelJsonSchema class (lazy import to avoid Pydantic v1 issues)."""
+    """Get the InputModelJsonSchema class lazily."""
     from pydantic.json_schema import GenerateJsonSchema  # noqa: PLC0415
 
     class InputModelJsonSchema(GenerateJsonSchema):

--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -204,7 +204,7 @@ class DataModelFieldBase(_BaseModel):
         """Check if field references its parent model.
 
         Result is cached after first call since parent is stable at render time.
-        Uses __dict__ for caching to avoid Pydantic v1 field assignment restrictions.
+        Uses __dict__ for caching to avoid Pydantic-managed field assignment.
         """
         if "_self_reference_cache" in self.__dict__:
             return self.__dict__["_self_reference_cache"]


### PR DESCRIPTION
## Summary
- replace the last `parse_obj()` example in GraphQL docs with `model_validate()`
- remove remaining Pydantic v1 mentions from internal comments
- sync `docs/llms-full.txt` with the GraphQL doc example

## Validation
- pre-commit hooks run on commit (`ruff`, `codespell`)
- no runtime behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GraphQL documentation examples to reflect current validation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->