### PR TITLE
Fix `--base-class-map` and `--enum-field-as-literal-map` long inline json support

### DIFF
--- a/src/datamodel_code_generator/arguments.py
+++ b/src/datamodel_code_generator/arguments.py
@@ -88,7 +88,18 @@ def _external_ref_mapping(value: str) -> str:
 def _json_value_or_file(value: str) -> dict[str, object]:
     """Parse a JSON value or load it from a JSON file path."""
     path = Path(value).expanduser()
-    if path.is_file():
+
+    # We need to suppress `path.is_file() OSError exception to align pathlib logic between Python<3.13 and Python>=3.14.
+    # Briefly:
+    #   - Python <= 3.13 raises OSError.
+    #   - Python >= 3.14 catches OSError and returns `false` instead.
+    is_file: bool
+    try:
+        is_file = path.is_file()
+    except OSError:
+        is_file = False
+
+    if is_file:
         try:
             json_input = path.read_text(encoding=DEFAULT_ENCODING)
         except (OSError, UnicodeDecodeError) as e:
@@ -96,6 +107,7 @@ def _json_value_or_file(value: str) -> dict[str, object]:
             raise ArgumentTypeError(msg) from e
     else:
         json_input = value
+
     try:
         result = json.loads(json_input)
     except json.JSONDecodeError as e:

--- a/src/datamodel_code_generator/arguments.py
+++ b/src/datamodel_code_generator/arguments.py
@@ -89,10 +89,10 @@ def _json_value_or_file(value: str) -> dict[str, object]:
     """Parse a JSON value or load it from a JSON file path."""
     path = Path(value).expanduser()
 
-    # We need to suppress `path.is_file() OSError exception to align pathlib logic between Python<3.13 and Python>=3.14.
-    # Briefly:
-    #   - Python <= 3.13 raises OSError.
-    #   - Python >= 3.14 catches OSError and returns `false` instead.
+    # In Python<=3.13, long json values would cause `path.is_file()` to raise an OSError exception
+    # because the string is too long to be interpreted as a filename.
+    # This changed in Python>=3.14 since now `path.is_file()` catches OSError and returns `false` instead.
+    # Therefore we are going to catch OSError exception raised in Python<=3.13 to replicate Python>=3.14 behavior.
     is_file: bool
     try:
         is_file = path.is_file()

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -4677,11 +4677,7 @@ def test_main_enum_field_as_literal_map_from_file(output_file: Path, tmp_path: P
 
 def test_main_enum_field_as_literal_map_long_json(output_file: Path) -> None:
     """Test enum_field_as_literal_map with very long json string."""
-    long_inline_mapping = (
-        '{"status": "literal",'
-        + ",".join(f'"unused_field_{i}": "enum"' for i in range(100))
-        + "}"
-    )
+    long_inline_mapping = '{"status": "literal",' + ",".join(f'"unused_field_{i}": "enum"' for i in range(100)) + "}"
     run_main_and_assert(
         input_path=JSON_SCHEMA_DATA_PATH / "enum_field_as_literal_map.json",
         output_path=output_file,

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools
 import json
 import os
 import tempfile
@@ -3139,6 +3140,21 @@ def test_main_jsonschema_base_class_map_empty_list(output_file: Path) -> None:
         extra_args=[
             "--base-class-map",
             '{"User": ["", ""]}',
+        ],
+    )
+
+
+def test_main_jsonschema_base_class_map_long_json(output_file: Path) -> None:
+    """Test base_class_map with very long json string."""
+    run_main_and_assert(
+        input_path=JSON_SCHEMA_DATA_PATH / "base_class_map_empty_list.json",
+        output_path=output_file,
+        input_file_type="jsonschema",
+        assert_func=assert_file_content,
+        expected_file="base_class_map_empty_list.py",
+        extra_args=[
+            "--base-class-map",
+            '{"User": [' + ",".join(itertools.repeat('""', 100)) + "]}",
         ],
     )
 

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -4675,6 +4675,26 @@ def test_main_enum_field_as_literal_map_from_file(output_file: Path, tmp_path: P
     )
 
 
+def test_main_enum_field_as_literal_map_long_json(output_file: Path) -> None:
+    """Test enum_field_as_literal_map with very long json string."""
+    long_inline_mapping = (
+        '{"status": "literal",'
+        + ",".join(f'"unused_field_{i}": "enum"' for i in range(100))
+        + "}"
+    )
+    run_main_and_assert(
+        input_path=JSON_SCHEMA_DATA_PATH / "enum_field_as_literal_map.json",
+        output_path=output_file,
+        input_file_type=None,
+        assert_func=assert_file_content,
+        expected_file="enum_field_as_literal_map.py",
+        extra_args=[
+            "--enum-field-as-literal-map",
+            long_inline_mapping,
+        ],
+    )
+
+
 def test_main_enum_field_as_literal_map_override_global(output_file: Path) -> None:
     """Test --enum-field-as-literal-map overrides global --enum-field-as-literal."""
     run_main_and_assert(


### PR DESCRIPTION
### Context

- `path.is_file()` was used to check whether a path is a file or not.
- When the path is too long, underlying `os.path.isfile()` function raises `OSError`.
- `path.is_file()` and similar functions behaves differently in different Python versions[^1]:
  - [Python <=3.13] `path.is_file()` propagate OSError.
  - [ Python >= 3.14] `path.is_file()` catches OSError and returns `false`.

### Consequence

- If a long inline json was provided, Python <= 3.13 would have raised an unhandled `OSError` exception creating a crash.

### Now

- We catch `OSError` to align `path.is_file()` behavior of Python <=3.13 with the one implemented by Python >= 3.14.
- We do not treat the value as a file path if `OSError` is raised by `path.is_file()`

### Note

- Reported in https://github.com/koxudaxi/datamodel-code-generator/pull/3071#issuecomment-4198270220

[^1]: https://docs.python.org/3/library/pathlib.html#querying-file-type-and-status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when detecting whether a JSON input is a file path: filesystem errors during path checks are now handled gracefully, treating the input as raw JSON to avoid crashes.

* **Tests**
  * Added tests covering very large inline JSON passed to the base-class-map option.
  * Added tests covering very large inline JSON passed to the enum-field-as-literal-map option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->