### PR TITLE
Fix release automation workflows

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -68,6 +68,7 @@ jobs:
           PATCH_PATH: ${{ runner.temp }}/changelog.patch
         run: |
           set -euo pipefail
+          git add --intent-to-add -- CHANGELOG.md
           if git diff --quiet -- CHANGELOG.md; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/config-types.yaml
+++ b/.github/workflows/config-types.yaml
@@ -2,35 +2,75 @@ name: Check config types
 
 on:
   push:
-    paths:
-      - 'src/datamodel_code_generator/config.py'
-      - 'src/datamodel_code_generator/_types/**'
-      - 'pyproject.toml'
-      - '.github/workflows/config-types.yaml'
   pull_request:
-    paths:
-      - 'src/datamodel_code_generator/config.py'
-      - 'src/datamodel_code_generator/_types/**'
-      - 'pyproject.toml'
-      - '.github/workflows/config-types.yaml'
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   config-types:
     runs-on: ubuntu-latest
     steps:
+      - name: Check config type inputs
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(gh api --paginate \
+              "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+              --jq '.[].filename')
+          elif [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            echo "needs_check=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            FILES=$(gh api \
+              "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
+              --jq '.files[].filename')
+          fi
+
+          NEEDS_CHECK=false
+          while IFS= read -r file; do
+            case "$file" in
+              src/datamodel_code_generator/config.py)
+                NEEDS_CHECK=true
+                ;;
+              src/datamodel_code_generator/_types/*)
+                NEEDS_CHECK=true
+                ;;
+              pyproject.toml)
+                NEEDS_CHECK=true
+                ;;
+              .github/workflows/config-types.yaml)
+                NEEDS_CHECK=true
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "needs_check=$NEEDS_CHECK" >> "$GITHUB_OUTPUT"
+
+      - name: Skip config type check
+        if: steps.changes.outputs.needs_check != 'true'
+        run: echo "No config type inputs changed."
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: steps.changes.outputs.needs_check == 'true'
         with:
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        if: steps.changes.outputs.needs_check == 'true'
         with:
           enable-cache: true
 
-      - run: uv python install 3.14
+      - if: steps.changes.outputs.needs_check == 'true'
+        run: uv python install 3.14
 
-      - run: uv tool install --python 3.14 tox --with tox-uv
+      - if: steps.changes.outputs.needs_check == 'true'
+        run: uv tool install --python 3.14 tox --with tox-uv
 
-      - run: tox -e config-types -- --check
+      - if: steps.changes.outputs.needs_check == 'true'
+        run: tox -e config-types -- --check

--- a/.github/workflows/config-types.yaml
+++ b/.github/workflows/config-types.yaml
@@ -27,9 +27,21 @@ jobs:
             echo "needs_check=true" >> "$GITHUB_OUTPUT"
             exit 0
           else
-            FILES=$(gh api \
-              "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
-              --jq '.files[].filename')
+            COMPARE_JSON=$(gh api \
+              "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}") || {
+              echo "compare API failed; running config-types check defensively."
+              echo "needs_check=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            }
+
+            FILE_COUNT=$(jq '.files | length' <<< "$COMPARE_JSON")
+            if [ "$FILE_COUNT" -ge 300 ]; then
+              echo "compare API may be truncated ($FILE_COUNT files); running config-types check defensively."
+              echo "needs_check=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            FILES=$(jq -r '.files[].filename' <<< "$COMPARE_JSON")
           fi
 
           NEEDS_CHECK=false

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -110,7 +110,7 @@ jobs:
     permissions:
       contents: write
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Download analysis artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -147,14 +147,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "breaking-change-analyzed"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" \
+            -f labels[]="breaking-change-analyzed" \
+            --silent
 
       - name: Add breaking-change label if applicable
         if: steps.analysis.outputs.has_breaking_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "breaking-change"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" \
+            -f labels[]="breaking-change" \
+            --silent
 
       - name: Post analysis result to PR
         env:
@@ -165,7 +175,8 @@ jobs:
         run: |
           # Use temp file to avoid shell escaping issues with special characters
           TMPFILE=$(mktemp)
-          trap 'rm -f "$TMPFILE"' EXIT
+          TMPJSON=$(mktemp)
+          trap 'rm -f "$TMPFILE" "$TMPJSON"' EXIT
 
           # Build comment using printf to avoid YAML parsing issues with markdown
           {
@@ -182,7 +193,14 @@ jobs:
             printf '*This analysis was performed by Claude Code Action*\n'
           } > "$TMPFILE"
 
-          gh pr comment ${{ github.event.pull_request.number }} --body-file "$TMPFILE"
+          jq -n --rawfile body "$TMPFILE" '{body: $body}' > "$TMPJSON"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/comments" \
+            --input "$TMPJSON" \
+            --silent
 
       - name: Calculate version and update draft release
         env:
@@ -193,7 +211,7 @@ jobs:
           set -euo pipefail
 
           # Get latest published release tag and strip "v" prefix if present
-          LATEST_TAG_RAW=$(gh release list --limit 1 --exclude-drafts --json tagName --jq '.[0].tagName // "0.0.0"')
+          LATEST_TAG_RAW=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 1 --exclude-drafts --json tagName --jq '.[0].tagName // "0.0.0"')
           LATEST_TAG="${LATEST_TAG_RAW#v}"
           LATEST_TAG="${LATEST_TAG#V}"
           echo "Latest published tag: $LATEST_TAG_RAW (parsed as: $LATEST_TAG)"
@@ -213,7 +231,7 @@ jobs:
 
           # Check if draft release exists (use jq to extract first draft tag safely)
           # Keep raw tag name for gh commands, strip prefix only for version comparison
-          DRAFT_TAG_RAW=$(gh release list --json tagName,isDraft --jq '[.[] | select(.isDraft == true)] | .[0].tagName // ""')
+          DRAFT_TAG_RAW=$(gh release list --repo "$GITHUB_REPOSITORY" --json tagName,isDraft --jq '[.[] | select(.isDraft == true)] | .[0].tagName // ""')
           DRAFT_TAG="${DRAFT_TAG_RAW#v}"
           DRAFT_TAG="${DRAFT_TAG#V}"
           BC_SOURCE_TAG_RAW="$DRAFT_TAG_RAW"
@@ -274,7 +292,7 @@ jobs:
           # Get existing draft body if updating (only if DRAFT_TAG_RAW is set, meaning we're updating same version)
           EXISTING_BC=""
           if [ -n "$BC_SOURCE_TAG_RAW" ]; then
-            EXISTING_BODY=$(gh release view "$BC_SOURCE_TAG_RAW" --json body --jq '.body // ""')
+            EXISTING_BODY=$(gh release view "$BC_SOURCE_TAG_RAW" --repo "$GITHUB_REPOSITORY" --json body --jq '.body // ""')
             # Extract existing Breaking Changes section content
             # Use awk for precise extraction - stops at any ## header that's not "## Breaking Changes"
             if echo "$EXISTING_BODY" | grep -q '^## Breaking Changes$'; then
@@ -336,19 +354,21 @@ jobs:
           if [ -n "$DRAFT_TAG_RAW" ] && [ "$DRAFT_TAG" = "$NEXT_VERSION" ]; then
             echo "Updating existing draft release: $DRAFT_TAG_RAW"
             echo "$RELEASE_BODY" | gh release edit "$DRAFT_TAG_RAW" \
+              --repo "$GITHUB_REPOSITORY" \
               --title "$NEXT_VERSION" \
               --notes-file -
           else
             echo "Creating new draft release: $NEXT_VERSION"
             # Create new draft first, then delete old one (to prevent data loss)
             if echo "$RELEASE_BODY" | gh release create "$NEXT_VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
               --title "$NEXT_VERSION" \
               --notes-file - \
               --draft; then
               # Only delete old draft after successful creation
               if [ -n "$OLD_DRAFT_TAG" ]; then
                 echo "Deleting old draft: $OLD_DRAFT_TAG"
-                gh release delete "$OLD_DRAFT_TAG" --yes 2>/dev/null || true
+                gh release delete "$OLD_DRAFT_TAG" --repo "$GITHUB_REPOSITORY" --yes 2>/dev/null || true
               fi
             else
               echo "Failed to create new draft release"

--- a/.github/workflows/release-notify.yaml
+++ b/.github/workflows/release-notify.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       TARGET_OWNER: koxudaxi
       TARGET_REPO: datamodel-code-generator


### PR DESCRIPTION
## Summary
- Pass `--repo "$GITHUB_REPOSITORY"` to release draft `gh` commands that run without checkout
- Use REST Issues APIs for release-draft PR labels and comments instead of GraphQL-backed `gh pr`/`gh issue` helpers
- Restore `pull-requests: write` where release automation needs to comment on merged PRs
- Detect newly-created `CHANGELOG.md` files when building the changelog patch
- Always report the required `config-types` status, using a no-op success when config type inputs did not change

## Checks
- `ruby -e 'require "yaml"; %w[.github/workflows/config-types.yaml .github/workflows/changelog.yaml .github/workflows/release-notify.yaml .github/workflows/release-draft.yaml].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- `git diff --check`
- `tox -e config-types -- --check`
- local changelog patch simulation with `git add --intent-to-add -- CHANGELOG.md` and `git apply --index`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of applying labels and posting analysis comments for PRs.
  * Tightened workflow permissions for pull-request operations to write access.
  * Made release operations explicitly target the repository for consistent draft/version handling.
  * Enhanced temporary file handling and cleanup for comment generation.
  * Ensured changelog changes are staged so patch generation recognizes and includes them.
  * Replaced path-based triggers with runtime change detection and conditional gating for config checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->