### PR TITLE
Fix docs preview required check

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,20 +12,16 @@ concurrency:
 
 jobs:
   build-preview:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/docs-deploy.yaml
     with:
       checkout_ref: ${{ github.event.pull_request.head.sha }}
-      deploy_branch: pr-${{ github.event.pull_request.number }}
+      # Fork PRs run the docs build only. Only same-repo PRs get a deploy
+      # branch and Cloudflare secrets for preview deployment.
+      deploy_branch: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('pr-{0}', github.event.pull_request.number) || '' }}
     secrets:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  build-pr:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    uses: ./.github/workflows/docs-deploy.yaml
-    with:
-      checkout_ref: ${{ github.event.pull_request.head.sha }}
+      CLOUDFLARE_API_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.CLOUDFLARE_API_TOKEN || '' }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.CLOUDFLARE_ACCOUNT_ID || '' }}
 
   build-production:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- Use one PR docs job name, `build-preview`, for both fork and same-repo pull requests.
- Pass Cloudflare secrets and a preview deploy branch only for same-repo PRs.
- Keep fork PRs on build-only behavior with no preview deploy.

## Security
Fork PRs run untrusted code without Cloudflare secrets. The deploy step remains guarded by a non-empty `deploy_branch`, so fork PRs do not deploy docs previews.

## Job behavior
- Fork PR: `build-preview / build-deploy` builds docs with an empty deploy branch and empty Cloudflare secret values.
- Same-repo PR: `build-preview / build-deploy` builds and deploys preview docs to `pr-<number>`.
- Release / workflow_dispatch: `build-production / build-deploy` continues production deployment to `main`.

## Required check
Branch protection should require `build-preview / build-deploy` for PR docs checks.

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/docs.yaml .github/workflows/docs-deploy.yaml`
- `tox -e type`
- `tox -e py314-parallel`
- `tox -e py312-parallel` (`py312-pydantic1-parallel` is not present in the current tox config)
- `tox -e readme`
- `tox -e cli-docs -- --check`
- `tox -e config-types -- --check`
- `.tox/dev/bin/pytest tests/ -n auto -p no:benchmark --cov=datamodel_code_generator --cov-branch --cov-report=term-missing` ran tests successfully but failed total coverage threshold on existing non-YAML coverage: 2101 passed, 10 skipped, total 99.90%.
- Automated review reported no actionable correctness issues.
- `coderabbit --prompt-only` was stopped after reporting unrelated existing generated-test findings outside this docs workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow configuration to streamline preview build handling across all pull request scenarios with consolidated logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->