### PR TITLE
Write generated prompt snapshots directly

### DIFF
--- a/.github/workflows/generated-docs-sync.yaml
+++ b/.github/workflows/generated-docs-sync.yaml
@@ -12,7 +12,10 @@ on:
       - 'scripts/build_prompt_data.py'
       - 'scripts/build_schema_docs.py'
       - 'scripts/build_llms_txt.py'
+      - 'scripts/update_generate_prompt_snapshots.py'
       - 'scripts/update_docs_version.py'
+      - 'tox.ini'
+      - '.github/workflows/generated-docs-sync.yaml'
       - 'docs/**/*.md'
       - 'CHANGELOG.md'
       - 'README.md'
@@ -39,52 +42,12 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: Install tox
         run: uv tool install --python-preference only-managed --python 3.13 tox --with tox-uv
-      - name: Setup README environment
-        run: tox run -vv --notest --skip-missing-interpreters false -e readme
+      - name: Setup generated docs environment
+        run: tox run -vv --notest --skip-missing-interpreters false -e generated-docs
         env:
           UV_PYTHON_PREFERENCE: "only-managed"
-      - name: Setup CLI docs environment
-        run: tox run -vv --notest --skip-missing-interpreters false -e cli-docs
-        env:
-          UV_PYTHON_PREFERENCE: "only-managed"
-      - name: Setup schema docs environment
-        run: tox run -vv --notest --skip-missing-interpreters false -e schema-docs
-        env:
-          UV_PYTHON_PREFERENCE: "only-managed"
-      - name: Setup llms.txt environment
-        run: tox run -vv --notest --skip-missing-interpreters false -e llms-txt
-        env:
-          UV_PYTHON_PREFERENCE: "only-managed"
-      - name: Update README
-        run: .tox/readme/bin/python scripts/update_command_help_on_markdown.py
-      - name: Collect CLI doc metadata
-        run: .tox/cli-docs/bin/pytest --collect-cli-docs -p no:xdist -q
-      - name: Build CLI docs
-        run: .tox/cli-docs/bin/python scripts/build_cli_docs.py
-      - name: Build prompt data
-        run: .tox/cli-docs/bin/python scripts/build_prompt_data.py
-      - name: Update generate prompt snapshots
-        env:
-          PYTHONPATH: ${{ github.workspace }}/src
-        run: |
-          set +e
-          .tox/cli-docs/bin/pytest \
-            tests/test_main_kr.py::test_generate_prompt_basic \
-            tests/test_main_kr.py::test_generate_prompt_with_question \
-            tests/test_main_kr.py::test_generate_prompt_with_options \
-            tests/test_main_kr.py::test_generate_prompt_with_list_options \
-            --inline-snapshot=fix \
-            -p no:xdist \
-            -q
-          snapshot_status=$?
-          set -e
-          if [ "$snapshot_status" -ne 0 ] && git diff --quiet -- tests/data/expected/main_kr/generate_prompt/; then
-            exit "$snapshot_status"
-          fi
-      - name: Build schema docs
-        run: .tox/schema-docs/bin/python scripts/build_schema_docs.py
-      - name: Build llms.txt
-        run: .tox/llms-txt/bin/python scripts/build_llms_txt.py
+      - name: Update generated docs
+        run: tox run --skip-uv-sync --skip-pkg-install -e generated-docs
       - name: Create generated docs patch
         id: patch
         env:

--- a/scripts/update_generate_prompt_snapshots.py
+++ b/scripts/update_generate_prompt_snapshots.py
@@ -1,0 +1,83 @@
+"""Update generate-prompt stdout snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+OUTPUT_DIR = Path(__file__).parent.parent / "tests" / "data" / "expected" / "main_kr" / "generate_prompt"
+
+CASES = (
+    ("basic.txt", ["--generate-prompt"]),
+    ("with_question.txt", ["--generate-prompt", "How do I convert enums to Literal types?"]),
+    (
+        "with_options.txt",
+        [
+            "--input",
+            "schema.json",
+            "--output-model-type",
+            "pydantic_v2.BaseModel",
+            "--snake-case-field",
+            "--generate-prompt",
+            "What other options should I use?",
+        ],
+    ),
+    ("with_list_options.txt", ["--strict-types", "str", "int", "--generate-prompt"]),
+)
+
+
+def _generate_stdout(args: list[str]) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "datamodel_code_generator", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        msg = f"datamodel-codegen exited with {result.returncode} for args: {args}"
+        raise RuntimeError(msg)
+    return result.stdout
+
+
+def _update_snapshots(*, check: bool = False) -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    mismatches: list[Path] = []
+    for filename, args in CASES:
+        output_path = OUTPUT_DIR / filename
+        generated = _generate_stdout(list(args))
+        if check:
+            if not output_path.exists() or output_path.read_text(encoding="utf-8") != generated:
+                mismatches.append(output_path)
+            continue
+        output_path.write_text(generated, encoding="utf-8")
+
+    if mismatches:
+        for path in mismatches:
+            print(f"Content mismatch: {path}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update generate-prompt stdout snapshots")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if snapshots are up to date without modifying files",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Parse CLI arguments and update generate-prompt snapshots."""
+    args = _parse_args()
+    return _update_snapshots(check=args.check)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -123,6 +123,28 @@ commands =
 dependency_groups =
 no_default_groups = true
 
+[testenv:generated-docs]
+description = Update all generated documentation and prompt snapshots
+set_env =
+    {[testenv]set_env}
+    PYTHONPATH = {tox_root}{/}src
+commands =
+    python scripts/update_command_help_on_markdown.py
+    pytest --collect-cli-docs -p no:xdist -q
+    python scripts/build_cli_docs.py
+    python scripts/build_prompt_data.py
+    python scripts/update_generate_prompt_snapshots.py
+    python scripts/build_schema_docs.py
+    python scripts/build_llms_txt.py
+    pytest \
+      tests/test_main_kr.py::test_generate_prompt_basic \
+      tests/test_main_kr.py::test_generate_prompt_with_question \
+      tests/test_main_kr.py::test_generate_prompt_with_options \
+      tests/test_main_kr.py::test_generate_prompt_with_list_options \
+      -p no:xdist \
+      -q
+dependency_groups = test
+
 [testenv:config-types]
 description = Generate TypedDict files from config models (use --check to validate only)
 commands =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined automated documentation generation and snapshot refresh process.
  * Added a script to (re)generate and verify prompt-output snapshots (supports a --check mode).
  * Introduced a dedicated CI/test environment to run the docs and snapshot update workflow.

---

Note: No user-facing changes; internal CI/CD and tooling updates only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->