### PR TITLE
Normalize changelog release body spacing

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,45 +29,10 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail
-
-          TAG="$RELEASE_TAG"
-          DATE=$(gh release view "$TAG" --json publishedAt --jq '.publishedAt | split("T")[0]')
-          BODY=$(gh release view "$TAG" --json body --jq '.body // ""')
-
-          # Create new entry
-          {
-            echo "## [$TAG](https://github.com/${{ github.repository }}/releases/tag/$TAG) - $DATE"
-            echo ""
-            printf '%s\n' "$BODY"
-            echo ""
-            echo "---"
-            echo ""
-          } > new_entry.md
-
-          # Initialize CHANGELOG.md if it doesn't exist
-          if [ ! -f CHANGELOG.md ]; then
-            {
-              echo "# Changelog"
-              echo ""
-              echo "All notable changes to this project are documented in this file."
-              echo "This changelog is automatically generated from GitHub Releases."
-              echo ""
-              echo "---"
-              echo ""
-            } > CHANGELOG.md
-          fi
-
-          # Split CHANGELOG.md at first "---" separator (content-based, not line-number based)
-          # Header includes everything up to and including the first "---" line
-          # Old entries are everything after the first "---" line
-          awk '/^---$/ && !found {found=1; print > "header.md"; next} !found {print > "header.md"} found {print > "old_entries.md"}' CHANGELOG.md
-
-          # Ensure old_entries.md exists even if empty
-          touch old_entries.md
-
-          # Reassemble: header + new entry + old entries
-          cat header.md new_entry.md old_entries.md > CHANGELOG.md
-          rm -f header.md new_entry.md old_entries.md
+          scripts/generate_changelog.sh \
+            --repo "${{ github.repository }}" \
+            --tag "$RELEASE_TAG" \
+            --prepend-to CHANGELOG.md
 
       - name: Create changelog patch
         id: patch

--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -1,30 +1,133 @@
 #!/bin/bash
-# Generate CHANGELOG.md from all GitHub Releases
-# Usage: ./scripts/generate_changelog.sh > CHANGELOG.md
+# Generate CHANGELOG.md from GitHub Releases
+# Usage:
+#   ./scripts/generate_changelog.sh > CHANGELOG.md
+#   ./scripts/generate_changelog.sh --tag 0.57.0 --prepend-to CHANGELOG.md
 # Note: --limit 500 may need to be increased if releases exceed 500
 
 set -euo pipefail
 
 REPO="koxudaxi/datamodel-code-generator"
+TAG=""
+PREPEND_TO=""
 
-echo "# Changelog"
-echo ""
-echo "All notable changes to this project are documented in this file."
-echo "This changelog is automatically generated from GitHub Releases."
-echo ""
-echo "---"
-echo ""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --tag)
+            TAG="$2"
+            shift 2
+            ;;
+        --prepend-to)
+            PREPEND_TO="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
 
-# Get all releases and process them
-gh release list --repo "$REPO" --limit 500 --json tagName --jq '.[].tagName' | while read -r tag; do
-    # Get release details (use // "" to handle null body)
-    DATE=$(gh release view "$tag" --repo "$REPO" --json publishedAt --jq '.publishedAt | split("T")[0]')
-    BODY=$(gh release view "$tag" --repo "$REPO" --json body --jq '.body // ""')
+normalize_release_body() {
+    awk '
+        {
+            sub(/\r$/, "")
+            if ($0 == "") {
+                if (blank < 2) {
+                    blank += 1
+                }
+                next
+            }
+            while (blank > 0 && seen) {
+                print ""
+                blank -= 1
+            }
+            seen = 1
+            blank = 0
+            print
+        }
+    '
+}
 
-    echo "## [$tag](https://github.com/$REPO/releases/tag/$tag) - $DATE"
+write_header() {
+    echo "# Changelog"
     echo ""
-    printf '%s\n' "$BODY"
+    echo "All notable changes to this project are documented in this file."
+    echo "This changelog is automatically generated from GitHub Releases."
     echo ""
     echo "---"
     echo ""
+}
+
+write_release_entry() {
+    local tag="$1"
+    local release_json
+    local is_draft
+    local date
+    local body
+
+    release_json=$(gh release view "$tag" --repo "$REPO" --json body,createdAt,isDraft,publishedAt)
+    is_draft=$(jq -r '.isDraft' <<< "$release_json")
+
+    if [ "$is_draft" = "true" ]; then
+        echo "Release is a draft: $tag" >&2
+        return 1
+    fi
+
+    date=$(jq -r '(.publishedAt // .createdAt) | split("T")[0]' <<< "$release_json")
+    body=$(jq -r '.body // ""' <<< "$release_json" | normalize_release_body)
+
+    echo "## [$tag](https://github.com/$REPO/releases/tag/$tag) - $date"
+    echo ""
+    printf '%s\n' "$body"
+    echo ""
+    echo "---"
+    echo ""
+}
+
+prepend_release_entry() {
+    local tag="$1"
+    local changelog="$2"
+    local tmp_dir
+
+    tmp_dir=$(mktemp -d)
+    trap 'rm -rf "$tmp_dir"' EXIT
+
+    write_release_entry "$tag" > "$tmp_dir/new_entry.md"
+
+    if [ ! -f "$changelog" ]; then
+        write_header > "$changelog"
+    fi
+
+    awk -v header="$tmp_dir/header.md" -v old_entries="$tmp_dir/old_entries.md" '
+        /^---$/ && !found {found=1; skip_blank=1; next}
+        found && skip_blank && $0 == "" {skip_blank=0; next}
+        !found {print > header; next}
+        found {skip_blank=0; print > old_entries}
+    ' \
+        "$changelog"
+    touch "$tmp_dir/old_entries.md"
+    { cat "$tmp_dir/header.md"; printf '%s\n\n' '---'; cat "$tmp_dir/new_entry.md" "$tmp_dir/old_entries.md"; } > "$changelog"
+    rm -rf "$tmp_dir"
+    trap - EXIT
+}
+
+if [ -n "$PREPEND_TO" ]; then
+    if [ -z "$TAG" ]; then
+        echo "--prepend-to requires --tag" >&2
+        exit 2
+    fi
+    prepend_release_entry "$TAG" "$PREPEND_TO"
+    exit 0
+fi
+
+write_header
+
+# Get all releases and process them
+gh release list --repo "$REPO" --limit 500 --exclude-drafts --json tagName --jq '.[].tagName' | while read -r tag; do
+    write_release_entry "$tag"
 done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changelog generation logic moved out of the workflow into a dedicated script for clearer, maintainable release entry creation.
  * The script supports repository and tag options and a prepend mode to insert a single rendered release entry into an existing changelog.
  * Release bodies are normalized, drafts/empty bodies are skipped, and full changelog regeneration remains supported; workflow steps that create/update the changelog PR remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->