### PR TITLE
Fix duplicate changelog prepend

### DIFF
--- a/scripts/generate_changelog.sh
+++ b/scripts/generate_changelog.sh
@@ -103,10 +103,24 @@ prepend_release_entry() {
         write_header > "$changelog"
     fi
 
-    awk -v header="$tmp_dir/header.md" -v old_entries="$tmp_dir/old_entries.md" '
+    awk -v header="$tmp_dir/header.md" -v old_entries="$tmp_dir/old_entries.md" -v tag="$tag" '
+        function is_release_heading(line) {
+            return index(line, "## [" tag "](") == 1
+        }
         /^---$/ && !found {found=1; skip_blank=1; next}
         found && skip_blank && $0 == "" {skip_blank=0; next}
+        found && skip_duplicate {
+            if ($0 == "---") {
+                skip_duplicate=0
+                skip_blank=1
+            }
+            next
+        }
         !found {print > header; next}
+        found && is_release_heading($0) {
+            skip_duplicate=1
+            next
+        }
         found {skip_blank=0; print > old_entries}
     ' \
         "$changelog"

--- a/tests/test_generate_changelog_script.py
+++ b/tests/test_generate_changelog_script.py
@@ -1,0 +1,88 @@
+"""Tests for the changelog generation script."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason="generate_changelog.sh requires jq")
+def test_prepend_release_entry_replaces_existing_tag(tmp_path: Path) -> None:
+    """Existing release entries are replaced instead of duplicated."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        textwrap.dedent(
+            """\
+            # Changelog
+
+            All notable changes to this project are documented in this file.
+            This changelog is automatically generated from GitHub Releases.
+
+            ---
+
+            ## [0.57.0](https://github.com/koxudaxi/datamodel-code-generator/releases/tag/0.57.0) - 2026-05-07
+
+            Old release body
+
+            ---
+
+            ## [0.56.1](https://github.com/koxudaxi/datamodel-code-generator/releases/tag/0.56.1) - 2026-04-16
+
+            Previous release body
+
+            ---
+            """
+        )
+    )
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            cat <<'JSON'
+            {
+              "body": "## What's Changed\\n* Fixed changelog generation",
+              "createdAt": "2026-05-07T00:00:00Z",
+              "isDraft": false,
+              "publishedAt": "2026-05-07T00:00:00Z"
+            }
+            JSON
+            """
+        )
+    )
+    gh.chmod(0o755)
+
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    command = [
+        "bash",
+        "scripts/generate_changelog.sh",
+        "--repo",
+        "koxudaxi/datamodel-code-generator",
+        "--tag",
+        "0.57.0",
+        "--prepend-to",
+        str(changelog),
+    ]
+
+    subprocess.run(command, check=True, env=env)
+    first_run = changelog.read_text()
+
+    subprocess.run(command, check=True, env=env)
+    second_run = changelog.read_text()
+
+    assert first_run == second_run
+    assert first_run.count("## [0.57.0]") == 1
+    assert "Old release body" not in first_run
+    assert "* Fixed changelog generation" in first_run
+    assert "## [0.56.1]" in first_run

--- a/tests/test_generate_changelog_script.py
+++ b/tests/test_generate_changelog_script.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason="generate_changelog.sh requires jq")
+@pytest.mark.skipif(sys.platform == "win32", reason="generate_changelog.sh is tested on POSIX runners")
 def test_prepend_release_entry_replaces_existing_tag(tmp_path: Path) -> None:
     """Existing release entries are replaced instead of duplicated."""
     changelog = tmp_path / "CHANGELOG.md"

--- a/tests/test_generate_changelog_script.py
+++ b/tests/test_generate_changelog_script.py
@@ -7,12 +7,11 @@ import shutil
 import subprocess
 import sys
 import textwrap
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
-if TYPE_CHECKING:
-    from pathlib import Path
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "generate_changelog.sh"
 
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason="generate_changelog.sh requires jq")
@@ -68,7 +67,7 @@ def test_prepend_release_entry_replaces_existing_tag(tmp_path: Path) -> None:
     env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
     command = [
         "bash",
-        "scripts/generate_changelog.sh",
+        str(SCRIPT),
         "--repo",
         "koxudaxi/datamodel-code-generator",
         "--tag",

--- a/tests/test_generate_changelog_script.py
+++ b/tests/test_generate_changelog_script.py
@@ -87,3 +87,4 @@ def test_prepend_release_entry_replaces_existing_tag(tmp_path: Path) -> None:
     assert "Old release body" not in first_run
     assert "* Fixed changelog generation" in first_run
     assert "## [0.56.1]" in first_run
+    assert "Previous release body" in first_run


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved changelog generation to prepend new release entries without creating duplicates, skip initial separator metadata, and preserve/merge existing content while replacing an existing entry for the same tag.

* **Tests**
  * Added tests that validate idempotent prepending, ensure a single replacement of a matching release section, confirm removal of old body text, and verify other entries remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->