### PR TITLE
Align schema feature support status

### DIFF
--- a/docs/supported_formats.md
+++ b/docs/supported_formats.md
@@ -112,7 +112,7 @@ The following features are tracked in the codebase with their implementation sta
 | `readOnly/writeOnly` | Draft 7 | ✅ Supported | Field visibility hints for read-only and write-only properties |
 | `const` | Draft 6 | ✅ Supported | Single constant value constraint |
 | `propertyNames` | Draft 6 | ✅ Supported | Dict key type constraints via pattern, enum, or $ref |
-| `contains` | Draft 6 | ⚠️ Partial | Array contains constraints for schemas that apply to every item |
+| `contains` | Draft 6 | ⚠️ Partial | Count constraints are modeled when contains matches every item; general schema-valued contains is not supported |
 | `deprecated` | 2019-09 | ⚠️ Partial | Marks schema elements as deprecated |
 | `if/then/else` | Draft 7 | ❌ Not Supported | Conditional schema validation |
 | `contentMediaType/contentEncoding` | Draft 7 | ❌ Not Supported | Content type and encoding hints for strings |

--- a/docs/supported_formats.md
+++ b/docs/supported_formats.md
@@ -112,14 +112,14 @@ The following features are tracked in the codebase with their implementation sta
 | `readOnly/writeOnly` | Draft 7 | ✅ Supported | Field visibility hints for read-only and write-only properties |
 | `const` | Draft 6 | ✅ Supported | Single constant value constraint |
 | `propertyNames` | Draft 6 | ✅ Supported | Dict key type constraints via pattern, enum, or $ref |
-| `contains` | Draft 6 | ❌ Not Supported | Array contains at least one matching item |
+| `contains` | Draft 6 | ⚠️ Partial | Array contains constraints for schemas that apply to every item |
 | `deprecated` | 2019-09 | ⚠️ Partial | Marks schema elements as deprecated |
 | `if/then/else` | Draft 7 | ❌ Not Supported | Conditional schema validation |
 | `contentMediaType/contentEncoding` | Draft 7 | ❌ Not Supported | Content type and encoding hints for strings |
 | `$anchor` | 2019-09 | ❌ Not Supported | Location-independent schema references |
 | `$vocabulary` | 2019-09 | ❌ Not Supported | Vocabulary declarations for meta-schemas |
-| `unevaluatedProperties` | 2019-09 | ❌ Not Supported | Additional properties not evaluated by subschemas |
-| `unevaluatedItems` | 2019-09 | ❌ Not Supported | Additional items not evaluated by subschemas |
+| `unevaluatedProperties` | 2019-09 | ⚠️ Partial | Additional properties not evaluated by subschemas |
+| `unevaluatedItems` | 2019-09 | ⚠️ Partial | Additional items not evaluated by subschemas |
 | `dependentRequired` | 2019-09 | ❌ Not Supported | Conditional property requirements |
 | `dependentSchemas` | 2019-09 | ❌ Not Supported | Conditional schema application based on property presence |
 | `$recursiveRef/$recursiveAnchor` | 2019-09 | ✅ Supported | Recursive reference resolution via anchors |
@@ -177,8 +177,9 @@ The following features are tracked in the codebase with their implementation sta
 | Feature | Introduced | Status | Notes |
 |---------|------------|--------|-------|
 | `$anchor` | 2019-09 | ❌ Not supported | Use `$ref` with `$id` instead |
-| `unevaluatedProperties` | 2019-09 | ❌ Not supported | Use `additionalProperties` instead |
-| `unevaluatedItems` | 2019-09 | ❌ Not supported | Use `additionalItems` instead |
+| `contains` | Draft 6 | ⚠️ Partial | Count constraints are modeled when `contains` matches every item |
+| `unevaluatedProperties` | 2019-09 | ⚠️ Partial | Boolean values and schema-valued extra allowance are modeled |
+| `unevaluatedItems` | 2019-09 | ⚠️ Partial | Boolean values and schema-valued array item types are modeled |
 | `contentMediaType` | Draft 7 | ❌ Not supported | Content type hints ignored |
 | `contentEncoding` | Draft 7 | ❌ Not supported | Encoding hints ignored |
 | `contentSchema` | 2019-09 | ❌ Not supported | Nested content schema ignored |

--- a/src/datamodel_code_generator/parser/schema_version.py
+++ b/src/datamodel_code_generator/parser/schema_version.py
@@ -142,8 +142,8 @@ class JsonSchemaFeatures:
         metadata=FeatureMetadata(
             introduced="Draft 6",
             doc_name="contains",
-            description="Array contains at least one matching item",
-            status="not_supported",
+            description="Array contains constraints for schemas that apply to every item",
+            status="partial",
         ),
     )
     deprecated_keyword: bool = field(
@@ -198,7 +198,7 @@ class JsonSchemaFeatures:
             introduced="2019-09",
             doc_name="unevaluatedProperties",
             description="Additional properties not evaluated by subschemas",
-            status="not_supported",
+            status="partial",
         ),
     )
     unevaluated_items: bool = field(
@@ -207,7 +207,7 @@ class JsonSchemaFeatures:
             introduced="2019-09",
             doc_name="unevaluatedItems",
             description="Additional items not evaluated by subschemas",
-            status="not_supported",
+            status="partial",
         ),
     )
     dependent_required: bool = field(

--- a/src/datamodel_code_generator/parser/schema_version.py
+++ b/src/datamodel_code_generator/parser/schema_version.py
@@ -142,7 +142,10 @@ class JsonSchemaFeatures:
         metadata=FeatureMetadata(
             introduced="Draft 6",
             doc_name="contains",
-            description="Array contains constraints for schemas that apply to every item",
+            description=(
+                "Count constraints are modeled when contains matches every item; "
+                "general schema-valued contains is not supported"
+            ),
             status="partial",
         ),
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated JSON Schema feature support statuses: `contains`, `unevaluatedProperties`, and `unevaluatedItems` are now marked as partially supported with clarified descriptions and revised limitations notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koxudaxi/datamodel-code-generator/pull/3174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->