### PR TITLE
Fix scoped type-overrides changing more fields then intended

### DIFF
--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -15,6 +15,7 @@ import sys
 from abc import ABC, abstractmethod
 from collections import Counter, OrderedDict, defaultdict
 from collections.abc import Callable, Hashable, Mapping, Sequence
+from copy import deepcopy
 from itertools import groupby
 from pathlib import Path
 from typing import (
@@ -2549,6 +2550,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
 
     def _apply_override_to_field(self, field: DataModelFieldBase, override_import: Import) -> None:
         """Apply override to entire field's data_type."""
+        field.data_type = deepcopy(field.data_type)
         field.data_type.import_ = override_import
         field.data_type.alias = override_import.import_
         self.generation_store.detach_data_type_ref(field.data_type)

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -2550,9 +2550,10 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
 
     def _apply_override_to_field(self, field: DataModelFieldBase, override_import: Import) -> None:
         """Apply override to entire field's data_type."""
-        field.data_type = deepcopy(field.data_type)
-        field.data_type.import_ = override_import
-        field.data_type.alias = override_import.import_
+        data_type = deepcopy(field.data_type)
+        data_type.import_ = override_import
+        data_type.alias = override_import.import_
+        self.generation_store.replace_field_type(field, data_type)
         self.generation_store.detach_data_type_ref(field.data_type)
         self.generation_store.set_nested_data_types(field.data_type, [])
 


### PR DESCRIPTION
Fixes scoped type-overrides (#3212) by creating a deepcopy of field.data_type before changing it.
Without the deepcopy() the whole data_type is modified, which affects all other fields using this data_type, too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented type override changes from unintentionally affecting shared type instances elsewhere, ensuring overrides are applied safely without side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koxudaxi/datamodel-code-generator/pull/3213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->