### PR TITLE
Support Pydantic 2.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -164,6 +164,8 @@ jobs:
           - type
           - docs
           - pkg_meta
+          - pydantic20
+          - pydantic25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "inflect>=4.1,<8",
   "isort>=4.3.21,<9",
   "jinja2>=2.10.1,<4",
-  "pydantic>=2.6,<3; python_version<'3.14'",
+  "pydantic>=2,<3; python_version<'3.14'",
   "pydantic>=2.12,<3; python_version>='3.14'",
   "pyyaml>=6.0.1",
   "tomli>=2.2.1,<3; python_version<'3.11'",

--- a/src/datamodel_code_generator/model/__init__.py
+++ b/src/datamodel_code_generator/model/__init__.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from datamodel_code_generator import PythonVersion
 
-from .base import ConstraintsBase, DataModel, DataModelFieldBase
+from .base import ConstraintsBase, DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -143,4 +143,4 @@ def get_data_model_types(  # noqa: PLR0912
     raise ValueError(msg)  # pragma: no cover
 
 
-__all__ = ["ConstraintsBase", "DataModel", "DataModelFieldBase"]
+__all__ = ["ConstraintsBase", "DataModel", "DataModelFieldBase", "_rebuild_model_with_datamodel_namespace"]

--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -7,12 +7,13 @@ representation, and DataModel as the abstract base for all model types.
 from __future__ import annotations
 
 import re
+import sys
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from copy import deepcopy
 from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
 from warnings import warn
 
 from pydantic import ConfigDict, Field
@@ -1016,7 +1017,20 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         ]
 
 
-_rebuild_namespace = {"Union": Union, "DataModelFieldBase": DataModelFieldBase, "DataType": DataType}
-DataType.model_rebuild(_types_namespace=_rebuild_namespace)
-BaseClassDataType.model_rebuild(_types_namespace=_rebuild_namespace)
-DataModelFieldBase.model_rebuild(_types_namespace={"DataModel": DataModel})
+def _model_rebuild_namespace(*classes: type[Any]) -> dict[str, Any]:
+    namespace: dict[str, Any] = {}
+    for cls in classes:
+        namespace.update(vars(sys.modules[cls.__module__]))
+    return namespace
+
+
+_rebuild_namespace = _model_rebuild_namespace(DataType, BaseClassDataType, DataModelFieldBase, DataModel)
+
+
+def _rebuild_model_with_datamodel_namespace(model: type[Any]) -> None:
+    model.model_rebuild(_types_namespace={**_rebuild_namespace, **vars(sys.modules[model.__module__])})
+
+
+_rebuild_model_with_datamodel_namespace(DataType)
+_rebuild_model_with_datamodel_namespace(BaseClassDataType)
+_rebuild_model_with_datamodel_namespace(DataModelFieldBase)

--- a/src/datamodel_code_generator/model/dataclass.py
+++ b/src/datamodel_code_generator/model/dataclass.py
@@ -21,7 +21,7 @@ from datamodel_code_generator.imports import (
     IMPORT_TIMEDELTA,
     Import,
 )
-from datamodel_code_generator.model import DataModel, DataModelFieldBase
+from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
 from datamodel_code_generator.model.base import UNDEFINED
 from datamodel_code_generator.model.imports import IMPORT_DATACLASS, IMPORT_FIELD
 from datamodel_code_generator.model.pydantic_base import Constraints  # noqa: TC001 # needed for pydantic
@@ -269,3 +269,6 @@ class DataTypeManager(_DataTypeManager):
             **datetime_map,
             **standard_primitive_map,
         }
+
+
+_rebuild_model_with_datamodel_namespace(DataModelField)

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -19,7 +19,7 @@ from datamodel_code_generator.imports import (
     IMPORT_UNION,
     Import,
 )
-from datamodel_code_generator.model import DataModel, DataModelFieldBase
+from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
 from datamodel_code_generator.model.base import UNDEFINED, BaseClassDataType
 from datamodel_code_generator.model.imports import (
     IMPORT_MSGSPEC_CONVERT,
@@ -551,3 +551,6 @@ class DataTypeManager(_DataTypeManager):
             **datetime_map,
             **standard_primitive_map,
         }
+
+
+_rebuild_model_with_datamodel_namespace(DataModelField)

--- a/src/datamodel_code_generator/model/pydantic_base.py
+++ b/src/datamodel_code_generator/model/pydantic_base.py
@@ -18,6 +18,7 @@ from datamodel_code_generator.model import (
     ConstraintsBase,
     DataModel,
     DataModelFieldBase,
+    _rebuild_model_with_datamodel_namespace,
 )
 from datamodel_code_generator.model.base import UNDEFINED, repr_set_sorted
 from datamodel_code_generator.types import UnionIntFloat, chain_as_tuple
@@ -348,3 +349,6 @@ class BaseModelBase(DataModel, ABC):
             if cached_path_exists(custom_template_file_path):
                 return custom_template_file_path
         return super().template_file_path
+
+
+_rebuild_model_with_datamodel_namespace(DataModelField)

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -13,7 +13,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, Optional
 from pydantic import Field, field_validator, model_validator
 
 from datamodel_code_generator.imports import IMPORT_ANY, Import
-from datamodel_code_generator.model.base import ALL_MODEL, UNDEFINED, BaseClassDataType, DataModelFieldBase
+from datamodel_code_generator.model import _rebuild_model_with_datamodel_namespace
+from datamodel_code_generator.model.base import (
+    ALL_MODEL,
+    UNDEFINED,
+    BaseClassDataType,
+    DataModelFieldBase,
+)
 from datamodel_code_generator.model.imports import IMPORT_CLASSVAR
 from datamodel_code_generator.model.pydantic_base import (
     BaseModelBase,
@@ -483,3 +489,6 @@ class BaseModel(BaseModelBase):
         )
 
         return base_model
+
+
+_rebuild_model_with_datamodel_namespace(DataModelField)

--- a/src/datamodel_code_generator/model/pydantic_v2/dataclass.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/dataclass.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from datamodel_code_generator.model import DataModel, DataModelFieldBase
+from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
 from datamodel_code_generator.model.base import UNDEFINED
 from datamodel_code_generator.model.dataclass import has_field_assignment
 from datamodel_code_generator.model.pydantic_v2.base_model import ConfigAttribute, Constraints
@@ -182,3 +182,6 @@ class DataModelField(DataModelFieldV2):
     def process_const(self) -> None:
         """Process const field constraint using literal type."""
         self._process_const_as_literal()
+
+
+_rebuild_model_with_datamodel_namespace(DataModelField)

--- a/src/datamodel_code_generator/model/pydantic_v2/types.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/types.py
@@ -499,6 +499,9 @@ class DataTypeManager(_PydanticDataTypeManager):
             use_serialize_as_any=(bool, use_serialize_as_any),
             __base__=PydanticV2DataType,
         )
+        from datamodel_code_generator.model import _rebuild_model_with_datamodel_namespace  # noqa: PLC0415
+
+        _rebuild_model_with_datamodel_namespace(self.data_type)
 
     def type_map_factory(  # noqa: PLR0913, PLR0917
         self,

--- a/src/datamodel_code_generator/model/typed_dict.py
+++ b/src/datamodel_code_generator/model/typed_dict.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import keyword
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from datamodel_code_generator.model import DataModel, DataModelFieldBase
+from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
 from datamodel_code_generator.model.base import UNDEFINED
 from datamodel_code_generator.model.imports import (
     IMPORT_NOT_REQUIRED,
@@ -251,3 +251,8 @@ class DataModelFieldBackport(DataModelField):
 
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_NOT_REQUIRED_BACKPORT,)
     DEFAULT_READ_ONLY_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_READ_ONLY_BACKPORT,)
+
+
+_rebuild_model_with_datamodel_namespace(DataModelField)
+_rebuild_model_with_datamodel_namespace(DataModelFieldReadOnlyBackport)
+_rebuild_model_with_datamodel_namespace(DataModelFieldBackport)

--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -1009,6 +1009,9 @@ class DataTypeManager(ABC):
             use_serialize_as_any=(bool, use_serialize_as_any),
             __base__=DataType,
         )
+        from datamodel_code_generator.model import _rebuild_model_with_datamodel_namespace  # noqa: PLC0415
+
+        _rebuild_model_with_datamodel_namespace(self.data_type)
 
     @abstractmethod
     def get_data_type(self, types: Types, **kwargs: Any) -> DataType:

--- a/tox.ini
+++ b/tox.ini
@@ -214,6 +214,30 @@ commands =
     python -c 'import sys; print(sys.executable)'
 dependency_groups = dev
 
+[testenv:pydantic25]
+runner = uv-venv-runner
+description = run Pydantic 2.5 regression tests under Python 3.12
+base_python = python3.12
+deps =
+    pydantic==2.5.3
+commands =
+    pytest --color=yes -q \
+      tests/main/test_main_general.py::test_show_help_when_no_input \
+      tests/main/test_main_general.py::test_generated_pydantic_v2_model_accepts_runtime_value
+dependency_groups = test
+
+[testenv:pydantic20]
+runner = uv-venv-runner
+description = run Pydantic 2.0 lower-bound regression tests under Python 3.11
+base_python = python3.11
+deps =
+    pydantic==2.0.3
+commands =
+    pytest --color=yes -q \
+      tests/main/test_main_general.py::test_show_help_when_no_input \
+      tests/main/test_main_general.py::test_generated_pydantic_v2_model_accepts_runtime_value
+dependency_groups = test
+
 [testenv:lock]
 runner = uv-venv-runner
 description = refresh requirement files

--- a/uv.lock
+++ b/uv.lock
@@ -961,7 +961,7 @@ requires-dist = [
     { name = "openapi-spec-validator", marker = "extra == 'validation'", specifier = ">=0.2.8,<0.8" },
     { name = "prance", marker = "extra == 'all'", specifier = ">=0.18.2" },
     { name = "prance", marker = "extra == 'validation'", specifier = ">=0.18.2" },
-    { name = "pydantic", marker = "python_full_version < '3.14'", specifier = ">=2.6,<3" },
+    { name = "pydantic", marker = "python_full_version < '3.14'", specifier = ">=2,<3" },
     { name = "pydantic", marker = "python_full_version >= '3.14'", specifier = ">=2.12,<3" },
     { name = "pysnooper", marker = "extra == 'all'", specifier = ">=0.4.1,<2" },
     { name = "pysnooper", marker = "extra == 'debug'", specifier = ">=0.4.1,<2" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened Pydantic support to allow any 2.x release (<3) on older Python, enabling use with 2.0–2.5.

* **Tests**
  * Added regression test coverage for Pydantic 2.5 (and maintained 2.0 tests) to validate compatibility.

* **Refactor**
  * Improved model rebuild/namespace handling for Pydantic v2 to enhance runtime compatibility across modules.

* **Chores**
  * CI matrix updated to run checks for additional Pydantic environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koxudaxi/datamodel-code-generator/pull/3215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->