### PR TITLE
Add playground version selector

### DIFF
--- a/docs/assets/playground/app.py
+++ b/docs/assets/playground/app.py
@@ -125,6 +125,17 @@ def InputTypeSelect(*, selected: str, children: Template = t"", **attrs: Any) ->
     """
 
 
+def VersionSelect(*, children: Template = t"", **attrs: Any) -> Template:
+    return t"""
+    <label class="version-control" {attrs}>
+      Version
+      <select id="playground-version" disabled>
+        <option value="current" selected>Current build</option>
+      </select>
+    </label>
+    """
+
+
 def Pane(
     *,
     title: str,
@@ -272,6 +283,7 @@ def App(
           <a href="/cli-reference/">CLI Reference</a>
         </nav>
         <div class="controls">
+          <{VersionSelect} />
           <{ActionButton} action="toggle-header" label="Compact Header" id="toggle-header" />
           <{ActionButton} action="toggle-workspace" label="Hide Editors" id="toggle-workspace" />
           <{ActionButton} action="copy-cli" label="Copy CLI" id="copy-cli" disabled={True} />

--- a/docs/assets/playground/app.py
+++ b/docs/assets/playground/app.py
@@ -275,6 +275,7 @@ def App(
           <{ActionButton} action="toggle-header" label="Compact Header" id="toggle-header" />
           <{ActionButton} action="toggle-workspace" label="Hide Editors" id="toggle-workspace" />
           <{ActionButton} action="copy-cli" label="Copy CLI" id="copy-cli" disabled={True} />
+          <{ActionButton} action="copy-repro-url" label="Copy Repro URL" id="copy-repro-url" />
           <{ActionButton} action="config" label="pyproject.toml" id="config" disabled={True} />
           <{ActionButton} action="auto-generate" label="Auto Generate: On" id="auto-generate" disabled={True} />
           <{ActionButton} action="generate" label="Generate" disabled={True} id="generate" />

--- a/docs/assets/playground/main.js
+++ b/docs/assets/playground/main.js
@@ -14,6 +14,11 @@ import {
 const appEl = document.querySelector("#app");
 const rawWorker = new Worker("./worker.js", { type: "module" });
 const worker = Comlink.wrap(rawWorker);
+const stateEncoder = new TextEncoder();
+const stateDecoder = new TextDecoder();
+const stateFormatGzip = "gz";
+const stateFormatPlain = "b64";
+const stateVersion = 1;
 
 let ready = false;
 let running = false;
@@ -30,6 +35,7 @@ let appShellMounted = false;
 let workspaceResizeObserver = null;
 let headerCompact = false;
 let workspaceCollapsed = false;
+let restoredUrlState = false;
 
 function currentSchema() {
   return getInputValue();
@@ -147,6 +153,129 @@ function mountRenderedShell(html) {
 function collectOptionEntries() {
   const form = document.querySelector("#options-form");
   return form ? Object.fromEntries(new FormData(form).entries()) : {};
+}
+
+function bytesToBase64Url(bytes) {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(value) {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+async function gzipText(text) {
+  const stream = new Blob([text]).stream().pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function gunzipText(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"));
+  return stateDecoder.decode(await new Response(stream).arrayBuffer());
+}
+
+async function encodePlaygroundState(state) {
+  const json = JSON.stringify(state);
+  if ("CompressionStream" in globalThis) {
+    return `${stateFormatGzip}.${bytesToBase64Url(await gzipText(json))}`;
+  }
+  return `${stateFormatPlain}.${bytesToBase64Url(stateEncoder.encode(json))}`;
+}
+
+async function decodePlaygroundState(payload) {
+  const [format, value] = payload.includes(".") ? payload.split(".", 2) : [stateFormatPlain, payload];
+  const bytes = base64UrlToBytes(value);
+  let json = "";
+  if (format === stateFormatGzip) {
+    if (!("DecompressionStream" in globalThis)) {
+      throw new Error("Compressed URL state is not supported by this browser");
+    }
+    json = await gunzipText(bytes);
+  } else if (format === stateFormatPlain) {
+    json = stateDecoder.decode(bytes);
+  } else {
+    throw new Error(`Unknown playground state format: ${format}`);
+  }
+  const state = JSON.parse(json);
+  if (state.v !== stateVersion) {
+    throw new Error(`Unsupported playground state version: ${state.v}`);
+  }
+  return state;
+}
+
+function buildPlaygroundState() {
+  return {
+    v: stateVersion,
+    inputType: currentInputType(),
+    schema: currentSchema(),
+    options: collectOptionEntries(),
+  };
+}
+
+function statePayloadFromHash() {
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  return params.get("state");
+}
+
+function buildReproUrl(payload) {
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams(url.hash.slice(1));
+  params.set("state", payload);
+  url.hash = params.toString();
+  return url.toString();
+}
+
+async function copyReproUrl() {
+  const payload = await encodePlaygroundState(buildPlaygroundState());
+  const url = buildReproUrl(payload);
+  await navigator.clipboard.writeText(url);
+  setStatus(url.length > 8000 ? "Copied reproducible URL. The URL is long." : "Copied reproducible URL.");
+}
+
+async function restoreStateFromUrl() {
+  const payload = statePayloadFromHash();
+  if (!payload) {
+    return false;
+  }
+  const state = await decodePlaygroundState(payload);
+  if (state.inputType) {
+    const inputType = document.querySelector("#input-type");
+    if (inputType) {
+      inputType.value = String(state.inputType);
+      updateInputFormatState();
+    }
+  }
+  if (typeof state.schema === "string") {
+    setInputValue(state.schema);
+  }
+  clearOptionControls();
+  Object.entries(state.options || {}).forEach(([key, value]) => {
+    const control = document.querySelector(`[data-option="${CSS.escape(key)}"]`);
+    if (!control) {
+      return;
+    }
+    if (control.type === "checkbox") {
+      control.checked = value === true || value === "true" || value === "on";
+    } else if (Array.isArray(value)) {
+      control.value = value.join("\n");
+    } else {
+      control.value = String(value);
+    }
+    control.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  restoredUrlState = true;
+  refreshEditors();
+  return true;
 }
 
 function filterOptions(query) {
@@ -389,7 +518,8 @@ async function initWorker() {
     mountRenderedShell(info.html);
   }
   ready = true;
-  setStatus(`Ready: Pyodide ${info.pyodideVersion}, Python ${info.pythonVersion}, UI rendered by tdom`);
+  const readyMessage = `Ready: Pyodide ${info.pyodideVersion}, Python ${info.pythonVersion}, UI rendered by tdom`;
+  setStatus(restoredUrlState ? `${readyMessage}. Restored URL state.` : readyMessage);
   setGenerateState();
   await refreshCliOptions();
   scheduleAutoGenerate(0);
@@ -424,6 +554,8 @@ document.addEventListener("click", async (event) => {
   } else if (action === "copy-cli") {
     await navigator.clipboard.writeText(cliCommandText);
     setStatus(cliCommandText ? "Copied CLI command." : "Copied empty CLI command.");
+  } else if (action === "copy-repro-url") {
+    await copyReproUrl();
   } else if (action === "config") {
     openConfigDialog();
   } else if (action === "copy-config") {
@@ -463,11 +595,30 @@ document.addEventListener("click", async (event) => {
   }
 });
 
-mountInitialShell().catch((error) => {
-  setStatus(error?.message || "Could not load the playground shell.", true);
-});
-initWorker().catch((error) => {
+async function startPlayground() {
+  await mountInitialShell();
+  try {
+    await restoreStateFromUrl();
+  } catch (error) {
+    setStatus(`Could not load URL state: ${error?.message || String(error)}`, true);
+  }
+  await initWorker();
+}
+
+startPlayground().catch((error) => {
   setStatus(error?.stack || String(error), true);
+});
+
+window.addEventListener("hashchange", async () => {
+  try {
+    if (await restoreStateFromUrl()) {
+      setStatus("Loaded state from URL.");
+      await refreshCliOptions();
+      scheduleAutoGenerate(0);
+    }
+  } catch (error) {
+    setStatus(`Could not load URL state: ${error?.message || String(error)}`, true);
+  }
 });
 
 window.addEventListener("resize", () => {

--- a/docs/assets/playground/main.js
+++ b/docs/assets/playground/main.js
@@ -12,14 +12,26 @@ import {
 } from "./editor.js";
 
 const appEl = document.querySelector("#app");
-const rawWorker = new Worker("./worker.js", { type: "module" });
-const worker = Comlink.wrap(rawWorker);
 const stateEncoder = new TextEncoder();
 const stateDecoder = new TextDecoder();
 const stateFormatGzip = "gz";
 const stateFormatPlain = "b64";
 const stateVersion = 1;
+const versionsManifestUrl = "./generated/playground-versions.json";
+const fallbackVersionManifest = {
+  default: "current",
+  versions: [
+    {
+      id: "current",
+      label: "Current build",
+      kind: "current",
+      asset_base: "./generated/",
+    },
+  ],
+};
 
+let rawWorker = null;
+let worker = null;
 let ready = false;
 let running = false;
 let lastOutput = "";
@@ -36,6 +48,139 @@ let workspaceResizeObserver = null;
 let headerCompact = false;
 let workspaceCollapsed = false;
 let restoredUrlState = false;
+let playgroundVersions = [];
+let selectedPlaygroundVersion = null;
+let versionSelectionNotice = "";
+
+function absoluteUrl(path, base = window.location.href) {
+  return new URL(path, base).toString();
+}
+
+function normalizeInstall(install, assetBaseUrl) {
+  if (!install || typeof install !== "object") {
+    return null;
+  }
+  if (install.type === "wheel" && install.url) {
+    return {
+      type: "wheel",
+      url: absoluteUrl(install.url, assetBaseUrl),
+      deps: install.deps === true,
+    };
+  }
+  if (install.type === "requirement" && install.requirement) {
+    return {
+      type: "requirement",
+      requirement: String(install.requirement),
+      deps: install.deps === true,
+    };
+  }
+  return null;
+}
+
+function normalizePlaygroundVersion(entry) {
+  const id = String(entry?.id || "").trim();
+  if (!id) {
+    return null;
+  }
+  const assetBaseUrl = absoluteUrl(entry.asset_base || entry.assetBase || "./generated/");
+  return {
+    id,
+    label: String(entry.label || id),
+    kind: String(entry.kind || "custom"),
+    assetBaseUrl,
+    shellUrl: absoluteUrl(entry.app_shell || entry.app_shell_url || entry.shell_url || "app-shell.html", assetBaseUrl),
+    metadataUrl: absoluteUrl(
+      entry.metadata || entry.metadata_url || "codegen-ui-metadata.json",
+      assetBaseUrl,
+    ),
+    appUrl: absoluteUrl(entry.app || entry.app_url || "app.py", assetBaseUrl),
+    install: normalizeInstall(entry.install, assetBaseUrl),
+  };
+}
+
+async function loadPlaygroundVersions() {
+  let manifest = fallbackVersionManifest;
+  try {
+    const response = await fetch(versionsManifestUrl, { cache: "no-cache" });
+    if (response.ok) {
+      manifest = await response.json();
+    }
+  } catch {
+    manifest = fallbackVersionManifest;
+  }
+  const versions = (manifest.versions || []).map(normalizePlaygroundVersion).filter(Boolean);
+  if (versions.length === 0) {
+    return {
+      manifest: fallbackVersionManifest,
+      versions: fallbackVersionManifest.versions.map(normalizePlaygroundVersion).filter(Boolean),
+    };
+  }
+  return { manifest, versions };
+}
+
+function resolvePlaygroundVersion(manifest, versions) {
+  const requested = new URLSearchParams(window.location.search).get("version");
+  const defaultId = manifest.default || versions[0]?.id;
+  const selected = versions.find((version) => version.id === requested)
+    || versions.find((version) => version.id === defaultId)
+    || versions[0];
+  versionSelectionNotice = requested && requested !== selected.id
+    ? `Unknown playground version "${requested}", using ${selected.label}.`
+    : "";
+  return selected;
+}
+
+async function initPlaygroundVersions() {
+  const { manifest, versions } = await loadPlaygroundVersions();
+  playgroundVersions = versions;
+  selectedPlaygroundVersion = resolvePlaygroundVersion(manifest, versions);
+}
+
+function renderVersionSelect() {
+  const select = document.querySelector("#playground-version");
+  if (!select || !selectedPlaygroundVersion) {
+    return;
+  }
+  const versionIds = playgroundVersions.map((version) => version.id).join("\n");
+  if (select.dataset.versionIds !== versionIds) {
+    const options = playgroundVersions.map((version) => {
+      const option = new Option(version.label, version.id);
+      option.selected = version.id === selectedPlaygroundVersion.id;
+      return option;
+    });
+    select.replaceChildren(...options);
+    select.dataset.versionIds = versionIds;
+  }
+  select.value = selectedPlaygroundVersion.id;
+  select.disabled = running || playgroundVersions.length < 2;
+  select.title = selectedPlaygroundVersion.label;
+}
+
+function switchPlaygroundVersion(versionId) {
+  const nextVersion = playgroundVersions.find((version) => version.id === versionId);
+  if (!nextVersion || nextVersion.id === selectedPlaygroundVersion?.id) {
+    renderVersionSelect();
+    return;
+  }
+  const url = new URL(window.location.href);
+  url.searchParams.set("version", nextVersion.id);
+  setStatus(`Switching to ${nextVersion.label}...`);
+  document.querySelector("#playground-version")?.setAttribute("disabled", "");
+  window.location.assign(url.toString());
+}
+
+function createWorker() {
+  if (worker) {
+    return worker;
+  }
+  rawWorker = new Worker("./worker.js", { type: "module" });
+  rawWorker.addEventListener("error", (event) => {
+    setStatus(event.message || "Worker failed.", true);
+    finishGeneration();
+  });
+  worker = Comlink.wrap(rawWorker);
+  return worker;
+}
 
 function currentSchema() {
   return getInputValue();
@@ -101,7 +246,8 @@ function setLayoutState() {
 }
 
 async function mountInitialShell() {
-  const response = await fetch("./generated/app-shell.html");
+  const shellUrl = selectedPlaygroundVersion?.shellUrl || "./generated/app-shell.html";
+  const response = await fetch(shellUrl, { cache: "no-cache" });
   if (appShellMounted || !response.ok) {
     return;
   }
@@ -116,6 +262,7 @@ async function mountInitialShell() {
   updateInputFormatState();
   mountEditor();
   setLayoutState();
+  renderVersionSelect();
 }
 
 function mountRenderedShell(html) {
@@ -147,6 +294,7 @@ function mountRenderedShell(html) {
   mountEditor();
   syncStickyOffsets();
   setLayoutState();
+  renderVersionSelect();
   setGenerateState();
 }
 
@@ -229,6 +377,9 @@ function statePayloadFromHash() {
 
 function buildReproUrl(payload) {
   const url = new URL(window.location.href);
+  if (selectedPlaygroundVersion) {
+    url.searchParams.set("version", selectedPlaygroundVersion.id);
+  }
   const params = new URLSearchParams(url.hash.slice(1));
   params.set("state", payload);
   url.hash = params.toString();
@@ -250,8 +401,12 @@ async function restoreStateFromUrl() {
   const state = await decodePlaygroundState(payload);
   if (state.inputType) {
     const inputType = document.querySelector("#input-type");
-    if (inputType) {
-      inputType.value = String(state.inputType);
+    const inputTypeValue = String(state.inputType);
+    const isAvailableInputType = Array.from(inputType?.options || []).some(
+      (option) => option.value === inputTypeValue && !option.disabled,
+    );
+    if (inputType && isAvailableInputType) {
+      inputType.value = inputTypeValue;
       updateInputFormatState();
     }
   }
@@ -321,7 +476,7 @@ function scheduleAutoGenerate(delay = 650) {
 }
 
 async function refreshCliOptions() {
-  if (!ready) {
+  if (!ready || !worker) {
     return;
   }
   const requestId = ++cliRequestId;
@@ -412,7 +567,7 @@ function finishGeneration() {
 }
 
 async function requestGenerate(mode = "manual") {
-  if (!ready) {
+  if (!ready || !worker) {
     return;
   }
   if (running) {
@@ -491,6 +646,7 @@ function setGenerateState() {
     autoButton.setAttribute("aria-pressed", autoGenerate ? "true" : "false");
     autoButton.textContent = autoGenerate ? "Auto Generate: On" : "Auto Generate";
   }
+  renderVersionSelect();
 }
 
 function updateStatusTooltip() {
@@ -513,22 +669,30 @@ function setStatus(text, isError = false) {
 }
 
 async function initWorker() {
-  const info = await worker.init(Comlink.proxy((message) => setStatus(message)));
+  const api = createWorker();
+  const info = await api.init(Comlink.proxy((message) => setStatus(message)), selectedPlaygroundVersion);
   if (!appShellMounted) {
     mountRenderedShell(info.html);
   }
   ready = true;
-  const readyMessage = `Ready: Pyodide ${info.pyodideVersion}, Python ${info.pythonVersion}, UI rendered by tdom`;
-  setStatus(restoredUrlState ? `${readyMessage}. Restored URL state.` : readyMessage);
+  const readyMessage = [
+    `Ready: datamodel-code-generator ${info.codegenVersion}`,
+    `Pyodide ${info.pyodideVersion}`,
+    `Python ${info.pythonVersion}`,
+    `UI rendered by tdom`,
+  ].join(", ");
+  const notices = [readyMessage];
+  if (restoredUrlState) {
+    notices.push("Restored URL state.");
+  }
+  if (versionSelectionNotice) {
+    notices.push(versionSelectionNotice);
+  }
+  setStatus(notices.join(" "));
   setGenerateState();
   await refreshCliOptions();
   scheduleAutoGenerate(0);
 }
-
-rawWorker.addEventListener("error", (event) => {
-  setStatus(event.message || "Worker failed.", true);
-  finishGeneration();
-});
 
 document.addEventListener("click", async (event) => {
   const target = event.target.closest("[data-action]");
@@ -539,6 +703,9 @@ document.addEventListener("click", async (event) => {
   if (action === "generate") {
     requestGenerate("manual");
   } else if (action === "sample") {
+    if (!worker) {
+      return;
+    }
     setInputValue(await worker.sample(currentInputType()));
     setStatus(`Loaded ${currentInputType()} sample.`);
     scheduleAutoGenerate();
@@ -563,6 +730,9 @@ document.addEventListener("click", async (event) => {
     await navigator.clipboard.writeText(textarea?.value || configToml);
     setStatus("Copied pyproject.toml config.");
   } else if (action === "import-config") {
+    if (!worker) {
+      return;
+    }
     const textarea = document.querySelector("#config-toml");
     const result = await worker.importConfigToml(textarea?.value || "");
     if (!result.ok) {
@@ -596,7 +766,9 @@ document.addEventListener("click", async (event) => {
 });
 
 async function startPlayground() {
+  await initPlaygroundVersions();
   await mountInitialShell();
+  renderVersionSelect();
   try {
     await restoreStateFromUrl();
   } catch (error) {
@@ -628,7 +800,9 @@ window.addEventListener("resize", () => {
 });
 
 document.addEventListener("change", (event) => {
-  if (event.target.id === "input-type") {
+  if (event.target.id === "playground-version") {
+    switchPlaygroundVersion(event.target.value);
+  } else if (event.target.id === "input-type") {
     updateInputFormatState();
     refreshCliOptions();
     scheduleAutoGenerate();

--- a/docs/assets/playground/styles.css
+++ b/docs/assets/playground/styles.css
@@ -210,6 +210,22 @@ h1 a:hover {
   gap: 6px;
 }
 
+.version-control {
+  display: flex;
+  align-items: center;
+  grid-template-columns: none;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.version-control select {
+  height: 30px;
+  min-width: 132px;
+  max-width: 180px;
+  padding-left: 8px;
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
+}
+
 .topbar button {
   height: 30px;
   padding: 0 9px;
@@ -741,6 +757,11 @@ body.header-compact .topbar button {
   height: 28px;
   padding: 0 8px;
   font-size: 12px;
+}
+
+body.header-compact .version-control select {
+  height: 28px;
+  min-width: 120px;
 }
 
 body.header-compact #generate {

--- a/docs/assets/playground/worker.js
+++ b/docs/assets/playground/worker.js
@@ -18,9 +18,57 @@ const PYTHON_RUNTIME_PACKAGES = [
 let pyodideReadyPromise = null;
 let bootInfo = null;
 let statusCallback = null;
+let activeVersion = null;
 
 function postStatus(message) {
   statusCallback?.(message);
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, { cache: "no-cache" });
+  if (!response.ok) {
+    throw new Error(`Could not load ${url}: ${response.status}`);
+  }
+  return response.text();
+}
+
+function withDefaultVersionConfig(versionConfig = {}) {
+  const config = versionConfig || {};
+  const assetBaseUrl = config.assetBaseUrl || new URL("./generated/", self.location.href).toString();
+  return {
+    id: config.id || "current",
+    label: config.label || "Current build",
+    assetBaseUrl,
+    metadataUrl: config.metadataUrl || new URL("codegen-ui-metadata.json", assetBaseUrl).toString(),
+    appUrl: config.appUrl || new URL("app.py", assetBaseUrl).toString(),
+    install: config.install || null,
+  };
+}
+
+function packageInstallFromMetadata(metadata, versionConfig) {
+  const install = versionConfig.install;
+  if (install?.type === "wheel" && install.url) {
+    return {
+      source: install.url,
+      deps: install.deps === true,
+    };
+  }
+  if (install?.type === "requirement" && install.requirement) {
+    return {
+      source: install.requirement,
+      deps: install.deps === true,
+    };
+  }
+  if (metadata.package_wheel) {
+    return {
+      source: new URL(metadata.package_wheel, versionConfig.assetBaseUrl).toString(),
+      deps: false,
+    };
+  }
+  return {
+    source: "datamodel-code-generator",
+    deps: false,
+  };
 }
 
 async function findWheelUrl(project, version, matcher) {
@@ -36,8 +84,9 @@ async function findWheelUrl(project, version, matcher) {
   return wheel.url;
 }
 
-async function initPyodide() {
-  const metadataJson = await (await fetch("./generated/codegen-ui-metadata.json")).text();
+async function initPyodide(versionConfig) {
+  activeVersion = withDefaultVersionConfig(versionConfig);
+  const metadataJson = await fetchText(activeVersion.metadataUrl);
   const metadata = JSON.parse(metadataJson);
 
   postStatus("Loading Pyodide...");
@@ -55,39 +104,44 @@ import micropip
 await micropip.install(${JSON.stringify(PYTHON_RUNTIME_PACKAGES)})
 `);
 
-  const packageSource = metadata.package_wheel
-    ? `./generated/${metadata.package_wheel}`
-    : "datamodel-code-generator";
-  postStatus("Installing datamodel-code-generator...");
-  pyodide.globals.set("package_source", packageSource);
+  const packageInstall = packageInstallFromMetadata(metadata, activeVersion);
+  postStatus(`Installing datamodel-code-generator (${activeVersion.label})...`);
+  pyodide.globals.set("package_source", packageInstall.source);
+  pyodide.globals.set("package_deps", packageInstall.deps);
   await pyodide.runPythonAsync(`
 import micropip
-await micropip.install(package_source, deps=False)
+await micropip.install(package_source, deps=package_deps)
 `);
   pyodide.globals.delete("package_source");
+  pyodide.globals.delete("package_deps");
 
-  const appSource = await (await fetch("./app.py")).text();
+  const appSource = await fetchText(activeVersion.appUrl);
   pyodide.runPython(appSource);
   pyodide.globals.get("set_ui_metadata")(metadataJson);
 
   bootInfo = {
     html: pyodide.globals.get("render_app")(),
     metadataJson,
+    codegenVersion: pyodide.runPython(
+      "from importlib.metadata import version\nversion('datamodel-code-generator')",
+    ),
+    selectedVersion: activeVersion.id,
+    selectedVersionLabel: activeVersion.label,
     pyodideVersion: PYODIDE_VERSION,
     pythonVersion: pyodide.runPython("import sys; sys.version.split()[0]"),
   };
   return pyodide;
 }
 
-async function ensurePyodide(onStatus = null) {
+async function ensurePyodide(onStatus = null, versionConfig = null) {
   statusCallback = onStatus;
-  pyodideReadyPromise ??= initPyodide();
+  pyodideReadyPromise ??= initPyodide(versionConfig);
   return pyodideReadyPromise;
 }
 
 const api = {
-  async init(onStatus) {
-    await ensurePyodide(onStatus);
+  async init(onStatus, versionConfig) {
+    await ensurePyodide(onStatus, versionConfig);
     return bootInfo;
   },
 

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -3,6 +3,7 @@
 Run datamodel-code-generator in your browser. The deployed site serves this route as a standalone app so Pyodide only starts after you open it.
 
 Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the URL fragment.
+When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared URL.
 
 <p>
   <a class="md-button md-button--primary" href="../assets/playground/index.html">Open Playground</a>

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -2,6 +2,8 @@
 
 Run datamodel-code-generator in your browser. The deployed site serves this route as a standalone app so Pyodide only starts after you open it.
 
+Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the URL fragment.
+
 <p>
   <a class="md-button md-button--primary" href="../assets/playground/index.html">Open Playground</a>
 </p>

--- a/scripts/build_playground_assets.py
+++ b/scripts/build_playground_assets.py
@@ -305,9 +305,13 @@ def _extra_versions() -> list[dict[str, Any]]:
     raw_versions = os.environ.get("PLAYGROUND_EXTRA_VERSIONS_JSON")
     if not raw_versions:
         return []
-    versions = json.loads(raw_versions)
-    if not isinstance(versions, list):
-        msg = "PLAYGROUND_EXTRA_VERSIONS_JSON must be a JSON array"
+    try:
+        versions = json.loads(raw_versions)
+    except json.JSONDecodeError as exc:
+        msg = f"PLAYGROUND_EXTRA_VERSIONS_JSON is not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(versions, list) or not all(isinstance(version, dict) for version in versions):
+        msg = "PLAYGROUND_EXTRA_VERSIONS_JSON must be a JSON array of objects"
         raise TypeError(msg)
     return cast("list[dict[str, Any]]", versions)
 

--- a/scripts/build_playground_assets.py
+++ b/scripts/build_playground_assets.py
@@ -7,6 +7,8 @@ import ast
 import importlib.util
 import inspect
 import json
+import os
+import shutil
 import sys
 import textwrap
 from pathlib import Path
@@ -22,6 +24,9 @@ PLAYGROUND_ROOT = ROOT / "docs" / "assets" / "playground"
 GENERATED_ROOT = PLAYGROUND_ROOT / "generated"
 METADATA_PATH = GENERATED_ROOT / "codegen-ui-metadata.json"
 APP_SHELL_PATH = GENERATED_ROOT / "app-shell.html"
+APP_SOURCE_PATH = PLAYGROUND_ROOT / "app.py"
+GENERATED_APP_PATH = GENERATED_ROOT / "app.py"
+VERSIONS_PATH = GENERATED_ROOT / "playground-versions.json"
 
 BROWSER_SUPPORTED_INPUT_TYPES = {
     InputFileType.Auto.value,
@@ -296,8 +301,51 @@ def build_metadata() -> dict[str, Any]:
     return metadata
 
 
+def _extra_versions() -> list[dict[str, Any]]:
+    raw_versions = os.environ.get("PLAYGROUND_EXTRA_VERSIONS_JSON")
+    if not raw_versions:
+        return []
+    versions = json.loads(raw_versions)
+    if not isinstance(versions, list):
+        msg = "PLAYGROUND_EXTRA_VERSIONS_JSON must be a JSON array"
+        raise TypeError(msg)
+    return cast("list[dict[str, Any]]", versions)
+
+
+def build_versions(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Return runtime version entries for the browser playground."""
+    current_id = os.environ.get("PLAYGROUND_VERSION_ID", "current")
+    current_version = {
+        "id": current_id,
+        "label": os.environ.get("PLAYGROUND_VERSION_LABEL", "Current build"),
+        "kind": os.environ.get("PLAYGROUND_VERSION_KIND", "current"),
+        "asset_base": "./generated/",
+    }
+    if source_ref := os.environ.get("PLAYGROUND_SOURCE_REF"):
+        current_version["source_ref"] = source_ref
+
+    if package_wheel := metadata.get("package_wheel"):
+        current_version["install"] = {
+            "type": "wheel",
+            "url": package_wheel,
+            "deps": False,
+        }
+    else:
+        current_version["install"] = {
+            "type": "requirement",
+            "requirement": "datamodel-code-generator",
+            "deps": False,
+        }
+
+    return {
+        "schema_version": 1,
+        "default": os.environ.get("PLAYGROUND_DEFAULT_VERSION", current_id),
+        "versions": [current_version, *_extra_versions()],
+    }
+
+
 def _load_playground_app() -> Any:
-    spec = importlib.util.spec_from_file_location("playground_app", PLAYGROUND_ROOT / "app.py")
+    spec = importlib.util.spec_from_file_location("playground_app", APP_SOURCE_PATH)
     if spec is None or spec.loader is None:
         message = "Could not load playground app module"
         raise RuntimeError(message)
@@ -312,6 +360,7 @@ def main() -> None:
     metadata_json = json.dumps(metadata, indent=2, ensure_ascii=False) + "\n"
     GENERATED_ROOT.mkdir(parents=True, exist_ok=True)
     METADATA_PATH.write_text(metadata_json, encoding="utf-8")
+    shutil.copyfile(APP_SOURCE_PATH, GENERATED_APP_PATH)
 
     app = _load_playground_app()
     app.set_ui_metadata(metadata_json)
@@ -319,9 +368,15 @@ def main() -> None:
         app.render_app() + "\n",
         encoding="utf-8",
     )
+    VERSIONS_PATH.write_text(
+        json.dumps(build_versions(metadata), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
 
     print(f"Generated {METADATA_PATH.relative_to(ROOT)}")
+    print(f"Generated {GENERATED_APP_PATH.relative_to(ROOT)}")
     print(f"Generated {APP_SHELL_PATH.relative_to(ROOT)}")
+    print(f"Generated {VERSIONS_PATH.relative_to(ROOT)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playground now preserves the selected version in shared URLs and exposes multiple selectable playground versions so you can switch and reproduce specific releases.

* **Documentation**
  * Updated playground docs to clarify that the selected ?version= parameter is retained when using Copy Repro URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->