### PR TITLE
Add playground privacy note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 🚀 Generate Python data models from schema definitions in seconds.
 
-🧪 Try it in your browser: [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) - runs locally in
-your browser with Pyodide; schemas and options are not sent to a backend.
+🧪 Try it in your browser: [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/)
+
+> [!NOTE]
+> Playground privacy: generation runs locally in your browser with Pyodide. Schemas and options are not sent to a
+> backend. Shared repro URLs encode them in the URL fragment (`#state=...`), which browsers do not send to the server;
+> the full URL can still be stored in your browser history or wherever you share it.
 
 [![PyPI version](https://badge.fury.io/py/datamodel-code-generator.svg)](https://pypi.python.org/pypi/datamodel-code-generator)
 [![Conda-forge](https://img.shields.io/conda/v/conda-forge/datamodel-code-generator)](https://anaconda.org/conda-forge/datamodel-code-generator)
@@ -30,8 +34,7 @@ your browser with Pyodide; schemas and options are not sent to a backend.
 **👉 [datamodel-code-generator.koxudaxi.dev](https://datamodel-code-generator.koxudaxi.dev)**
 
 - 🖥️ [CLI Reference](https://datamodel-code-generator.koxudaxi.dev/cli-reference/) - All command-line options
-- 🧪 [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) - Try generation locally in your browser
-  with Pyodide; shared repro URLs encode state in the URL fragment.
+- 🧪 [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) - Try generation in your browser
 - ⚙️ [pyproject.toml](https://datamodel-code-generator.koxudaxi.dev/pyproject_toml/) - Configuration file
 - 🔄 [CI/CD Integration](https://datamodel-code-generator.koxudaxi.dev/ci-cd/) - GitHub Actions, pre-commit hooks
 - 🚀 [One-liner Usage](https://datamodel-code-generator.koxudaxi.dev/oneliner/) - uvx, pipx, clipboard integration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 🚀 Generate Python data models from schema definitions in seconds.
 
-🧪 Try it in your browser: [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/)
+🧪 Try it in your browser: [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) - runs locally in
+your browser with Pyodide; schemas and options are not sent to a backend.
 
 [![PyPI version](https://badge.fury.io/py/datamodel-code-generator.svg)](https://pypi.python.org/pypi/datamodel-code-generator)
 [![Conda-forge](https://img.shields.io/conda/v/conda-forge/datamodel-code-generator)](https://anaconda.org/conda-forge/datamodel-code-generator)
@@ -29,7 +30,8 @@
 **👉 [datamodel-code-generator.koxudaxi.dev](https://datamodel-code-generator.koxudaxi.dev)**
 
 - 🖥️ [CLI Reference](https://datamodel-code-generator.koxudaxi.dev/cli-reference/) - All command-line options
-- 🧪 [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) - Try generation in your browser
+- 🧪 [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) - Try generation locally in your browser
+  with Pyodide; shared repro URLs encode state in the URL fragment.
 - ⚙️ [pyproject.toml](https://datamodel-code-generator.koxudaxi.dev/pyproject_toml/) - Configuration file
 - 🔄 [CI/CD Integration](https://datamodel-code-generator.koxudaxi.dev/ci-cd/) - GitHub Actions, pre-commit hooks
 - 🚀 [One-liner Usage](https://datamodel-code-generator.koxudaxi.dev/oneliner/) - uvx, pipx, clipboard integration

--- a/docs/assets/playground/app.py
+++ b/docs/assets/playground/app.py
@@ -94,6 +94,12 @@ CONFIG_FORCED_OPTIONS = {
     "formatters": [formatter.value for formatter in PLAYGROUND_FORMATTERS],
 }
 CONFIG_TABLE = "tool.datamodel-codegen"
+SECURITY_TOOLTIP = (
+    "Generation runs locally in your browser with Pyodide. Schemas and options are not uploaded. "
+    "Copy Repro URL stores them in the #state URL fragment, which is not sent to the server; "
+    "only the optional ?version query is sent as a normal page request. The full shared URL can still be saved "
+    "in browser history or services where you paste it."
+)
 
 
 def set_ui_metadata(metadata_json: str) -> None:
@@ -297,6 +303,13 @@ def App(
             UI rendered with <a href="https://github.com/t-strings/tdom" target="_blank" rel="noreferrer">tdom</a>
             using <a href="https://peps.python.org/pep-0750/" target="_blank" rel="noreferrer">PEP 750 t-strings</a>.
           </p>
+          <span
+            class="security-note"
+            tabindex="0"
+            data-tooltip="{SECURITY_TOOLTIP}"
+          >
+            Security: local execution
+          </span>
           <p id="status">Loading Pyodide runtime...</p>
         </div>
       </header>

--- a/docs/assets/playground/styles.css
+++ b/docs/assets/playground/styles.css
@@ -88,6 +88,7 @@ input {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 14px;
 }
 
@@ -176,6 +177,55 @@ h1 a:hover {
 
 .tech-note a:hover {
   text-decoration: underline;
+}
+
+.security-note {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid rgb(129 212 250 / 34%);
+  border-radius: 999px;
+  background: rgb(3 169 244 / 10%);
+  color: #b3e5fc;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: help;
+}
+
+.security-note::after {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 8px);
+  z-index: 40;
+  width: min(420px, calc(100vw - 24px));
+  padding: 9px 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel-strong);
+  box-shadow: var(--shadow-md);
+  color: var(--text);
+  content: attr(data-tooltip);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translateX(-50%) translateY(2px);
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+  white-space: normal;
+}
+
+.security-note:hover::after,
+.security-note:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }
 
 .docs-nav {
@@ -796,6 +846,33 @@ body.workspace-collapsed .output-editor-mount {
   .docs-nav {
     margin-left: 0;
     overflow-x: auto;
+  }
+
+  .topbar-meta {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .tech-note,
+  #status {
+    width: 100%;
+    min-width: 0;
+    white-space: normal;
+  }
+
+  .security-note {
+    width: fit-content;
+  }
+
+  .security-note::after {
+    left: 0;
+    transform: translateY(-2px);
+  }
+
+  .security-note:hover::after,
+  .security-note:focus-visible::after {
+    transform: translateY(0);
   }
 
   .controls {

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,10 +30,11 @@ Generate models in your browser without installing anything.
   <a class="md-button md-button--primary" href="playground.md" target="_self">Open Playground</a>
 </p>
 
-The playground runs datamodel-code-generator locally in your browser with Pyodide. Your schema and options are not sent
-to a backend for generation. If you copy a repro URL, the schema and options are encoded in the URL fragment
-(`#state=...`), which browsers do not send to the server; the full URL can still be stored in your browser history or
-wherever you share it.
+!!! note "Playground privacy"
+    The playground runs datamodel-code-generator locally in your browser with Pyodide. Your schema and options are not
+    sent to a backend for generation. If you copy a repro URL, the schema and options are encoded in the URL fragment
+    (`#state=...`), which browsers do not send to the server; the full URL can still be stored in your browser history
+    or wherever you share it.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,11 @@ Generate models in your browser without installing anything.
   <a class="md-button md-button--primary" href="playground.md" target="_self">Open Playground</a>
 </p>
 
+The playground runs datamodel-code-generator locally in your browser with Pyodide. Your schema and options are not sent
+to a backend for generation. If you copy a repro URL, the schema and options are encoded in the URL fragment
+(`#state=...`), which browsers do not send to the server; the full URL can still be stored in your browser history or
+wherever you share it.
+
 ---
 
 ## 📦 Installation

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -32,10 +32,11 @@ Generate models in your browser without installing anything.
   <a class="md-button md-button--primary" href="playground.md" target="_self">Open Playground</a>
 </p>
 
-The playground runs datamodel-code-generator locally in your browser with Pyodide. Your schema and options are not sent
-to a backend for generation. If you copy a repro URL, the schema and options are encoded in the URL fragment
-(`#state=...`), which browsers do not send to the server; the full URL can still be stored in your browser history or
-wherever you share it.
+!!! note "Playground privacy"
+    The playground runs datamodel-code-generator locally in your browser with Pyodide. Your schema and options are not
+    sent to a backend for generation. If you copy a repro URL, the schema and options are encoded in the URL fragment
+    (`#state=...`), which browsers do not send to the server; the full URL can still be stored in your browser history
+    or wherever you share it.
 
 ---
 
@@ -256,16 +257,17 @@ Source: https://datamodel-code-generator.koxudaxi.dev/playground/
 
 Run datamodel-code-generator in your browser. The deployed site serves this route as a standalone app so Pyodide only starts after you open it.
 
-The playground runs entirely in your browser with Pyodide. Your schema, selected input type, and options are passed to
-the local Pyodide worker for generation and are not posted to a backend server.
+!!! note "Playground privacy"
+    The playground runs entirely in your browser with Pyodide. Your schema, selected input type, and options are passed
+    to the local Pyodide worker for generation and are not posted to a backend server.
 
-Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the URL fragment.
-When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared URL.
-The fragment part (`#state=...`) is client-side URL state and is not included in HTTP requests, so the encoded schema and
-options are not sent to the hosting server or Cloudflare by opening the link. The complete URL, including the fragment,
-can still be stored in local browser history and is visible to anyone or any service you share it with. The optional
-`?version=` query parameter is sent in normal page requests, so hosting/CDN metrics can record the selected playground
-version but not the encoded schema or options.
+    Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the
+    URL fragment. When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared
+    URL. The fragment part (`#state=...`) is client-side URL state and is not included in HTTP requests, so the encoded
+    schema and options are not sent to the hosting server or Cloudflare by opening the link. The complete URL, including
+    the fragment, can still be stored in local browser history and is visible to anyone or any service you share it
+    with. The optional `?version=` query parameter is sent in normal page requests, so hosting/CDN metrics can record the
+    selected playground version but not the encoded schema or options.
 
 <p>
   <a class="md-button md-button--primary" href="../assets/playground/index.html">Open Playground</a>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -32,6 +32,11 @@ Generate models in your browser without installing anything.
   <a class="md-button md-button--primary" href="playground.md" target="_self">Open Playground</a>
 </p>
 
+The playground runs datamodel-code-generator locally in your browser with Pyodide. Your schema and options are not sent
+to a backend for generation. If you copy a repro URL, the schema and options are encoded in the URL fragment
+(`#state=...`), which browsers do not send to the server; the full URL can still be stored in your browser history or
+wherever you share it.
+
 ---
 
 ## 📦 Installation
@@ -251,7 +256,16 @@ Source: https://datamodel-code-generator.koxudaxi.dev/playground/
 
 Run datamodel-code-generator in your browser. The deployed site serves this route as a standalone app so Pyodide only starts after you open it.
 
+The playground runs entirely in your browser with Pyodide. Your schema, selected input type, and options are passed to
+the local Pyodide worker for generation and are not posted to a backend server.
+
 Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the URL fragment.
+When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared URL.
+The fragment part (`#state=...`) is client-side URL state and is not included in HTTP requests, so the encoded schema and
+options are not sent to the hosting server or Cloudflare by opening the link. The complete URL, including the fragment,
+can still be stored in local browser history and is visible to anyone or any service you share it with. The optional
+`?version=` query parameter is sent in normal page requests, so hosting/CDN metrics can record the selected playground
+version but not the encoded schema or options.
 
 <p>
   <a class="md-button md-button--primary" href="../assets/playground/index.html">Open Playground</a>

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -2,8 +2,16 @@
 
 Run datamodel-code-generator in your browser. The deployed site serves this route as a standalone app so Pyodide only starts after you open it.
 
+The playground runs entirely in your browser with Pyodide. Your schema, selected input type, and options are passed to
+the local Pyodide worker for generation and are not posted to a backend server.
+
 Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the URL fragment.
 When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared URL.
+The fragment part (`#state=...`) is client-side URL state and is not included in HTTP requests, so the encoded schema and
+options are not sent to the hosting server or Cloudflare by opening the link. The complete URL, including the fragment,
+can still be stored in local browser history and is visible to anyone or any service you share it with. The optional
+`?version=` query parameter is sent in normal page requests, so hosting/CDN metrics can record the selected playground
+version but not the encoded schema or options.
 
 <p>
   <a class="md-button md-button--primary" href="../assets/playground/index.html">Open Playground</a>

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -2,16 +2,17 @@
 
 Run datamodel-code-generator in your browser. The deployed site serves this route as a standalone app so Pyodide only starts after you open it.
 
-The playground runs entirely in your browser with Pyodide. Your schema, selected input type, and options are passed to
-the local Pyodide worker for generation and are not posted to a backend server.
+!!! note "Playground privacy"
+    The playground runs entirely in your browser with Pyodide. Your schema, selected input type, and options are passed
+    to the local Pyodide worker for generation and are not posted to a backend server.
 
-Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the URL fragment.
-When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared URL.
-The fragment part (`#state=...`) is client-side URL state and is not included in HTTP requests, so the encoded schema and
-options are not sent to the hosting server or Cloudflare by opening the link. The complete URL, including the fragment,
-can still be stored in local browser history and is visible to anyone or any service you share it with. The optional
-`?version=` query parameter is sent in normal page requests, so hosting/CDN metrics can record the selected playground
-version but not the encoded schema or options.
+    Use **Copy Repro URL** in the playground to share the current input schema, input type, and selected options in the
+    URL fragment. When a playground version is selected, **Copy Repro URL** keeps the selected `?version=` in the shared
+    URL. The fragment part (`#state=...`) is client-side URL state and is not included in HTTP requests, so the encoded
+    schema and options are not sent to the hosting server or Cloudflare by opening the link. The complete URL, including
+    the fragment, can still be stored in local browser history and is visible to anyone or any service you share it
+    with. The optional `?version=` query parameter is sent in normal page requests, so hosting/CDN metrics can record the
+    selected playground version but not the encoded schema or options.
 
 <p>
   <a class="md-button md-button--primary" href="../assets/playground/index.html">Open Playground</a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Playground runs fully in the browser via Pyodide and does not send schemas/options to backend servers.
  * Expanded guidance on sharing reproductions: explains how state is encoded in the URL fragment (client-side only), how the version query parameter is preserved, and what is included when copying or sharing a repro URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->