### PR TITLE
Fix generated files

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -8,7 +8,7 @@ This page lists deprecations and scheduled breaking changes.
 |----|------|--------|---------------|---------|-------------|
 | `format.default-formatters` | behavior | `Default formatters` | 0.52.0 | TBD | Set formatters explicitly, for example black and isort or builtin. |
 | `behavior.pydantic-v2-use-annotated-default` | behavior | `Pydantic v2 default for --use-annotated` | 0.52.1 | TBD | Explicitly pass --use-annotated or --no-use-annotated. |
-| `behavior.remote-ref-default` | behavior | `Remote $ref fetching without --allow-remote-refs` | 0.56.0 | TBD | Pass --allow-remote-refs or --no-allow-remote-refs explicitly. |
+| `behavior.remote-ref-default` | behavior | `Remote $ref fetching without --allow-remote-refs` | 0.56.0 | TBD | Pass --allow-remote-refs for trusted remote schemas, or --no-allow-remote-refs to block HTTP(S) $ref fetching. |
 | `cli.allow-extra-fields` | cli-option | `--allow-extra-fields` | 0.31.0 | TBD | --extra-fields=allow |
 | `cli.parent-scoped-naming` | cli-option | `--parent-scoped-naming` | 0.48.0 | TBD | --naming-strategy parent-prefixed |
 | `cli.validation` | cli-option | `--validation` | 0.24.0 | TBD | --field-constraints |
@@ -48,11 +48,11 @@ Pydantic v2 with --use-annotated is recommended for correct type annotations. In
 - **Warning since:** 0.56.0
 - **Planned removal:** TBD
 - **Warning category:** `FutureWarning`
-- **Replacement:** Pass --allow-remote-refs or --no-allow-remote-refs explicitly.
+- **Replacement:** Pass --allow-remote-refs for trusted remote schemas, or --no-allow-remote-refs to block HTTP(S) $ref fetching.
 
 Remote $ref fetching without --allow-remote-refs is deprecated.
 
-The current default allows remote fetching for compatibility; the scheduled default is disabled.
+The current default allows remote fetching for compatibility; the scheduled default is disabled. Private, loopback, link-local, and otherwise non-public network targets require --allow-private-network.
 
 ### `cli.allow-extra-fields`
 

--- a/src/datamodel_code_generator/http.py
+++ b/src/datamodel_code_generator/http.py
@@ -32,17 +32,66 @@ DEFAULT_HTTP_TIMEOUT = 30.0
 MAX_HTTP_REDIRECTS = 20
 _HTTP_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 _UNSAFE_HOST_NAMES = frozenset({"localhost"})
+_IPV4_PART_COUNT = 4
+_IPV4_OCTET_MAX = 0xFF
+_IPV4_THREE_PART_TAIL_MAX = 0xFFFF
+_IPV4_TWO_PART_TAIL_MAX = 0xFFFFFF
+_IPV4_ADDRESS_MAX = 0xFFFFFFFF
 
 
 def _is_safe_ip(ip: IPv4Address | IPv6Address) -> bool:
     return ip.is_global
 
 
-def _get_ips_from_host(host: str) -> tuple[IPv4Address | IPv6Address, ...]:
+def _parse_legacy_ipv4_int(value: str) -> int | None:
     try:
-        return (ip_address(host.split("%", maxsplit=1)[0]),)
+        if value.lower().startswith("0x"):
+            return int(value, 0)
+        if len(value) > 1 and value.startswith("0"):
+            return int(value[1:], 8)
+        return int(value, 10)
+    except ValueError:
+        return None
+
+
+def _parse_legacy_ipv4_address(host: str) -> IPv4Address | None:
+    parts = host.split(".")
+    if len(parts) > _IPV4_PART_COUNT:
+        return None
+
+    numbers: list[int] = []
+    for part in parts:
+        if (number := _parse_legacy_ipv4_int(part)) is None:
+            return None
+        numbers.append(number)
+
+    ipv4_value: int | None
+    match numbers:
+        case [a] if 0 <= a <= _IPV4_ADDRESS_MAX:
+            ipv4_value = a
+        case [a, b] if 0 <= a <= _IPV4_OCTET_MAX and 0 <= b <= _IPV4_TWO_PART_TAIL_MAX:
+            ipv4_value = (a << 24) | b
+        case [a, b, c] if (
+            0 <= a <= _IPV4_OCTET_MAX and 0 <= b <= _IPV4_OCTET_MAX and 0 <= c <= _IPV4_THREE_PART_TAIL_MAX
+        ):
+            ipv4_value = (a << 24) | (b << 16) | c
+        case [a, b, c, d] if all(0 <= part <= _IPV4_OCTET_MAX for part in (a, b, c, d)):
+            ipv4_value = (a << 24) | (b << 16) | (c << 8) | d
+        case _:
+            ipv4_value = None
+
+    return IPv4Address(ipv4_value) if ipv4_value is not None else None
+
+
+def _get_ips_from_host(host: str) -> tuple[IPv4Address | IPv6Address, ...]:
+    normalized_host = host.split("%", maxsplit=1)[0]
+    try:
+        return (ip_address(normalized_host),)
     except ValueError:
         pass
+
+    if (legacy_ipv4 := _parse_legacy_ipv4_address(normalized_host)) is not None:
+        return (legacy_ipv4,)
 
     try:
         addr_infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)

--- a/tests/data/expected/main/input_model/config_class.py
+++ b/tests/data/expected/main/input_model/config_class.py
@@ -211,6 +211,7 @@ class GenerateConfig(TypedDict, closed=True):
     allof_merge_mode: NotRequired[AllOfMergeMode]
     allof_class_hierarchy: NotRequired[AllOfClassHierarchy]
     allow_remote_refs: NotRequired[bool | None]
+    allow_private_network: NotRequired[bool]
     http_headers: NotRequired[Sequence[tuple[str, str]] | None]
     http_local_ref_path: NotRequired[str | None]
     http_ignore_tls: NotRequired[bool]

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 from datamodel_code_generator import SchemaFetchError
-from datamodel_code_generator.http import get_body
+from datamodel_code_generator.http import MAX_HTTP_REDIRECTS, get_body
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -82,6 +82,52 @@ def test_get_body_blocks_unsafe_url_hosts(mocker: MockerFixture, url: str) -> No
     with pytest.raises(SchemaFetchError, match="--allow-private-network"):
         get_body(url)
     assert mock_get.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.1/schema.json",
+        "http://2130706433/schema.json",
+        "http://0x7f000001/schema.json",
+        "http://0177.0.0.1/schema.json",
+    ],
+)
+def test_get_body_blocks_unsafe_ipv4_literals_without_dns(mocker: MockerFixture, url: str) -> None:
+    """Block legacy IPv4 literals without depending on platform DNS behavior."""
+    mocker.patch("socket.getaddrinfo", side_effect=OSError)
+    mock_get = mocker.patch("httpx.get")
+
+    with pytest.raises(SchemaFetchError, match="--allow-private-network"):
+        get_body(url)
+    assert mock_get.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.1/schema.json",
+        "http://1.2.3.4.5/schema.json",
+        "http://256.0.0.1/schema.json",
+    ],
+)
+def test_get_body_handles_legacy_ipv4_literal_boundaries(mocker: MockerFixture, url: str) -> None:
+    """Cover legacy IPv4 parser boundary cases without platform DNS behavior."""
+    mocker.patch("socket.getaddrinfo", side_effect=OSError)
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = '{"type": "object"}'
+    mock_get = mocker.patch("httpx.get", return_value=mock_response)
+
+    if url == "http://127.0.1/schema.json":
+        with pytest.raises(SchemaFetchError, match="--allow-private-network"):
+            get_body(url)
+        assert mock_get.call_count == 0
+    else:
+        result = get_body(url)
+        assert result == '{"type": "object"}'
+        assert mock_get.call_count == 1
 
 
 def test_get_body_allows_unsafe_url_host_with_explicit_opt_in(mocker: MockerFixture) -> None:
@@ -166,6 +212,40 @@ def test_get_body_follows_relative_redirect(mocker: MockerFixture) -> None:
     ]
     assert mock_get.call_args_list[0].kwargs["params"] == [("version", "v2")]
     assert mock_get.call_args_list[1].kwargs["params"] is None
+
+
+@pytest.mark.parametrize("url", ["ftp://example.com/schema.json", "https:///schema.json"])
+def test_get_body_rejects_invalid_fetch_urls(mocker: MockerFixture, url: str) -> None:
+    """Reject unsupported or incomplete URLs before fetching."""
+    mock_get = mocker.patch("httpx.get")
+
+    with pytest.raises(SchemaFetchError, match="HTTP fetch"):
+        get_body(url)
+    assert mock_get.call_count == 0
+
+
+def test_get_body_rejects_redirect_without_location(mocker: MockerFixture) -> None:
+    """Reject redirect responses that do not provide a target."""
+    mock_response = Mock()
+    mock_response.status_code = 302
+    mock_response.headers = {}
+    mock_get = mocker.patch("httpx.get", return_value=mock_response)
+
+    with pytest.raises(SchemaFetchError, match="missing a Location header"):
+        get_body("https://example.com/schema.json")
+    assert mock_get.call_count == 1
+
+
+def test_get_body_rejects_too_many_redirects(mocker: MockerFixture) -> None:
+    """Reject redirect chains that exceed the configured limit."""
+    mock_response = Mock()
+    mock_response.status_code = 302
+    mock_response.headers = {"location": "https://example.com/schema.json"}
+    mock_get = mocker.patch("httpx.get", return_value=mock_response)
+
+    with pytest.raises(SchemaFetchError, match="Too many redirects"):
+        get_body("https://example.com/schema.json")
+    assert mock_get.call_count == MAX_HTTP_REDIRECTS + 1
 
 
 def test_get_body_wraps_transport_error(mocker: MockerFixture) -> None:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in allow-private-network option to enable fetching from non-public network targets.

* **Documentation**
  * Clarified deprecation guidance to distinguish trusted remote schema allowance from blocking HTTP(S) reference fetching and noted the opt-in requirement for non-public network targets.

* **Bug Fixes**
  * Strengthened URL/host validation to block legacy IPv4 literal forms unless allow-private-network is enabled.

* **Tests**
  * Expanded HTTP/redirect and URL-safety tests to cover legacy IPv4 and redirect edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->