### PR TITLE
Reuse ModelResolver for field name collision resolution

### DIFF
--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -2420,6 +2420,11 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         rename_type = self.field_type_collision_strategy == FieldTypeCollisionStrategy.RenameType
         all_class_names = {cast("str", m.class_name) for m in models if m.class_name}
 
+        resolver = ModelResolver(
+            snake_case_field=self.snake_case_field,
+            remove_suffix_number=True,
+        )
+
         for model in models:
             if "Enum" in model.base_class or not model.BASE_CLASS:
                 continue
@@ -2437,22 +2442,14 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                         colliding_reference = data_type.reference
 
                 if colliding_reference is not None:
-                    resolver = ModelResolver(
-                        exclude_names=all_class_names.copy(),
-                        snake_case_field=self.snake_case_field,
-                        remove_suffix_number=True,
-                    )
+                    resolver._reset_for_reuse(all_class_names.copy())  # noqa: SLF001
                     source = cast("DataModel", colliding_reference.source)
                     resolver.exclude_names.add(cast("str", filed_name))
                     new_class_name = resolver.add(["type"], cast("str", source.class_name)).name  # ty: ignore
                     source.class_name = new_class_name
                     all_class_names.add(new_class_name)
                 elif not rename_type:
-                    resolver = ModelResolver(
-                        exclude_names=reference_type_names,
-                        snake_case_field=self.snake_case_field,
-                        remove_suffix_number=True,
-                    )
+                    resolver._reset_for_reuse(reference_type_names)  # noqa: SLF001
                     new_filed_name = resolver.add(["field"], cast("str", filed_name)).name
                     if filed_name != new_filed_name:
                         field.alias = filed_name

--- a/src/datamodel_code_generator/reference.py
+++ b/src/datamodel_code_generator/reference.py
@@ -554,6 +554,16 @@ class ModelResolver:  # noqa: PLR0904
             {} if default_value_overrides is None else {**default_value_overrides}
         )
 
+    def _reset_for_reuse(self, exclude_names: set[str]) -> None:
+        """Reset naming state so this resolver behaves like a freshly constructed one.
+
+        Internal helper for hot paths that would otherwise construct a new
+        ModelResolver per call; only the state touched by add() is reset.
+        """
+        self.exclude_names = exclude_names
+        self.references.clear()
+        self._reference_names_cache.clear()
+
     def _get_reference_names(self) -> set[str]:
         """Get the set of all reference names for uniqueness checking."""
         return self._reference_names_cache


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal name collision resolution logic to improve performance by reusing components instead of reconstructing instances for each collision scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->