### PR TITLE
Break reference cycles in parsed graph after generation

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -999,6 +999,7 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             all_exports_collision_strategy=config.all_exports_collision_strategy,
             module_split_mode=config.module_split_mode,
         )
+    parser._dispose()  # noqa: SLF001
     if not input_filename:  # pragma: no cover
         match input_:
             case str():

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -3565,6 +3565,18 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                     future_imports=future_imports_str,
                 )
 
+    def _dispose(self) -> None:
+        """Break reference cycles in the parsed object graph.
+
+        Models, fields, data types, and references point at each other in
+        cycles, which keeps the whole graph alive until a full garbage
+        collection pass. Severing the back references lets ordinary reference
+        counting reclaim the graph as soon as the parser is dropped, which
+        matters for processes that call generate() repeatedly.
+        """
+        self.generation_store._dispose(self.model_resolver.references.values())  # noqa: SLF001
+        self.model_resolver.references.clear()
+
     def parse(  # noqa: PLR0913, PLR0914, PLR0917
         self,
         with_import: bool | None = True,  # noqa: FBT001, FBT002

--- a/src/datamodel_code_generator/parser/generation.py
+++ b/src/datamodel_code_generator/parser/generation.py
@@ -533,6 +533,34 @@ class GenerationStore:  # noqa: PLR0904
         store = cls()
         return store, store.models
 
+    def _dispose(self, references: Iterable[Reference] = ()) -> None:
+        """Drop all facts and model references so the parsed graph can be reclaimed.
+
+        The store, its model list, and its facts hold strong references to every
+        model and data type; clearing them removes the last anchors keeping the
+        object graph alive once the parser is dropped. Models, fields, data
+        types, and references also point at each other in cycles, so their back
+        references are severed first to let ordinary reference counting reclaim
+        the graph without waiting for a full garbage collection pass.
+        """
+        for model in self.models:
+            for model_field in model.fields:
+                for data_type in list(model_field.data_type.all_data_types):
+                    data_type.parent = None
+                    data_type.reference = None
+                model_field.parent = None
+            for base_class in model.base_classes:
+                for data_type in list(base_class.all_data_types):
+                    data_type.parent = None
+                    data_type.reference = None
+        for reference in references:
+            reference.children.clear()
+            reference.source = None
+        self._facts = GenerationFacts()
+        self._model_ids_by_object.clear()
+        self.models.clear()
+        self._dirty = True
+
     @property
     def facts(self) -> GenerationFacts:
         """Return the current facts snapshot."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved parser memory management by ensuring resources are properly cleaned up and garbage collected after parsing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->