### PR TITLE
Use resolved converted source cache keys

### DIFF
--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -5307,7 +5307,7 @@ class JsonSchemaParser(Parser["JSONSchemaParserConfig", "JsonSchemaFeatures"]):
             raw_obj = make_converter().convert(source)
             source.raw_data = raw_obj
             if source.path.parts:
-                self.remote_object_cache[str(self.base_path / source.path)] = raw_obj
+                self.remote_object_cache[str((self.base_path / source.path).resolve())] = raw_obj
             self.raw_obj = raw_obj
             obj_name, preserve_root_class_name = self._resolve_root_model_name(raw_obj)
             self._parse_file(

--- a/tests/main/xmlschema/test_main_xmlschema.py
+++ b/tests/main/xmlschema/test_main_xmlschema.py
@@ -25,6 +25,23 @@ def test_main_xmlschema_purchase_order(output_file: Path) -> None:
     )
 
 
+def test_main_xmlschema_purchase_order_from_normalized_external_path(tmp_path: Path, output_file: Path) -> None:
+    """Generate XML Schema models when the external input path needs normalization."""
+    redirect_dir = tmp_path / "redirect"
+    redirect_dir.mkdir()
+    run_main_and_assert(
+        input_path=redirect_dir / ".." / "purchase_order.xsd",
+        output_path=output_file,
+        input_file_type="xmlschema",
+        assert_func=assert_file_content,
+        expected_file="purchase_order.py",
+        copy_files=[
+            (XML_SCHEMA_DATA_PATH / "purchase_order.xsd", tmp_path / "purchase_order.xsd"),
+            (XML_SCHEMA_DATA_PATH / "common.xsd", tmp_path / "common.xsd"),
+        ],
+    )
+
+
 def test_main_xmlschema_infer_input_file_type(output_file: Path) -> None:
     """Infer XML Schema input and generate a model."""
     run_main_and_assert(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema caching so converted sources use resolved absolute paths for cache keys, improving reliability of local schema lookups.

* **Tests**
  * Added an integration test verifying XML Schema generation works when input paths require normalization (redirected/relative paths), ensuring correct model output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->