### PR TITLE
Cover to_hashable branch cases

### DIFF
--- a/src/datamodel_code_generator/_internal_utils.py
+++ b/src/datamodel_code_generator/_internal_utils.py
@@ -48,9 +48,9 @@ def to_hashable(item: Any) -> HashableComparable:
                 for k, v in item.items()
             )
         )
-    if isinstance(item, set):  # pragma: no cover
+    if isinstance(item, set):
         return frozenset(to_hashable(i) for i in item)  # type: ignore[return-value]
-    if isinstance(item, BaseModel):  # pragma: no cover
+    if isinstance(item, BaseModel):
         return to_hashable(item.model_dump())
     return item  # type: ignore[return-value]
 

--- a/tests/parser/test_base.py
+++ b/tests/parser/test_base.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from pydantic import BaseModel as PydanticBaseModel
 
 import datamodel_code_generator._internal_utils as internal_utils
 from datamodel_code_generator.enums import CollapseRootModelsNameStrategy
@@ -743,6 +744,24 @@ def test_to_hashable_dict() -> None:
     assert isinstance(result, tuple)
     # sorted by key
     assert result == (("a", 1), ("b", 2))
+
+
+def test_to_hashable_set() -> None:
+    """Test to_hashable with set."""
+    result = to_hashable({3, 1, 2})
+    assert isinstance(result, frozenset)
+    assert result == frozenset({1, 2, 3})
+
+
+def test_to_hashable_pydantic_base_model() -> None:
+    """Test to_hashable with pydantic BaseModel."""
+
+    class Item(PydanticBaseModel):
+        name: str
+        tags: set[str]
+
+    result = to_hashable(Item(name="item", tags={"blue", "red"}))
+    assert result == (("name", "item"), ("tags", frozenset({"blue", "red"})))
 
 
 def test_to_hashable_mixed_types_fallback() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for `set` to `frozenset` conversion and Pydantic model handling in utility functions.

* **Refactor**
  * Optimized internal utility function logic for handling set conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->