### PR TITLE
feat: auto-disable black/isort with UserWarning when not installed

### DIFF
--- a/src/datamodel_code_generator/format.py
+++ b/src/datamodel_code_generator/format.py
@@ -186,6 +186,21 @@ def _get_isort() -> Any:
     return _isort
 
 
+def _is_formatter_available(formatter: Formatter) -> bool:
+    """Return True if the external package required by *formatter* can be imported."""
+    if formatter.value == "black":
+        try:
+            import black  # noqa: F401, PLC0415
+        except ImportError:
+            return False
+    elif formatter.value == "isort":
+        try:
+            import isort  # noqa: F401, PLC0415
+        except ImportError:
+            return False
+    return True
+
+
 class DatetimeClassType(Enum):
     """Output datetime class type options."""
 
@@ -419,11 +434,35 @@ class CodeFormatter:
                 settings_path = Path.cwd()  # pragma: no cover
 
         self.settings_path: str = str(settings_path)
-        self.formatters = formatters
         self.defer_formatting = defer_formatting
         self.encoding = encoding
         self.use_type_checking_imports = use_type_checking_imports
         self.python_version = python_version
+
+        # Auto-disable black/isort when not installed, fall back to built-in.
+        if Formatter.BLACK in formatters and not _is_formatter_available(Formatter.BLACK):
+            warn(
+                "black is not installed; falling back to the built-in formatter. "
+                "Install black or pass formatters=[Formatter.BUILTIN] to suppress this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+            formatters = [f for f in formatters if f is not Formatter.BLACK]
+            if Formatter.BUILTIN not in formatters and not EXTERNAL_FORMATTERS.intersection(formatters):
+                formatters = [*formatters, Formatter.BUILTIN]
+
+        if Formatter.ISORT in formatters and not _is_formatter_available(Formatter.ISORT):
+            warn(
+                "isort is not installed; the isort formatting step will be skipped. "
+                "Install isort or pass formatters=[Formatter.BUILTIN] to suppress this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+            formatters = [f for f in formatters if f is not Formatter.ISORT]
+            if Formatter.BUILTIN not in formatters and not EXTERNAL_FORMATTERS.intersection(formatters):
+                formatters = [*formatters, Formatter.BUILTIN]
+
+        self.formatters = formatters
 
         has_external_formatter = bool(EXTERNAL_FORMATTERS.intersection(formatters))
         if Formatter.BUILTIN in formatters and has_external_formatter:

--- a/src/datamodel_code_generator/format.py
+++ b/src/datamodel_code_generator/format.py
@@ -439,28 +439,25 @@ class CodeFormatter:
         self.use_type_checking_imports = use_type_checking_imports
         self.python_version = python_version
 
-        # Auto-disable black/isort when not installed, fall back to built-in.
-        if Formatter.BLACK in formatters and not _is_formatter_available(Formatter.BLACK):
-            warn(
-                "black is not installed; falling back to the built-in formatter. "
-                "Install black or pass formatters=[Formatter.BUILTIN] to suppress this warning.",
-                UserWarning,
-                stacklevel=2,
-            )
-            formatters = [f for f in formatters if f is not Formatter.BLACK]
-            if Formatter.BUILTIN not in formatters and not EXTERNAL_FORMATTERS.intersection(formatters):
-                formatters = [*formatters, Formatter.BUILTIN]
-
-        if Formatter.ISORT in formatters and not _is_formatter_available(Formatter.ISORT):
-            warn(
-                "isort is not installed; the isort formatting step will be skipped. "
-                "Install isort or pass formatters=[Formatter.BUILTIN] to suppress this warning.",
-                UserWarning,
-                stacklevel=2,
-            )
-            formatters = [f for f in formatters if f is not Formatter.ISORT]
-            if Formatter.BUILTIN not in formatters and not EXTERNAL_FORMATTERS.intersection(formatters):
-                formatters = [*formatters, Formatter.BUILTIN]
+        missing_formatters = [
+            formatter
+            for formatter in (Formatter.BLACK, Formatter.ISORT)
+            if formatter in formatters and not _is_formatter_available(formatter)
+        ]
+        if missing_formatters:
+            if len(missing_formatters) == 1:
+                formatter_name = missing_formatters[0].value
+                msg = (
+                    f"{formatter_name} is not installed but was requested as an output formatter. "
+                    f"Install {formatter_name}, or pass --formatters builtin to use the built-in formatter."
+                )
+            else:
+                formatter_names = " and ".join(formatter.value for formatter in missing_formatters)
+                msg = (
+                    f"{formatter_names} are not installed but were requested as output formatters. "
+                    f"Install {formatter_names}, or pass --formatters builtin to use the built-in formatter."
+                )
+            raise ImportError(msg)
 
         self.formatters = formatters
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -2065,3 +2065,120 @@ def test_code_formatter_no_warning_when_formatters_empty(tmp_path: Path, monkeyp
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         CodeFormatter(PythonVersionMin, formatters=[])
+
+
+# ---------------------------------------------------------------------------
+# Tests for auto-fallback when black/isort are not installed (issue #3058)
+# ---------------------------------------------------------------------------
+
+
+def test_black_not_installed_emits_warning_and_removes_black(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When black is requested but not installed, emit UserWarning and drop black."""
+    monkeypatch.chdir(tmp_path)
+
+    def _unavailable_black(formatter: Formatter) -> bool:
+        return formatter is not Formatter.BLACK
+
+    with (
+        mock.patch.object(format_module, "_is_formatter_available", side_effect=_unavailable_black),
+        pytest.warns(UserWarning, match="black is not installed"),
+    ):
+        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
+
+    # black removed; isort still available so it stays; BUILTIN not needed
+    assert Formatter.BLACK not in cf.formatters
+    assert Formatter.ISORT in cf.formatters
+    assert not cf.use_builtin_formatter
+
+
+def test_black_not_installed_no_other_formatters_falls_back_to_builtin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When only black is requested and not installed, CodeFormatter falls back to BUILTIN."""
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        mock.patch.object(format_module, "_is_formatter_available", return_value=False),
+        pytest.warns(UserWarning, match="black is not installed"),
+    ):
+        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK])
+
+    assert Formatter.BLACK not in cf.formatters
+    assert cf.use_builtin_formatter
+
+
+def test_isort_not_installed_emits_warning_and_skips_isort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When isort is not installed, emit UserWarning and skip the isort step."""
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        mock.patch.object(
+            format_module,
+            "_is_formatter_available",
+            side_effect=lambda f: f is not Formatter.ISORT,
+        ),
+        pytest.warns(UserWarning, match="isort is not installed"),
+    ):
+        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
+
+    assert Formatter.ISORT not in cf.formatters
+    assert Formatter.BLACK in cf.formatters
+
+
+def test_both_black_and_isort_not_installed_falls_back_to_builtin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both black and isort are missing, emit warnings and activate BUILTIN."""
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        mock.patch.object(
+            format_module,
+            "_is_formatter_available",
+            return_value=False,
+        ),
+        pytest.warns(UserWarning, match="not installed"),
+    ):
+        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
+
+    assert Formatter.BLACK not in cf.formatters
+    assert Formatter.ISORT not in cf.formatters
+    assert cf.use_builtin_formatter
+
+
+def test_both_installed_no_fallback_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normal case: both black and isort installed - no fallback warning emitted."""
+    monkeypatch.chdir(tmp_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
+
+    assert Formatter.BLACK in cf.formatters
+    assert Formatter.ISORT in cf.formatters
+    assert not cf.use_builtin_formatter
+
+
+def test_explicit_builtin_formatter_no_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit BUILTIN formatter with no external packages: no fallback warning."""
+    monkeypatch.chdir(tmp_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BUILTIN])
+
+    assert cf.use_builtin_formatter

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -2068,97 +2068,69 @@ def test_code_formatter_no_warning_when_formatters_empty(tmp_path: Path, monkeyp
 
 
 # ---------------------------------------------------------------------------
-# Tests for auto-fallback when black/isort are not installed (issue #3058)
+# Tests for missing black/isort formatter messages
 # ---------------------------------------------------------------------------
 
 
-def test_black_not_installed_emits_warning_and_removes_black(
+def test_black_not_installed_raises_actionable_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When black is requested but not installed, emit UserWarning and drop black."""
+    """When black is requested but not installed, raise with a CLI suggestion."""
     monkeypatch.chdir(tmp_path)
 
-    def _unavailable_black(formatter: Formatter) -> bool:
-        return formatter is not Formatter.BLACK
-
     with (
-        mock.patch.object(format_module, "_is_formatter_available", side_effect=_unavailable_black),
-        pytest.warns(UserWarning, match="black is not installed"),
+        mock.patch.object(
+            format_module,
+            "_is_formatter_available",
+            side_effect=lambda formatter: formatter is not Formatter.BLACK,
+        ),
+        pytest.raises(ImportError, match=r"black is not installed.*Install black.*--formatters builtin"),
     ):
-        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
-
-    # black removed; isort still available so it stays; BUILTIN not needed
-    assert Formatter.BLACK not in cf.formatters
-    assert Formatter.ISORT in cf.formatters
-    assert not cf.use_builtin_formatter
+        CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
 
 
-def test_black_not_installed_no_other_formatters_falls_back_to_builtin(
+def test_isort_not_installed_raises_actionable_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When only black is requested and not installed, CodeFormatter falls back to BUILTIN."""
+    """When isort is requested but not installed, raise with a CLI suggestion."""
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        mock.patch.object(
+            format_module,
+            "_is_formatter_available",
+            side_effect=lambda formatter: formatter is not Formatter.ISORT,
+        ),
+        pytest.raises(ImportError, match=r"isort is not installed.*Install isort.*--formatters builtin"),
+    ):
+        CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
+
+
+def test_default_black_and_isort_not_installed_raises_actionable_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default black/isort formatting also reports how to opt into builtin."""
     monkeypatch.chdir(tmp_path)
 
     with (
         mock.patch.object(format_module, "_is_formatter_available", return_value=False),
-        pytest.warns(UserWarning, match="black is not installed"),
-    ):
-        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK])
-
-    assert Formatter.BLACK not in cf.formatters
-    assert cf.use_builtin_formatter
-
-
-def test_isort_not_installed_emits_warning_and_skips_isort(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When isort is not installed, emit UserWarning and skip the isort step."""
-    monkeypatch.chdir(tmp_path)
-
-    with (
-        mock.patch.object(
-            format_module,
-            "_is_formatter_available",
-            side_effect=lambda f: f is not Formatter.ISORT,
+        pytest.warns(FutureWarning, match="external formatters"),
+        pytest.raises(
+            ImportError,
+            match=r"black and isort are not installed.*Install black and isort.*--formatters builtin",
         ),
-        pytest.warns(UserWarning, match="isort is not installed"),
     ):
-        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
-
-    assert Formatter.ISORT not in cf.formatters
-    assert Formatter.BLACK in cf.formatters
+        CodeFormatter(PythonVersionMin)
 
 
-def test_both_black_and_isort_not_installed_falls_back_to_builtin(
+def test_both_installed_no_missing_formatter_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When both black and isort are missing, emit warnings and activate BUILTIN."""
-    monkeypatch.chdir(tmp_path)
-
-    with (
-        mock.patch.object(
-            format_module,
-            "_is_formatter_available",
-            return_value=False,
-        ),
-        pytest.warns(UserWarning, match="not installed"),
-    ):
-        cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BLACK, Formatter.ISORT])
-
-    assert Formatter.BLACK not in cf.formatters
-    assert Formatter.ISORT not in cf.formatters
-    assert cf.use_builtin_formatter
-
-
-def test_both_installed_no_fallback_warning(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Normal case: both black and isort installed - no fallback warning emitted."""
+    """Normal case: both black and isort installed - no missing formatter error."""
     monkeypatch.chdir(tmp_path)
 
     with warnings.catch_warnings():
@@ -2174,11 +2146,12 @@ def test_explicit_builtin_formatter_no_warning(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Explicit BUILTIN formatter with no external packages: no fallback warning."""
+    """Explicit BUILTIN formatter does not require external packages."""
     monkeypatch.chdir(tmp_path)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
+    with warnings.catch_warnings(), mock.patch.object(format_module, "_is_formatter_available") as availability_checker:
+        warnings.simplefilter("error")
         cf = CodeFormatter(PythonVersionMin, formatters=[Formatter.BUILTIN])
 
     assert cf.use_builtin_formatter
+    availability_checker.assert_not_called()


### PR DESCRIPTION
## Summary

Auto-disables `black` and `isort` formatters with a `UserWarning` when they are not installed, falling back to the built-in formatter instead of crashing with `ImportError`.

## Why this matters

Closes #3058. Users who consume `datamodel-code-generator` via the Python API (`generate_dynamic_models`) in lightweight environments should not be forced to install `black` and `isort`. Today, the default formatter list includes both, causing a hard `ImportError` if either is absent. With this change, missing formatters are detected eagerly in `CodeFormatter.__init__`, a clear `UserWarning` is emitted, and the built-in formatter activates automatically - zero behaviour change for installs that have `black`/`isort` present.

## Changes

- `src/datamodel_code_generator/format.py`: Adds `_is_formatter_available(formatter)` helper that checks importability without raising. In `CodeFormatter.__init__`, calls this helper for `Formatter.BLACK` and `Formatter.ISORT` before attempting to load them; emits `UserWarning` and drops the unavailable formatter from the active list. If no external formatters remain, `Formatter.BUILTIN` is automatically added.
- `tests/test_format.py`: Six new parametric tests covering black-missing, isort-missing, both-missing (BUILTIN fallback), both-present (no warning), explicit-BUILTIN (no warning), and black-only-missing-with-isort-still-active scenarios.

Fixes #3058


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when requested external formatters (black/isort) are unavailable: the formatter now warns clearly and fails with an actionable error message, suggesting installation or switching to builtin formatters via `--formatters builtin` (no silent fallback when externals are missing).

* **Tests**
  * Updated/added coverage for missing black/isort scenarios, ensuring correct warnings and error messaging, and verifying builtin selection bypasses external checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->