### PR TITLE
Reduce Pydantic v2 render work

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -159,6 +159,13 @@ class _RenderedDataModelField:
         try:
             return self._cache[name]
         except KeyError:
+            if name in {"annotated", "field"} and (
+                rendered_field_values := getattr(self._field, "_rendered_field_values", None)
+            ):
+                field, annotated = rendered_field_values()
+                self._cache["field"] = field
+                self._cache["annotated"] = annotated
+                return self._cache[name]
             value = getattr(self._field, name)
             self._cache[name] = value
             return value

--- a/src/datamodel_code_generator/model/pydantic_base.py
+++ b/src/datamodel_code_generator/model/pydantic_base.py
@@ -102,6 +102,9 @@ class DataModelField(DataModelFieldBase):
         if self.is_class_var:
             return None
         result = str(self)
+        return self._field_from_rendered(result)
+
+    def _field_from_rendered(self, result: str) -> str | None:
         if (
             self.use_default_kwarg
             and not result.startswith("Field(...")
@@ -114,6 +117,16 @@ class DataModelField(DataModelFieldBase):
         if not result:
             return None
         return result
+
+    def _rendered_field_values(self) -> tuple[str | None, str | None]:
+        """Render field and annotated values from one Field() string for built-in templates."""
+        if self.is_class_var:
+            return None, None
+        result = str(self)
+        field = self._field_from_rendered(result)
+        if not self.use_annotated or not result:
+            return field, None
+        return field, f"Annotated[{self.type_hint}, {result}]"
 
     def _has_field_statement(self) -> bool:
         """Return whether rendering this field will require a Field() call."""

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -252,6 +252,8 @@ class DataModelField(_PydanticBaseDataModelField):
 
     def _has_discriminator_in_data_type(self) -> bool:
         """Check if any nested DataType has a discriminator."""
+        if not self.data_type.discriminator and not self.data_type.data_types and self.data_type.dict_key is None:
+            return False
         return any(dt.discriminator for dt in self.data_type.all_data_types)
 
     @property

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -3569,7 +3569,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
             module, models = model_to_module_models[unused_model]
             if unused_model in models:  # pragma: no branch
                 imports = module_to_import[module]
-                imports.remove(model_imports[unused_model])
+                imports.remove(model_imports.get(unused_model, unused_model.imports))
                 models.remove(unused_model)
 
         for ctx in contexts:

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -3056,7 +3056,11 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         return export_imports
 
     @classmethod
-    def _collect_used_names_from_models(cls, models: list[DataModel]) -> set[str]:
+    def _collect_used_names_from_models(
+        cls,
+        models: list[DataModel],
+        model_imports: Mapping[DataModel, tuple[Import, ...]] | None = None,
+    ) -> set[str]:
         """Collect identifiers referenced by models before rendering."""
         names: set[str] = set()
 
@@ -3075,7 +3079,8 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
             add(model.duplicate_class_name)
             for base in model.base_classes:
                 add(base.type_hint)
-            for import_ in model.imports:
+            imports = model_imports[model] if model_imports is not None else model.imports
+            for import_ in imports:
                 add(import_.alias or import_.import_.split(".")[-1])
             for field in model.fields:
                 if field.extras.get("is_classvar"):
@@ -3554,27 +3559,28 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         all_models = [model for ctx in contexts for model in ctx.models]
         self.__mark_set_item_models_hashable(all_models)
         self.__apply_generic_base_class(contexts)
+        model_imports = {model: model.imports for ctx in contexts for model in ctx.models}
 
         for ctx in contexts:
             for model in ctx.models:
-                ctx.imports.append(model.imports)
+                ctx.imports.append(model_imports[model])
 
         for unused_model in unused_models:
             module, models = model_to_module_models[unused_model]
             if unused_model in models:  # pragma: no branch
                 imports = module_to_import[module]
-                imports.remove(unused_model.imports)
+                imports.remove(model_imports[unused_model])
                 models.remove(unused_model)
 
         for ctx in contexts:
-            used_names = self._collect_used_names_from_models(ctx.models)
+            used_names = self._collect_used_names_from_models(ctx.models, model_imports)
             ctx.imports.remove_unused(used_names)
 
         for ctx in contexts:
             # If any model in this module needs typing_extensions.TypedDict (e.g. for PEP 728
             # closed/extra_items backport), remove typing.TypedDict to avoid duplicate imports.
             if (
-                any(IMPORT_TYPED_DICT_BACKPORT in model.imports for model in ctx.models)
+                any(IMPORT_TYPED_DICT_BACKPORT in model_imports[model] for model in ctx.models)
                 and IMPORT_TYPED_DICT_BACKPORT.import_ in ctx.imports.get(IMPORT_TYPED_DICT_BACKPORT.from_, set())
                 and IMPORT_TYPED_DICT.import_ in ctx.imports.get(IMPORT_TYPED_DICT.from_, set())
             ):

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -12,6 +12,7 @@ from datamodel_code_generator.model.base import (
     DataModel,
     DataModelFieldBase,
     TemplateBase,
+    _RenderedDataModelField,
     comment_safe,
     escape_docstring,
     format_docstring,
@@ -21,6 +22,7 @@ from datamodel_code_generator.model.base import (
 )
 from datamodel_code_generator.model.pydantic_v2 import BaseModel
 from datamodel_code_generator.model.pydantic_v2 import DataModelField as PydanticV2DataModelField
+from datamodel_code_generator.model.pydantic_v2.imports import IMPORT_FIELD
 from datamodel_code_generator.reference import Reference
 from datamodel_code_generator.types import DataType, Types
 
@@ -155,6 +157,60 @@ def test_pydantic_v2_extra_type_hint_keeps_non_dict_hint() -> None:
     )
 
     assert field.pydantic_extra_type_hint == "str"
+
+
+def test_rendered_pydantic_v2_field_reuses_field_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test built-in field proxy computes field and annotated values from one Field() string."""
+    field = PydanticV2DataModelField(
+        name="name",
+        data_type=DataType(type="str"),
+        required=True,
+        extras={"title": "Name"},
+        use_annotated=True,
+    )
+    expected_field = field.field
+    expected_annotated = field.annotated
+    calls = 0
+    original_str = PydanticV2DataModelField.__str__
+
+    def count_str(self: PydanticV2DataModelField) -> str:
+        nonlocal calls
+        calls += 1
+        return original_str(self)
+
+    monkeypatch.setattr(PydanticV2DataModelField, "__str__", count_str)
+    rendered_field = _RenderedDataModelField(field, "")
+
+    assert rendered_field.annotated == expected_annotated
+    assert rendered_field.field == expected_field
+    assert calls == 1
+
+
+def test_pydantic_v2_leaf_field_imports_skip_discriminator_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test leaf fields do not walk all nested data types for impossible discriminators."""
+    field = PydanticV2DataModelField(
+        name="name",
+        data_type=DataType(type="str"),
+        required=True,
+    )
+
+    def fail_all_data_types(self: DataType) -> None:
+        pytest.fail(f"unexpected discriminator scan for {self!r}")
+
+    monkeypatch.setattr(DataType, "all_data_types", property(fail_all_data_types))
+
+    assert IMPORT_FIELD not in field.imports
+
+
+def test_pydantic_v2_nested_discriminator_still_imports_field() -> None:
+    """Test discriminator imports still work for nested data types."""
+    field = PydanticV2DataModelField(
+        name="item",
+        data_type=DataType(data_types=[DataType(type="Pet", discriminator="pet_type")]),
+        required=True,
+    )
+
+    assert IMPORT_FIELD in field.imports
 
 
 def test_data_model_exception() -> None:

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -186,6 +186,22 @@ def test_rendered_pydantic_v2_field_reuses_field_string(monkeypatch: pytest.Monk
     assert calls == 1
 
 
+def test_rendered_pydantic_v2_class_var_field_values_are_none() -> None:
+    """Test class variable fields do not render Field or Annotated values."""
+    field = PydanticV2DataModelField(
+        name="name",
+        data_type=DataType(type="str"),
+        required=True,
+        extras={"x-is-classvar": True},
+        use_annotated=True,
+    )
+    rendered_field = _RenderedDataModelField(field, "")
+
+    assert field.field is None
+    assert rendered_field.field is None
+    assert rendered_field.annotated is None
+
+
 def test_pydantic_v2_leaf_field_imports_skip_discriminator_scan(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test leaf fields do not walk all nested data types for impossible discriminators."""
     field = PydanticV2DataModelField(

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -194,12 +194,15 @@ def test_pydantic_v2_leaf_field_imports_skip_discriminator_scan(monkeypatch: pyt
         required=True,
     )
 
-    def fail_all_data_types(self: DataType) -> None:
-        pytest.fail(f"unexpected discriminator scan for {self!r}")
+    def fail_all_data_types(_self: DataType) -> tuple[DataType, ...]:
+        message = "unexpected discriminator scan"
+        raise AssertionError(message)
 
     monkeypatch.setattr(DataType, "all_data_types", property(fail_all_data_types))
 
     assert IMPORT_FIELD not in field.imports
+    with pytest.raises(AssertionError, match="unexpected discriminator scan"):
+        tuple(DataType(type="str").all_data_types)
 
 
 def test_pydantic_v2_nested_discriminator_still_imports_field() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved performance and consistency in Pydantic field rendering by reusing computed `field`/`annotated` values.
  * Reduced unnecessary discriminator detection work for simple/leaf fields.
  * Improved accuracy of import collection by using the correct per-model import context during module finalization.

* **Tests**
  * Added coverage for `field`/`annotated` reuse behavior, class-variable handling, and discriminator-related import inclusion/exclusion scenarios.
  * Added checks ensuring discriminator scanning is skipped when it isn’t needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->