### PR TITLE
Fast path list output

### DIFF
--- a/src/datamodel_code_generator/__main__.py
+++ b/src/datamodel_code_generator/__main__.py
@@ -43,6 +43,61 @@ match schema_output_name:
         sys.stdout.write(f"{structured_output_json_schema()}\n")
         sys.exit(0)
 
+match sys.argv:
+    case [_, "--list-deprecations"]:
+        list_output_kind = "deprecations"
+        list_output_format = "table"
+    case [_, "--list-deprecations", list_output_format] if list_output_format in {"table", "json", "markdown"}:
+        list_output_kind = "deprecations"
+    case [_, list_output_option] if list_output_option.startswith("--list-deprecations=") and (
+        list_output_format := list_output_option.partition("=")[2]
+    ) in {"table", "json", "markdown"}:
+        list_output_kind = "deprecations"
+    case [_, "--list-experimental"]:
+        list_output_kind = "experimental"
+        list_output_format = "table"
+    case [_, "--list-experimental", list_output_format] if list_output_format in {"table", "json", "markdown"}:
+        list_output_kind = "experimental"
+    case [_, list_output_option] if list_output_option.startswith("--list-experimental=") and (
+        list_output_format := list_output_option.partition("=")[2]
+    ) in {"table", "json", "markdown"}:
+        list_output_kind = "experimental"
+    case _:
+        list_output_kind = None
+        list_output_format = None
+
+match (list_output_kind, list_output_format):
+    case ("deprecations", "table"):  # pragma: no cover
+        from datamodel_code_generator.deprecations import render_deprecations
+
+        sys.stdout.write(render_deprecations("table"))
+        sys.exit(0)
+    case ("deprecations", "json"):  # pragma: no cover
+        from datamodel_code_generator.deprecations import render_deprecations
+
+        sys.stdout.write(render_deprecations("json"))
+        sys.exit(0)
+    case ("deprecations", "markdown"):  # pragma: no cover
+        from datamodel_code_generator.deprecations import render_deprecations
+
+        sys.stdout.write(render_deprecations("markdown"))
+        sys.exit(0)
+    case ("experimental", "table"):  # pragma: no cover
+        from datamodel_code_generator.experimental import render_experimental_features
+
+        sys.stdout.write(render_experimental_features("table"))
+        sys.exit(0)
+    case ("experimental", "json"):  # pragma: no cover
+        from datamodel_code_generator.experimental import render_experimental_features
+
+        sys.stdout.write(render_experimental_features("json"))
+        sys.exit(0)
+    case ("experimental", "markdown"):  # pragma: no cover
+        from datamodel_code_generator.experimental import render_experimental_features
+
+        sys.stdout.write(render_experimental_features("markdown"))
+        sys.exit(0)
+
 # Fast path for prompt helper outputs
 if any(
     arg.startswith(("--generate-prompt", "--output-format-json-schema=")) or arg == "--output-format-json-schema"

--- a/tests/main/test_cli_fast_paths.py
+++ b/tests/main/test_cli_fast_paths.py
@@ -36,10 +36,14 @@ def _run_probe(script: str) -> dict[str, Any]:
 
 
 def _run_module_schema_fast_path_in_process(schema_options: list[str]) -> dict[str, Any]:
+    return _run_module_fast_path_in_process(schema_options)
+
+
+def _run_module_fast_path_in_process(options: list[str]) -> dict[str, Any]:
     module_name = "datamodel_code_generator.__main__"
     previous_module = sys.modules.pop(module_name, MISSING)
     original_argv = sys.argv[:]
-    sys.argv = ["datamodel-codegen", *schema_options]
+    sys.argv = ["datamodel-codegen", *options]
     stdout = io.StringIO()
     try:
         with contextlib.redirect_stdout(stdout):
@@ -58,6 +62,10 @@ def _run_module_schema_fast_path_in_process(schema_options: list[str]) -> dict[s
 
 
 def _run_module_schema_fast_path(schema_options: list[str]) -> dict[str, Any]:
+    return _run_module_fast_path(schema_options)
+
+
+def _run_module_fast_path(options: list[str]) -> dict[str, Any]:
     return _run_probe(
         textwrap.dedent(
             f"""
@@ -67,7 +75,7 @@ def _run_module_schema_fast_path(schema_options: list[str]) -> dict[str, Any]:
             import runpy
             import sys
 
-            sys.argv = ["datamodel-codegen", *{schema_options!r}]
+            sys.argv = ["datamodel-codegen", *{options!r}]
             stdout = io.StringIO()
             with contextlib.redirect_stdout(stdout):
                 try:
@@ -88,6 +96,10 @@ def _run_module_schema_fast_path(schema_options: list[str]) -> dict[str, Any]:
 
 
 def _run_parsed_schema_path(schema_name: str) -> dict[str, Any]:
+    return _run_parsed_path(["--output-format-json-schema", schema_name])
+
+
+def _run_parsed_path(options: list[str]) -> dict[str, Any]:
     return _run_probe(
         textwrap.dedent(
             f"""
@@ -99,7 +111,7 @@ def _run_parsed_schema_path(schema_name: str) -> dict[str, Any]:
 
             stdout = io.StringIO()
             with contextlib.redirect_stdout(stdout):
-                code = main(["--output-format-json-schema", {schema_name!r}])
+                code = main({options!r})
 
             print(json.dumps({{"code": code, "stdout": stdout.getvalue()}}))
             """
@@ -131,3 +143,36 @@ def test_output_format_json_schema_exact_fast_paths_skip_argument_parser_import(
         for fast_path in covered_fast_paths:
             assert fast_path["code"] == 0
             assert fast_path["stdout"] == parsed_path["stdout"]
+
+
+@pytest.mark.allow_direct_assert
+def test_list_utility_exact_fast_paths_skip_argument_parser_import() -> None:
+    """Exact list utility invocations bypass argparse without changing output."""
+    cases = [
+        ["--list-deprecations"],
+        ["--list-deprecations", "table"],
+        ["--list-deprecations", "json"],
+        ["--list-deprecations", "markdown"],
+        ["--list-deprecations=table"],
+        ["--list-deprecations=json"],
+        ["--list-deprecations=markdown"],
+        ["--list-experimental"],
+        ["--list-experimental", "table"],
+        ["--list-experimental", "json"],
+        ["--list-experimental", "markdown"],
+        ["--list-experimental=table"],
+        ["--list-experimental=json"],
+        ["--list-experimental=markdown"],
+    ]
+
+    for options in cases:
+        parsed_path = _run_parsed_path(options)
+        fast_path = _run_module_fast_path(options)
+        covered_fast_path = _run_module_fast_path_in_process(options)
+
+        assert parsed_path["code"] == 0
+        assert fast_path["code"] == 0
+        assert fast_path["imported_arguments"] is False
+        assert fast_path["stdout"] == parsed_path["stdout"]
+        assert covered_fast_path["code"] == 0
+        assert covered_fast_path["stdout"] == parsed_path["stdout"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `--list-deprecations` and `--list-experimental` commands now support multiple output formats (table, json, markdown)
  * Commands accept flexible argument syntax in both space-separated and equals notation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->