### PR TITLE
Guard JSON-pointer list indexing against invalid segments

### DIFF
--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -106,6 +106,22 @@ def unescape_json_pointer_segment(segment: str) -> str:
     return unquote(segment.replace("~1", "/").replace("~0", "~"))
 
 
+_JSON_POINTER_ARRAY_INDEX = re.compile(r"0|[1-9][0-9]*")
+
+
+def _resolve_json_pointer_array_index(sequence: list[YamlValue], segment: object) -> YamlValue:
+    """Resolve a JSON-pointer segment against a list per the RFC 6901 array-index grammar."""
+    text = str(segment)
+    if not _JSON_POINTER_ARRAY_INDEX.fullmatch(text):
+        msg = f"Invalid JSON pointer array index {text!r}: expected a non-negative integer."
+        raise Error(msg)
+    index = int(text)
+    if index >= len(sequence):
+        msg = f"JSON pointer array index {index} is out of range (array length {len(sequence)})."
+        raise Error(msg)
+    return sequence[index]
+
+
 def get_model_by_path(schema: dict[str, YamlValue] | list[YamlValue], keys: list[str] | list[int]) -> YamlValue:
     """Retrieve a model from schema by traversing the given path keys."""
     if not keys:
@@ -117,7 +133,13 @@ def get_model_by_path(schema: dict[str, YamlValue] | list[YamlValue], keys: list
     key = keys[0]
     if isinstance(key, str):  # pragma: no branch
         key = unescape_json_pointer_segment(key)
-    value = schema.get(str(key), {}) if isinstance(schema, dict) else schema[int(key)]
+    if isinstance(schema, dict):
+        value = schema.get(str(key), {})
+    elif isinstance(schema, list):
+        value = _resolve_json_pointer_array_index(schema, key)
+    else:
+        msg = f"Cannot traverse non-container schema. schema={schema}, key={key}"
+        raise NotImplementedError(msg)
     if len(keys) == 1:
         return value
     if isinstance(value, (dict, list)):
@@ -171,7 +193,7 @@ def _split_json_pointer(schema: dict[str, YamlValue] | list[YamlValue], pointer:
         parts.append(part)
         reference_parts.append(raw_parts[index])
         if isinstance(current, list):  # pragma: no branch
-            current = current[int(part)]
+            current = _resolve_json_pointer_array_index(current, part)
         index += 1
     return parts, reference_parts
 

--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -115,7 +115,11 @@ def _resolve_json_pointer_array_index(sequence: list[YamlValue], segment: object
     if not _JSON_POINTER_ARRAY_INDEX.fullmatch(text):
         msg = f"Invalid JSON pointer array index {text!r}: expected a non-negative integer."
         raise Error(msg)
-    index = int(text)
+    try:
+        index = int(text)
+    except ValueError as exc:
+        msg = f"Invalid JSON pointer array index {text!r}: integer string is too long to parse."
+        raise Error(msg) from exc
     if index >= len(sequence):
         msg = f"JSON pointer array index {index} is out of range (array length {len(sequence)})."
         raise Error(msg)

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -26,6 +26,7 @@ from datamodel_code_generator.parser.jsonschema import (
     Types,
     _validate_schema_python_import_path,
     get_model_by_path,
+    split_json_pointer,
 )
 from datamodel_code_generator.reference import SPECIAL_PATH_MARKER, Reference
 from datamodel_code_generator.types import DataType
@@ -53,11 +54,44 @@ def block_dns_by_default(mocker: MockerFixture) -> None:
         ({"a": {"b": {"foo": "bar"}}}, "a/b", {"foo": "bar"}),
         ({"a": {"b": {"c": {"foo": "bar"}}}}, "a/b", {"c": {"foo": "bar"}}),
         ({"a": {"b": {"c": {"foo": "bar"}}}}, "a/b/c", {"foo": "bar"}),
+        ({"a": [{"x": 1}, {"y": 2}]}, "a/0", {"x": 1}),
+        ({"a": [{"x": 1}, {"y": 2}]}, "a/1", {"y": 2}),
     ],
 )
 def test_get_model_by_path(schema: dict, path: str, model: dict) -> None:
     """Test model retrieval by path."""
     assert get_model_by_path(schema, path.split("/") if path else []) == model
+
+
+@pytest.mark.parametrize(
+    ("path", "match"),
+    [
+        ("a/foo", "Invalid JSON pointer array index 'foo'"),
+        ("a/-1", "Invalid JSON pointer array index '-1'"),
+        ("a/01", "Invalid JSON pointer array index '01'"),
+        ("a/99999", "JSON pointer array index 99999 is out of range"),
+        ("a/0x1", "Invalid JSON pointer array index '0x1'"),
+        ("a/0o1", "Invalid JSON pointer array index '0o1'"),
+        ("a/0b1", "Invalid JSON pointer array index '0b1'"),
+        ("a/017", "Invalid JSON pointer array index '017'"),
+        ("a/1_0", "Invalid JSON pointer array index '1_0'"),
+        ("a/+1", r"Invalid JSON pointer array index '\+1'"),
+    ],
+)
+def test_get_model_by_path_rejects_invalid_list_index(path: str, match: str) -> None:
+    """Test list-index pointer segments are validated, not fed to raw list indexing."""
+    schema = {"a": [{"x": 1}, {"y": 2}]}
+    with pytest.raises(Error, match=match):
+        get_model_by_path(schema, path.split("/"))
+
+
+def test_split_json_pointer_slow_path_rejects_invalid_list_index() -> None:
+    """Test the slow-path pointer traversal applies the same list-index guard."""
+    # "~1" forces the slow path; the escaped key resolves to a list, then the next
+    # segment is an invalid index.
+    schema = {"weird/key": ["x", "y"]}
+    with pytest.raises(Error, match="Invalid JSON pointer array index 'foo'"):
+        split_json_pointer(schema, "weird~1key/foo")
 
 
 def test_validate_schema_python_import_path_rejects_non_string() -> None:

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import socket
+import sys
 from collections import Counter
 from ipaddress import ip_address
 from pathlib import Path
@@ -83,6 +84,18 @@ def test_get_model_by_path_rejects_invalid_list_index(path: str, match: str) -> 
     schema = {"a": [{"x": 1}, {"y": 2}]}
     with pytest.raises(Error, match=match):
         get_model_by_path(schema, path.split("/"))
+
+
+@pytest.mark.skipif(
+    not hasattr(sys, "set_int_max_str_digits"),
+    reason="int string-conversion length limit requires Python 3.11+",
+)
+def test_get_model_by_path_rejects_overlong_list_index() -> None:
+    """Test a digit string above the int conversion limit raises Error, not ValueError."""
+    schema = {"a": [{"x": 1}]}
+    overlong = "9" * (sys.get_int_max_str_digits() + 1)
+    with pytest.raises(Error, match="integer string is too long to parse"):
+        get_model_by_path(schema, ["a", overlong])
 
 
 def test_split_json_pointer_slow_path_rejects_invalid_list_index() -> None:


### PR DESCRIPTION
`get_model_by_path` and the `_split_json_pointer` slow path indexed list nodes via a bare `schema[int(key)]`.

A $ref segment hitting an array could crash (ValueError/IndexError) or silently pick the wrong element. Now validated against the RFC 6901 array-index grammar and bounds-checked, raising a clean Error; valid pointers unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JSON Pointer array index handling to comply with RFC 6901 standard, providing stricter validation and proper error handling for invalid indices, including non-decimal formats, negative values, and out-of-range references.

* **Tests**
  * Expanded test coverage for array index path segments and validation of invalid JSON Pointer list indices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->