### PR TITLE
Escape generated pyproject TOML strings

### DIFF
--- a/src/datamodel_code_generator/__main__.py
+++ b/src/datamodel_code_generator/__main__.py
@@ -622,7 +622,7 @@ def _format_toml_value(value: TomlValue) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        return f'"{value}"'
+        return json.dumps(value, ensure_ascii=False)
     formatted_items = [_format_toml_value(item) for item in value]
     return f"[{', '.join(formatted_items)}]"
 

--- a/tests/data/expected/main_kr/generate_pyproject_config/escapes_toml_strings.txt
+++ b/tests/data/expected/main_kr/generate_pyproject_config/escapes_toml_strings.txt
@@ -1,0 +1,5 @@
+[tool.datamodel-codegen]
+custom-file-header = "say \"hi\" on C:\\tmp\nnext"
+http-headers = ["Authorization: Bearer \"abc\"", "X-Path: C:\\tmp"]
+input = "schema.yaml"
+

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -827,6 +827,7 @@ def test_generate_pyproject_config_with_enum_option(capsys: pytest.CaptureFixtur
     )
 
 
+@pytest.mark.allow_direct_assert
 def test_generate_pyproject_config_escapes_toml_strings() -> None:
     """Test --generate-pyproject-config escapes TOML basic strings."""
     try:

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -827,6 +827,28 @@ def test_generate_pyproject_config_with_enum_option(capsys: pytest.CaptureFixtur
     )
 
 
+def test_generate_pyproject_config_escapes_toml_strings() -> None:
+    """Test --generate-pyproject-config escapes TOML basic strings."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    custom_header = 'say "hi" on C:\\tmp\nnext'
+    http_headers = ['Authorization: Bearer "abc"', "X-Path: C:\\tmp"]
+    output = generate_pyproject_config(
+        Namespace(
+            custom_file_header=custom_header,
+            http_headers=http_headers,
+        )
+    )
+
+    config = tomllib.loads(output)["tool"]["datamodel-codegen"]
+
+    assert config["custom-file-header"] == custom_header
+    assert config["http-headers"] == http_headers
+
+
 EXPECTED_GENERATE_CLI_COMMAND_PATH = EXPECTED_MAIN_KR_PATH / "generate_cli_command"
 
 

--- a/tests/test_main_kr.py
+++ b/tests/test_main_kr.py
@@ -827,27 +827,22 @@ def test_generate_pyproject_config_with_enum_option(capsys: pytest.CaptureFixtur
     )
 
 
-@pytest.mark.allow_direct_assert
-def test_generate_pyproject_config_escapes_toml_strings() -> None:
-    """Test --generate-pyproject-config escapes TOML basic strings."""
-    try:
-        import tomllib
-    except ModuleNotFoundError:  # pragma: no cover
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    custom_header = 'say "hi" on C:\\tmp\nnext'
-    http_headers = ['Authorization: Bearer "abc"', "X-Path: C:\\tmp"]
-    output = generate_pyproject_config(
-        Namespace(
-            custom_file_header=custom_header,
-            http_headers=http_headers,
-        )
+def test_generate_pyproject_config_escapes_toml_strings(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test --generate-pyproject-config escapes special characters in TOML basic strings."""
+    run_main_with_args(
+        [
+            "--generate-pyproject-config",
+            "--input",
+            "schema.yaml",
+            "--custom-file-header",
+            'say "hi" on C:\\tmp\nnext',
+            "--http-headers",
+            'Authorization: Bearer "abc"',
+            "X-Path: C:\\tmp",
+        ],
+        capsys=capsys,
+        expected_stdout_path=EXPECTED_GENERATE_PYPROJECT_CONFIG_PATH / "escapes_toml_strings.txt",
     )
-
-    config = tomllib.loads(output)["tool"]["datamodel-codegen"]
-
-    assert config["custom-file-header"] == custom_header
-    assert config["http-headers"] == http_headers
 
 
 EXPECTED_GENERATE_CLI_COMMAND_PATH = EXPECTED_MAIN_KR_PATH / "generate_cli_command"


### PR DESCRIPTION
Fixes TOML string escaping in generated pyproject.toml config output by using JSON-style string serialization for TOML basic strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOML string serialization for generated configuration values, producing correct escaping for quotes, Windows-style backslashes, embedded newlines, and proper non-ASCII handling.

* **Tests**
  * Added a CLI-focused pytest coverage that runs `--generate-pyproject-config` with special-character-rich headers and verifies the emitted output matches a golden reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->