### PR TITLE
Skip YAML tag scan without unsupported markers

### DIFF
--- a/src/datamodel_code_generator/util.py
+++ b/src/datamodel_code_generator/util.py
@@ -37,6 +37,7 @@ _YAML_DEPRECATED_BOOL_LINE_PATTERN = re.compile(r"(?m)(?::|-\s*)\s*(True|False|T
 _YAML_DEPRECATED_BOOL_WARNING_MESSAGE = "YAML bool "
 _YAML_DEPRECATED_BOOL_WARNING_MODULE = "datamodel_code_generator"
 _YAML_UNSUPPORTED_TAGS = {"tag:yaml.org,2002:set"}
+_YAML_UNSUPPORTED_TAG_MARKERS = ("!!set", "tag:yaml.org,2002:set")
 # Pattern for scientific notation without decimal point (e.g., 1e-5, 1E+10)
 # Standard YAML only matches floats with decimal points, missing patterns like "1e-5"
 _YAML_SCIENTIFIC_NOTATION_PATTERN = re.compile(r"^[-+]?[0-9][0-9_]*[eE][-+]?[0-9]+$")
@@ -93,6 +94,9 @@ def _iter_yaml_nodes(node: Any) -> Iterator[Any]:
 
 def reject_unsupported_yaml_tags(text: str) -> None:
     """Reject YAML tags that cannot be represented by JSON-compatible sample data."""
+    if not any(marker in text for marker in _YAML_UNSUPPORTED_TAG_MARKERS):
+        return
+
     import yaml  # noqa: PLC0415
 
     node = yaml.compose(text, Loader=get_safe_loader())

--- a/src/datamodel_code_generator/util.py
+++ b/src/datamodel_code_generator/util.py
@@ -38,6 +38,7 @@ _YAML_DEPRECATED_BOOL_WARNING_MESSAGE = "YAML bool "
 _YAML_DEPRECATED_BOOL_WARNING_MODULE = "datamodel_code_generator"
 _YAML_UNSUPPORTED_TAGS = {"tag:yaml.org,2002:set"}
 _YAML_UNSUPPORTED_TAG_MARKERS = ("!!set", "tag:yaml.org,2002:set")
+_YAML_TAG_DIRECTIVE_PATTERN = re.compile(r"(?m)^%TAG(?:\s|$)")
 # Pattern for scientific notation without decimal point (e.g., 1e-5, 1E+10)
 # Standard YAML only matches floats with decimal points, missing patterns like "1e-5"
 _YAML_SCIENTIFIC_NOTATION_PATTERN = re.compile(r"^[-+]?[0-9][0-9_]*[eE][-+]?[0-9]+$")
@@ -94,7 +95,9 @@ def _iter_yaml_nodes(node: Any) -> Iterator[Any]:
 
 def reject_unsupported_yaml_tags(text: str) -> None:
     """Reject YAML tags that cannot be represented by JSON-compatible sample data."""
-    if not any(marker in text for marker in _YAML_UNSUPPORTED_TAG_MARKERS):
+    if not any(marker in text for marker in _YAML_UNSUPPORTED_TAG_MARKERS) and not _YAML_TAG_DIRECTIVE_PATTERN.search(
+        text
+    ):
         return
 
     import yaml  # noqa: PLC0415

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -93,15 +93,13 @@ class TestLoadYaml:
 
     def test_load_yaml_allows_literal_unsupported_tag_marker_text(self) -> None:
         """Literal marker text is valid YAML data when it is not a YAML tag."""
-        with patch.dict("sys.modules", {"ryaml": None}):
-            result = load_yaml("description: 'literal !!set text'\n")
+        result = load_yaml("description: 'literal !!set text'\n")
 
         assert result == {"description": "literal !!set text"}
 
     def test_load_yaml_allows_comment_only_unsupported_tag_marker_text(self) -> None:
         """Comment-only marker text is not a YAML tag."""
-        with patch.dict("sys.modules", {"ryaml": None}):
-            result = load_yaml("# !!set\n")
+        result = load_yaml("# !!set\n")
 
         assert result is None
 

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -114,6 +114,11 @@ class TestLoadYaml:
         with pytest.raises(yaml.YAMLError, match=r"Unsupported YAML tag: tag:yaml\.org,2002:set"):
             load_yaml("fruits: !!set\n  ? apple\n")
 
+    def test_load_yaml_rejects_yaml_set_tag_with_custom_handle(self) -> None:
+        """YAML set tags are rejected even when declared through a custom YAML tag handle."""
+        with pytest.raises(yaml.YAMLError, match=r"Unsupported YAML tag: tag:yaml\.org,2002:set"):
+            load_yaml("%TAG !e! tag:yaml.org,2002:\n---\nfruits: !e!set\n  ? apple\n")
+
     def test_with_ryaml_string(self) -> None:
         """When ryaml is available, ryaml.loads() is used for string input."""
         mock_ryaml = MagicMock()

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -97,6 +97,12 @@ class TestLoadYaml:
 
         assert result == {"description": "literal !!set text"}
 
+    def test_load_yaml_allows_literal_unsupported_tag_marker_text_in_sequence(self) -> None:
+        """Literal marker text is valid YAML sequence data when it is not a YAML tag."""
+        result = load_yaml("descriptions:\n  - 'literal !!set text'\n")
+
+        assert result == {"descriptions": ["literal !!set text"]}
+
     def test_load_yaml_allows_comment_only_unsupported_tag_marker_text(self) -> None:
         """Comment-only marker text is not a YAML tag."""
         result = load_yaml("# !!set\n")

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -91,6 +91,25 @@ class TestLoadYaml:
             result = load_yaml(io.StringIO("key: value"))
             assert result == {"key": "value"}
 
+    def test_load_yaml_allows_literal_unsupported_tag_marker_text(self) -> None:
+        """Literal marker text is valid YAML data when it is not a YAML tag."""
+        with patch.dict("sys.modules", {"ryaml": None}):
+            result = load_yaml("description: 'literal !!set text'\n")
+
+        assert result == {"description": "literal !!set text"}
+
+    def test_load_yaml_allows_comment_only_unsupported_tag_marker_text(self) -> None:
+        """Comment-only marker text is not a YAML tag."""
+        with patch.dict("sys.modules", {"ryaml": None}):
+            result = load_yaml("# !!set\n")
+
+        assert result is None
+
+    def test_load_yaml_rejects_yaml_set_tag(self) -> None:
+        """YAML set tags are rejected through the public YAML loader."""
+        with pytest.raises(yaml.YAMLError, match=r"Unsupported YAML tag: tag:yaml\.org,2002:set"):
+            load_yaml("fruits: !!set\n  ? apple\n")
+
     def test_with_ryaml_string(self) -> None:
         """When ryaml is available, ryaml.loads() is used for string input."""
         mock_ryaml = MagicMock()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded YAML loader coverage to verify `!!set` handling as quoted text vs comments, and to ensure actual `!!set` YAML tags are rejected with clear error messaging.

* **Refactor**
  * Improved YAML validation performance by adding a quick pre-check to avoid deeper parsing when unsupported `!!set` markers are not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->