### PR TITLE
Reuse loaded sources for local refs

### DIFF
--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -5663,13 +5663,20 @@ class JsonSchemaParser(Parser["JSONSchemaParserConfig", "JsonSchemaFeatures"]):
             case list() as paths:
                 yield from ((self.base_path / path) for path in paths)
 
-    def _load_source_dict(self, source: Source) -> dict[str, Any]:  # noqa: PLR6301
+    def _load_source_dict(self, source: Source) -> dict[str, YamlValue]:  # noqa: PLR6301
+        """Load a source into a schema dictionary."""
         if source.raw_data is None:
             return load_data(source.text)
         if not isinstance(source.raw_data, dict):
             msg = f"Expected dict, got {type(source.raw_data).__name__}"
             raise TypeError(msg)
         return dict(source.raw_data)
+
+    def _cache_source_ref_body(self, source: Source, raw_obj: dict[str, YamlValue]) -> None:
+        """Cache a local source body for later local $ref resolution."""
+        if not source.path.parts:
+            return
+        self.remote_object_cache[str((self.base_path / source.path).resolve())] = raw_obj
 
     def _resolve_root_model_name(self, raw_obj: dict[str, Any]) -> tuple[str, bool]:
         title = raw_obj.get("title")
@@ -5694,8 +5701,7 @@ class JsonSchemaParser(Parser["JSONSchemaParserConfig", "JsonSchemaFeatures"]):
             for source, path_parts in self._get_context_source_path_parts():
                 raw_obj = make_converter().convert(source)
                 source.raw_data = raw_obj
-                if source.path.parts:
-                    self.remote_object_cache[str((self.base_path / source.path).resolve())] = raw_obj
+                self._cache_source_ref_body(source, raw_obj)
                 self.raw_obj = raw_obj
                 obj_name, preserve_root_class_name = self._resolve_root_model_name(raw_obj)
                 self._parse_file(
@@ -5719,6 +5725,7 @@ class JsonSchemaParser(Parser["JSONSchemaParserConfig", "JsonSchemaFeatures"]):
                 except TypeError:
                     warn(f"{source.path} is empty or not a dict. Skipping this file", stacklevel=2)
                     continue
+                self._cache_source_ref_body(source, raw_obj)
                 self.raw_obj = raw_obj
                 obj_name, preserve_root_class_name = self._resolve_root_model_name(self.raw_obj)
                 self._parse_file(self.raw_obj, obj_name, path_parts, preserve_root_class_name=preserve_root_class_name)

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -2219,8 +2219,13 @@ def test_main_root_model_with_additional_properties_literal(min_version: str, ou
     )
 
 
-def test_main_jsonschema_multiple_files_ref(output_dir: Path) -> None:
+def test_main_jsonschema_multiple_files_ref(output_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test multiple files with references."""
+    monkeypatch.setattr(
+        "datamodel_code_generator.parser.jsonschema.load_data_from_path",
+        lambda *_args, **_kwargs: pytest.fail("local refs should reuse loaded directory sources"),
+    )
+
     run_main_and_assert(
         input_path=JSON_SCHEMA_DATA_PATH / "multiple_files_self_ref",
         output_path=output_dir,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage to verify that local JSON schema references properly reuse already-loaded sources for optimal performance.

* **Chores**
  * Refactored the source caching mechanism to improve efficiency when parsing multiple JSON schema files with cross-file references.
  * Strengthened input validation for JSON schema source data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->