### PR TITLE
Cache model imports

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -1021,6 +1021,8 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     @property
     def imports(self) -> tuple[Import, ...]:
         """Get all imports required by this model and its fields."""
+        # DataModel is intentionally mutable during parser post-processing. Keep
+        # this cache coarse-grained: import-affecting mutations must clear it.
         if self._IMPORTS_CACHE_KEY in self.__dict__:
             return self.__dict__[self._IMPORTS_CACHE_KEY]
 
@@ -1032,7 +1034,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         return imports
 
     def clear_imports_cache(self) -> None:
-        """Clear cached imports after model, field, or data type mutations."""
+        """Clear cached imports after import-affecting model, field, or data type mutations."""
         self.__dict__.pop(self._IMPORTS_CACHE_KEY, None)
 
     @property

--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -629,6 +629,8 @@ class DataModelFieldBase(_BaseModel):
         else:
             self.data_type = new_data_type
             new_data_type.parent = self
+        if self.parent is not None:
+            self.parent.clear_imports_cache()
 
 
 def _nested_model_default_factory(field: DataModelFieldBase, model_cls: type[DataModel]) -> str | None:
@@ -812,6 +814,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     DOCSTRING_INDENT: ClassVar[int] = 4
     FIELD_DOCSTRING_INDENT: ClassVar[int] = 4
     FORMAT_DESCRIPTION_AS_DOCSTRING: ClassVar[bool] = True
+    _IMPORTS_CACHE_KEY: ClassVar[str] = "_cached_imports"
     has_forward_reference: bool = False
 
     @classmethod
@@ -967,6 +970,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
             message = f"{self.class_name} is deprecated."
             self.decorators = [*self.decorators, f"@deprecated({message!r})"]
         self._additional_imports.append(Import.from_full_path("typing_extensions.deprecated"))
+        self.clear_imports_cache()
 
     def replace_children_in_models(self, models: list[DataModel], new_ref: Reference) -> None:
         """Replace reference children if their parent model is in models list."""
@@ -985,6 +989,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
 
         if not base_class_list:
             self.base_classes = []
+            self.clear_imports_cache()
             return
 
         result = []
@@ -993,6 +998,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
             self._additional_imports.append(base_class_import)
             result.append(BaseClassDataType.from_import(base_class_import))
         self.base_classes = result
+        self.clear_imports_cache()
 
     @cached_property
     def template_file_path(self) -> Path:
@@ -1015,10 +1021,19 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     @property
     def imports(self) -> tuple[Import, ...]:
         """Get all imports required by this model and its fields."""
-        return chain_as_tuple(
+        if self._IMPORTS_CACHE_KEY in self.__dict__:
+            return self.__dict__[self._IMPORTS_CACHE_KEY]
+
+        imports = chain_as_tuple(
             (i for f in self.fields for i in f.imports),
             self._additional_imports,
         )
+        self.__dict__[self._IMPORTS_CACHE_KEY] = imports
+        return imports
+
+    def clear_imports_cache(self) -> None:
+        """Clear cached imports after model, field, or data type mutations."""
+        self.__dict__.pop(self._IMPORTS_CACHE_KEY, None)
 
     @property
     def reference_classes(self) -> frozenset[str]:
@@ -1060,6 +1075,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
             self.reference.name = f"{self.reference.name.rsplit('.', 1)[0]}.{class_name}"
         else:
             self.reference.name = class_name
+        self.clear_imports_cache()
 
     @property
     def duplicate_class_name(self) -> str:
@@ -1119,6 +1135,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         self.reference.path = new_path
         if "path" in self.__dict__:  # pragma: no branch
             del self.__dict__["path"]
+        self.clear_imports_cache()
 
     def render(self, *, class_name: str | None = None) -> str:
         """Render the model to a string using the template."""

--- a/src/datamodel_code_generator/model/pydantic_v2/dataclass.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/dataclass.py
@@ -137,6 +137,7 @@ class DataClass(_DataclassReuseMixin, DataModel):
         config = self.extra_template_data.setdefault("config", {})
         config["regex_engine"] = '"python-re"'
         self._additional_imports.append(IMPORT_CONFIG_DICT)
+        self.clear_imports_cache()
 
     @property
     def imports(self) -> tuple[Import, ...]:

--- a/src/datamodel_code_generator/model/pydantic_v2/root_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/root_model.py
@@ -64,6 +64,7 @@ class RootModel(BaseModel):
         self.extra_template_data[_SEQUENCE_BASE_CLASS_TEMPLATE_DATA_KEY] = f"Sequence[{item_type}]"
         self.extra_template_data[_SEQUENCE_ITEM_TYPE_TEMPLATE_DATA_KEY] = item_type
         self.extra_template_data[_SEQUENCE_SLICE_TYPE_TEMPLATE_DATA_KEY] = slice_type
+        self.clear_imports_cache()
 
     def render(self, *, class_name: str | None = None) -> str:
         """Render the RootModel and validate custom sequence templates when needed."""

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -564,6 +564,8 @@ def _alias_base_class_imports(
 
 def _clear_model_imports_cache(models: Iterable[DataModel]) -> None:
     """Clear per-model imports caches after import-affecting mutations."""
+    # Parser post-processing rewrites fields, data types, and aliases in bulk.
+    # Clear at the end of those rewrite steps so later imports are recomputed.
     for model in models:
         model.clear_imports_cache()
 

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -562,6 +562,12 @@ def _alias_base_class_imports(
                 break
 
 
+def _clear_model_imports_cache(models: Iterable[DataModel]) -> None:
+    """Clear per-model imports caches after import-affecting mutations."""
+    for model in models:
+        model.clear_imports_cache()
+
+
 ReferenceMapSet = dict[str, set[str]]
 SortedDataModels = dict[str, DataModel]
 
@@ -1893,6 +1899,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                     ),
                 )
             if import_sensitive_alias_changed:  # pragma: no cover
+                model.clear_imports_cache()
                 after_import = model.imports
                 if before_import != after_import:
                     imports.append(after_import)
@@ -2138,6 +2145,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         return None  # pragma: no cover
 
     def __replace_unique_list_to_set(self, models: list[DataModel]) -> None:
+        changed = False
         for model in models:
             for model_field in model.fields:
                 if not self.use_unique_items_as_set:
@@ -2157,6 +2165,9 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                             continue
                         model_field.default = converted_default
                     self.generation_store.replace_field_type(model_field, set_data_type)
+                    changed = True
+        if changed:
+            _clear_model_imports_cache(models)
 
     @classmethod
     def __collect_set_item_references(cls, models: list[DataModel]) -> set[str]:
@@ -2542,6 +2553,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         self,
         models: list[DataModel],
     ) -> None:
+        changed = False
         for model in models:
             if isinstance(model, (Enum, self.data_model_root_type)):
                 continue
@@ -2560,6 +2572,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                 original_field = _find_field(model_field.original_name, _find_base_classes(model))
                 if not original_field:
                     self.generation_store.remove_field(model, model_field)
+                    changed = True
                     continue
                 copied_original_field = original_field.model_copy()
                 if original_field.data_type.reference:
@@ -2581,6 +2594,9 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                     copied_original_field.use_default_with_required = True
                 self.generation_store.insert_field(model, index, copied_original_field)
                 self.generation_store.remove_field(model, model_field)
+                changed = True
+        if changed:
+            _clear_model_imports_cache(models)
 
     def __sort_models(
         self,
@@ -2937,6 +2953,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
 
         for model in models:
             _alias_base_class_imports(model, aliased_imports)
+        _clear_model_imports_cache(models)
 
     def __apply_generic_base_class(  # noqa: PLR0912, PLR0914, PLR0915
         self,
@@ -3631,6 +3648,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
             models, self.pydantic_v2_root_model_type, use_deferred_annotations=config.use_deferred_annotations
         )
         self.__set_validate_default_on_fields(models)
+        _clear_model_imports_cache(models)
 
         return ModuleContext(module, module_, models, is_init, imports, scoped_model_resolver)
 

--- a/tests/model/pydantic_v2/test_dataclass.py
+++ b/tests/model/pydantic_v2/test_dataclass.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import pytest
 
 from datamodel_code_generator.model import DataModelFieldBase
-from datamodel_code_generator.model.pydantic_v2.base_model import has_lookaround_pattern
+from datamodel_code_generator.model.base import DataModel
+from datamodel_code_generator.model.pydantic_v2.base_model import Constraints, has_lookaround_pattern
 from datamodel_code_generator.model.pydantic_v2.dataclass import DataClass, DataModelField
+from datamodel_code_generator.model.pydantic_v2.imports import IMPORT_CONFIG_DICT
 from datamodel_code_generator.model.pydantic_v2.types import DataTypeManager
 from datamodel_code_generator.model.pydantic_v2.version import PYDANTIC_V2_DATACLASS_ALIAS_NEEDS_FALLBACK
 from datamodel_code_generator.reference import Reference
@@ -198,6 +200,27 @@ def test_has_lookaround_pattern_skips_reference_without_fields() -> None:
     field = DataModelFieldBase(name="value", data_type=DataType(reference=sourceless_ref), required=False)
 
     assert has_lookaround_pattern([field], follow_references=True) is False
+
+
+def test_data_class_imports_cache_clears_after_lookaround_regex_engine() -> None:
+    """Lookaround regex config imports are visible after an earlier imports read."""
+    field = DataModelFieldBase(
+        name="a",
+        data_type=DataType(type="str"),
+        constraints=Constraints(pattern="(?<=prefix)value"),
+        required=True,
+    )
+    data_class = DataClass(fields=[field], reference=Reference(name="Model", path="model"))
+
+    base_imports_getter = DataModel.imports.fget
+
+    assert base_imports_getter is not None
+    base_imports = base_imports_getter(data_class)
+    assert IMPORT_CONFIG_DICT not in base_imports
+
+    data_class.render()
+
+    assert IMPORT_CONFIG_DICT in data_class.imports
 
 
 def test_create_reuse_model() -> None:

--- a/tests/model/pydantic_v2/test_root_model.py
+++ b/tests/model/pydantic_v2/test_root_model.py
@@ -66,6 +66,8 @@ def test_root_model_sequence_interface() -> None:
         reference=Reference(name="TestRootModel", path="test_root_model"),
     )
 
+    assert not any(import_.import_ == "Iterator" for import_ in root_model.imports)
+
     root_model.add_sequence_interface("str", "list[str]")
 
     assert root_model.render() == (

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -159,6 +159,18 @@ def test_data_model_dedup_key_uses_model_base_to_hashable_seam(monkeypatch: pyte
     assert calls[1] == model.imports
 
 
+def test_data_model_imports_cache_clears_after_field_type_replacement() -> None:
+    """Test model imports reflect field type replacements after an earlier read."""
+    field = DataModelFieldBase(name="a", data_type=DataType(type="str"), required=True)
+    model = BaseModel(fields=[field], reference=Reference(path="Model", original_name="Model", name="Model"))
+
+    assert IMPORT_DECIMAL not in model.imports
+
+    field.replace_data_type(DataType.from_import(IMPORT_DECIMAL))
+
+    assert IMPORT_DECIMAL in model.imports
+
+
 def test_pydantic_v2_extra_type_hint_keeps_non_dict_hint() -> None:
     """Test typed-extra type hint conversion leaves non-dict hints unchanged."""
     field = PydanticV2DataModelField(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed import generation so rendered output always reflects changes made to model fields and metadata after model creation.
  * Prevented stale or memoized imports from being reused after updates such as decorator changes, base class adjustments, reference path/class name updates, regex engine configuration, and sequence interface setup.
  * Improved cache invalidation during post-processing steps that modify type aliases, unique-to-set conversions, and required-field overrides.
* **Tests**
  * Added coverage for import cache invalidation after regex engine updates, field type replacement, and sequence interface behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->