### PR TITLE
Use structured SerializeAsAny imports

### DIFF
--- a/src/datamodel_code_generator/model/pydantic_v2/types.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/types.py
@@ -461,7 +461,7 @@ class PydanticV2DataType(DataType):
         """Yield imports including SerializeAsAny when needed."""
         yield from super().imports
 
-        if self.use_serialize_as_any and "SerializeAsAny" in self.type_hint:
+        if self.use_serialize_as_any and self.reference is not None and self._should_wrap_with_serialize_as_any():
             yield IMPORT_SERIALIZE_AS_ANY
 
 

--- a/src/datamodel_code_generator/model/pydantic_v2/types.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/types.py
@@ -456,12 +456,19 @@ class PydanticV2DataType(DataType):
 
         return type_
 
+    def _needs_serialize_as_any_import(self) -> bool:
+        if not self.use_serialize_as_any:
+            return False
+        if self.alias or self.type or self.reference is None:
+            return False
+        return self._should_wrap_with_serialize_as_any()
+
     @property
     def imports(self) -> Iterator[Import]:
         """Yield imports including SerializeAsAny when needed."""
         yield from super().imports
 
-        if self.use_serialize_as_any and self.reference is not None and self._should_wrap_with_serialize_as_any():
+        if self._needs_serialize_as_any_import():
             yield IMPORT_SERIALIZE_AS_ANY
 
 

--- a/tests/model/pydantic_v2/test_types.py
+++ b/tests/model/pydantic_v2/test_types.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from datamodel_code_generator.model.pydantic_v2 import BaseModel, DataModelField
 from datamodel_code_generator.model.pydantic_v2.imports import IMPORT_SERIALIZE_AS_ANY
 from datamodel_code_generator.model.pydantic_v2.types import DataTypeManager, PydanticV2DataType
+from datamodel_code_generator.reference import Reference
+from datamodel_code_generator.types import DataType
 
 
 class TypeHintErrorDataType(PydanticV2DataType):
@@ -15,15 +18,6 @@ class TypeHintErrorDataType(PydanticV2DataType):
     def type_hint(self) -> str:
         """Fail when type_hint is evaluated."""
         raise AssertionError
-
-
-class SerializeAsAnyDataType(PydanticV2DataType):
-    """DataType that renders a SerializeAsAny wrapper."""
-
-    @property
-    def type_hint(self) -> str:
-        """Return a SerializeAsAny type hint."""
-        return "SerializeAsAny[User]"
 
 
 @pytest.mark.allow_direct_assert
@@ -36,10 +30,24 @@ def test_imports_skip_serialize_as_any_type_hint_when_disabled() -> None:
 
 @pytest.mark.allow_direct_assert
 def test_imports_include_serialize_as_any_when_enabled() -> None:
-    """Keep SerializeAsAny import when the rendered type hint uses it."""
-    data_type = SerializeAsAnyDataType(type="User", use_serialize_as_any=True)
+    """Keep SerializeAsAny import when the reference structure needs it."""
+    reference = Reference(path="#/$defs/User", name="User")
+    model = BaseModel(
+        fields=[DataModelField(name="name", data_type=DataType(type="str"), required=True)],
+        reference=reference,
+    )
+    reference.children.append(model)
+    data_type = PydanticV2DataType(reference=reference, use_serialize_as_any=True)
 
     assert list(data_type.imports) == [IMPORT_SERIALIZE_AS_ANY]
+
+
+@pytest.mark.allow_direct_assert
+def test_imports_skip_serialize_as_any_without_reference() -> None:
+    """Do not render type_hint or assert when no reference can be wrapped."""
+    data_type = TypeHintErrorDataType(type="User", use_serialize_as_any=True)
+
+    assert list(data_type.imports) == []
 
 
 @pytest.mark.allow_direct_assert

--- a/tests/model/pydantic_v2/test_types.py
+++ b/tests/model/pydantic_v2/test_types.py
@@ -43,6 +43,20 @@ def test_imports_include_serialize_as_any_when_enabled() -> None:
 
 
 @pytest.mark.allow_direct_assert
+def test_imports_skip_serialize_as_any_when_type_renders_without_wrapper() -> None:
+    """Do not import SerializeAsAny for reference structures rendered through type."""
+    reference = Reference(path="#/$defs/User", name="User")
+    model = BaseModel(
+        fields=[DataModelField(name="name", data_type=DataType(type="str"), required=True)],
+        reference=reference,
+    )
+    reference.children.append(model)
+    data_type = PydanticV2DataType(type="Shared.User", reference=reference, use_serialize_as_any=True)
+
+    assert list(data_type.imports) == []
+
+
+@pytest.mark.allow_direct_assert
 def test_imports_skip_serialize_as_any_without_reference() -> None:
     """Do not render type_hint or assert when no reference can be wrapped."""
     data_type = TypeHintErrorDataType(type="User", use_serialize_as_any=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pydantic v2 type import logic for advanced serialization, ensuring `SerializeAsAny` is only added when it’s truly required.
  * Updated and expanded tests to better validate wrapper behavior, including cases where serialization settings are enabled but no reference information is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->