### PR TITLE
Use structured msgspec unset unions

### DIFF
--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -5,8 +5,6 @@ Generates Python models using msgspec.Struct for high-performance serialization.
 
 from __future__ import annotations
 
-import io
-import tokenize
 from functools import lru_cache, wraps
 from math import isfinite
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
@@ -43,7 +41,7 @@ from datamodel_code_generator.types import (
 
 UNSET_TYPE = "UnsetType"
 _UNSET_WRAPPER_NAMES = (OPTIONAL, UNION)
-_IGNORED_TYPE_HINT_TOKEN_TYPES = frozenset({tokenize.ENDMARKER, tokenize.NEWLINE, tokenize.NL})
+_TYPE_HINT_QUOTE_CHARS = "'\""
 
 
 class _UNSET:
@@ -217,42 +215,57 @@ class Constraints(_Constraints):
     """Constraint model for msgspec fields."""
 
 
+def _is_escaped_position(type_: str, index: int) -> bool:
+    backslash_count = 0
+    while index - backslash_count > 0 and type_[index - backslash_count - 1] == "\\":
+        backslash_count += 1
+    return backslash_count % 2 == 1
+
+
+def _skip_string_literal(type_: str, index: int, quote: str) -> int:
+    quote_size = 3 if type_[index : index + 3] == quote * 3 else 1
+    quote_token = quote * quote_size
+    index += quote_size
+    while (next_index := type_.find(quote_token, index)) != -1:
+        if not _is_escaped_position(type_, next_index):
+            return next_index + quote_size
+        index = next_index + quote_size
+    return len(type_)
+
+
+def _find_subscript_end(type_: str, open_index: int) -> int | None:
+    depth = 0
+    index = open_index
+    while index < len(type_):
+        char = type_[index]
+        if char in _TYPE_HINT_QUOTE_CHARS:
+            index = _skip_string_literal(type_, index, char)
+            continue
+        match char:
+            case "[":
+                depth += 1
+            case "]":
+                depth -= 1
+                if depth == 0:
+                    return index
+        index += 1
+    return None
+
+
 @lru_cache
 def _get_top_level_typing_subscript(type_: str) -> tuple[str, str] | None:
     """Return the top-level Optional/Union name and args for a type hint."""
-    try:
-        tokens = [
-            token_info
-            for token_info in tokenize.generate_tokens(io.StringIO(type_).readline)
-            if token_info.type not in _IGNORED_TYPE_HINT_TOKEN_TYPES
-        ]
-    except tokenize.TokenError:
+    if (open_index := type_.find("[")) == -1:
         return None
 
-    match tokens:
-        case [name_token, open_token, *_] if (
-            name_token.type == tokenize.NAME
-            and name_token.string in _UNSET_WRAPPER_NAMES
-            and name_token.start == (1, 0)
-            and open_token.type == tokenize.OP
-            and open_token.string == "["
-        ):
-            depth = 0
-            for index, token_info in enumerate(tokens[1:], start=1):
-                if token_info.type != tokenize.OP:
-                    continue
-                match token_info.string:
-                    case "[":
-                        depth += 1
-                    case "]":
-                        depth -= 1
-                        if depth == 0:
-                            if index != len(tokens) - 1:
-                                return None
-                            return name_token.string, type_[open_token.end[1] : token_info.start[1]]
+    name = type_[:open_index]
+    match name:
+        case name if name in _UNSET_WRAPPER_NAMES:
+            if (close_index := _find_subscript_end(type_, open_index)) != len(type_) - 1:
+                return None
+            return name, type_[open_index + 1 : close_index]
         case _:
             return None
-    return None
 
 
 def _get_top_level_typing_args(type_: str, expected_name: str) -> str | None:

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -239,6 +239,7 @@ def _get_top_level_typing_args(type_: str, expected_name: str) -> str | None:
             return args
         case _:
             return None
+    return None  # pragma: no cover
 
 
 @lru_cache

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -5,6 +5,7 @@ Generates Python models using msgspec.Struct for high-performance serialization.
 
 from __future__ import annotations
 
+import ast
 from functools import lru_cache, wraps
 from math import isfinite
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
@@ -28,7 +29,8 @@ from datamodel_code_generator.model.types import DataTypeManager as _DataTypeMan
 from datamodel_code_generator.python_literal import represent_python_value
 from datamodel_code_generator.types import (
     NONE,
-    OPTIONAL_PREFIX,
+    OPTIONAL,
+    UNION,
     UNION_DELIMITER,
     UNION_OPERATOR_DELIMITER,
     UNION_PREFIX,
@@ -39,6 +41,7 @@ from datamodel_code_generator.types import (
 )
 
 UNSET_TYPE = "UnsetType"
+_UNSET_WRAPPER_NAMES = (OPTIONAL, UNION)
 
 
 class _UNSET:
@@ -213,18 +216,44 @@ class Constraints(_Constraints):
 
 
 @lru_cache
+def _get_top_level_typing_subscript(type_: str) -> tuple[str, str] | None:
+    """Return the top-level Optional/Union name and args for a type hint."""
+    try:
+        expression = ast.parse(type_, mode="eval").body
+    except SyntaxError:
+        return None
+
+    match expression:
+        case ast.Subscript(value=ast.Name(id=name), slice=slice_node) if name in _UNSET_WRAPPER_NAMES:
+            if (args := ast.get_source_segment(type_, slice_node)) is not None:
+                return name, args
+        case _:
+            return None
+    return None
+
+
+def _get_top_level_typing_args(type_: str, expected_name: str) -> str | None:
+    """Return args when the type hint is a specific top-level typing subscript."""
+    match _get_top_level_typing_subscript(type_):
+        case (name, args) if name == expected_name:
+            return args
+        case _:
+            return None
+
+
+@lru_cache
 def get_neither_required_nor_nullable_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT001
     """Get type hint for fields that are neither required nor nullable, using UnsetType."""
     type_ = _remove_none_from_union(type_, use_union_operator=use_union_operator)
-    if type_.startswith(OPTIONAL_PREFIX):  # pragma: no cover
-        type_ = type_[len(OPTIONAL_PREFIX) : -1]
+    if (inner_type := _get_top_level_typing_args(type_, OPTIONAL)) is not None:  # pragma: no cover
+        type_ = inner_type
 
     if not type_ or type_ == NONE:
         return UNSET_TYPE
     if use_union_operator:
         return UNION_OPERATOR_DELIMITER.join((type_, UNSET_TYPE))
-    if type_.startswith(UNION_PREFIX):
-        return f"{type_[:-1]}{UNION_DELIMITER}{UNSET_TYPE}]"
+    if (union_args := _get_top_level_typing_args(type_, UNION)) is not None:
+        return f"{UNION_PREFIX}{union_args}{UNION_DELIMITER}{UNSET_TYPE}]"
     return f"{UNION_PREFIX}{type_}{UNION_DELIMITER}{UNSET_TYPE}]"
 
 
@@ -233,12 +262,13 @@ def _add_unset_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT00
     """Add UnsetType to a type hint without removing None."""
     if use_union_operator:
         return f"{type_}{UNION_OPERATOR_DELIMITER}{UNSET_TYPE}"
-    if type_.startswith(UNION_PREFIX):  # pragma: no cover
-        return f"{type_[:-1]}{UNION_DELIMITER}{UNSET_TYPE}]"
-    if type_.startswith(OPTIONAL_PREFIX):  # pragma: no cover
-        inner_type = type_[len(OPTIONAL_PREFIX) : -1]
-        return f"{UNION_PREFIX}{inner_type}{UNION_DELIMITER}{NONE}{UNION_DELIMITER}{UNSET_TYPE}]"
-    return f"{UNION_PREFIX}{type_}{UNION_DELIMITER}{UNSET_TYPE}]"  # pragma: no cover
+    match _get_top_level_typing_subscript(type_):
+        case (name, union_args) if name == UNION:  # pragma: no cover
+            return f"{UNION_PREFIX}{union_args}{UNION_DELIMITER}{UNSET_TYPE}]"
+        case (name, inner_type) if name == OPTIONAL:  # pragma: no cover
+            return f"{UNION_PREFIX}{inner_type}{UNION_DELIMITER}{NONE}{UNION_DELIMITER}{UNSET_TYPE}]"
+        case _:
+            return f"{UNION_PREFIX}{type_}{UNION_DELIMITER}{UNSET_TYPE}]"  # pragma: no cover
 
 
 @import_extender

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -5,7 +5,8 @@ Generates Python models using msgspec.Struct for high-performance serialization.
 
 from __future__ import annotations
 
-import ast
+import io
+import tokenize
 from functools import lru_cache, wraps
 from math import isfinite
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
@@ -42,6 +43,7 @@ from datamodel_code_generator.types import (
 
 UNSET_TYPE = "UnsetType"
 _UNSET_WRAPPER_NAMES = (OPTIONAL, UNION)
+_IGNORED_TYPE_HINT_TOKEN_TYPES = frozenset({tokenize.ENDMARKER, tokenize.NEWLINE, tokenize.NL})
 
 
 class _UNSET:
@@ -219,14 +221,35 @@ class Constraints(_Constraints):
 def _get_top_level_typing_subscript(type_: str) -> tuple[str, str] | None:
     """Return the top-level Optional/Union name and args for a type hint."""
     try:
-        expression = ast.parse(type_, mode="eval").body
-    except SyntaxError:
+        tokens = [
+            token_info
+            for token_info in tokenize.generate_tokens(io.StringIO(type_).readline)
+            if token_info.type not in _IGNORED_TYPE_HINT_TOKEN_TYPES
+        ]
+    except tokenize.TokenError:
         return None
 
-    match expression:
-        case ast.Subscript(value=ast.Name(id=name), slice=slice_node) if name in _UNSET_WRAPPER_NAMES:
-            if (args := ast.get_source_segment(type_, slice_node)) is not None:
-                return name, args
+    match tokens:
+        case [name_token, open_token, *_] if (
+            name_token.type == tokenize.NAME
+            and name_token.string in _UNSET_WRAPPER_NAMES
+            and name_token.start == (1, 0)
+            and open_token.type == tokenize.OP
+            and open_token.string == "["
+        ):
+            depth = 0
+            for index, token_info in enumerate(tokens[1:], start=1):
+                if token_info.type != tokenize.OP:
+                    continue
+                match token_info.string:
+                    case "[":
+                        depth += 1
+                    case "]":
+                        depth -= 1
+                        if depth == 0:
+                            if index != len(tokens) - 1:
+                                return None
+                            return name_token.string, type_[open_token.end[1] : token_info.start[1]]
         case _:
             return None
     return None

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -266,6 +266,7 @@ def _get_top_level_typing_subscript(type_: str) -> tuple[str, str] | None:
             return name, type_[open_index + 1 : close_index]
         case _:
             return None
+    return None  # pragma: no cover
 
 
 def _get_top_level_typing_args(type_: str, expected_name: str) -> str | None:

--- a/tests/model/test_msgspec.py
+++ b/tests/model/test_msgspec.py
@@ -63,6 +63,7 @@ def test_add_unset_type(type_hint: str, use_union_operator: bool, expected: str)
         ("Optional[str]", ("Optional", "str")),
         ("Union[str, int]", ("Union", "str, int")),
         ("Optional[Literal[']']]", ("Optional", "Literal[']']")),
+        ("Optional[Literal['\\'']]", ("Optional", "Literal['\\'']")),
         ("Optional[tuple[*Ts]]", ("Optional", "tuple[*Ts]")),
         ("Union[tuple[*Ts], int]", ("Union", "tuple[*Ts], int")),
         ("typing.Optional[str]", None),

--- a/tests/model/test_msgspec.py
+++ b/tests/model/test_msgspec.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import tokenize
+
 import pytest
 
 from datamodel_code_generator.model.msgspec import (
@@ -18,6 +20,7 @@ from datamodel_code_generator.model.msgspec import (
     [
         ("Optional[str]", False, "Union[str, UnsetType]"),
         ("Union[str, int]", False, "Union[str, int, UnsetType]"),
+        ("Union[tuple[*Ts], int]", False, "Union[tuple[*Ts], int, UnsetType]"),
         ("Union[str, None]", False, "Union[str, UnsetType]"),
         (
             "Annotated[Optional[str], Meta(min_length=1)]",
@@ -39,6 +42,7 @@ def test_get_neither_required_nor_nullable_type(type_hint: str, use_union_operat
     [
         ("Optional[str]", False, "Union[str, None, UnsetType]"),
         ("Union[str, int]", False, "Union[str, int, UnsetType]"),
+        ("Union[tuple[*Ts], int]", False, "Union[tuple[*Ts], int, UnsetType]"),
         ("Union[str, None]", False, "Union[str, None, UnsetType]"),
         (
             "Annotated[Optional[str], Meta(min_length=1)]",
@@ -60,8 +64,11 @@ def test_add_unset_type(type_hint: str, use_union_operator: bool, expected: str)
     [
         ("Optional[str]", ("Optional", "str")),
         ("Union[str, int]", ("Union", "str, int")),
+        ("Optional[tuple[*Ts]]", ("Optional", "tuple[*Ts]")),
+        ("Union[tuple[*Ts], int]", ("Union", "tuple[*Ts], int")),
         ("typing.Optional[str]", None),
         ("list[Union[str, int]]", None),
+        ("Optional[str] | None", None),
         ("str", None),
         ("[", None),
     ],
@@ -86,9 +93,12 @@ def test_get_top_level_typing_args(type_hint: str, expected_name: str, expected:
 
 
 @pytest.mark.allow_direct_assert
-def test_get_top_level_typing_subscript_without_source_segment(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Return None when ast cannot provide a source segment."""
-    monkeypatch.setattr("datamodel_code_generator.model.msgspec.ast.get_source_segment", lambda *_: None)
+def test_get_top_level_typing_subscript_rejects_token_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return None when the type hint cannot be tokenized."""
+    monkeypatch.setattr(
+        "datamodel_code_generator.model.msgspec.tokenize.generate_tokens",
+        lambda _: (_ for _ in ()).throw(tokenize.TokenError("bad", (1, 0))),
+    )
     _get_top_level_typing_subscript.cache_clear()
 
     try:

--- a/tests/model/test_msgspec.py
+++ b/tests/model/test_msgspec.py
@@ -1,0 +1,49 @@
+"""Tests for msgspec model helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from datamodel_code_generator.model.msgspec import _add_unset_type, get_neither_required_nor_nullable_type
+
+
+@pytest.mark.allow_direct_assert
+@pytest.mark.parametrize(
+    ("type_hint", "use_union_operator", "expected"),
+    [
+        ("Optional[str]", False, "Union[str, UnsetType]"),
+        ("Union[str, int]", False, "Union[str, int, UnsetType]"),
+        ("Union[str, None]", False, "Union[str, UnsetType]"),
+        (
+            "Annotated[Optional[str], Meta(min_length=1)]",
+            False,
+            "Union[Annotated[Optional[str], Meta(min_length=1)], UnsetType]",
+        ),
+        ("list[Union[str, int]]", False, "Union[list[Union[str, int]], UnsetType]"),
+        ("str | None", True, "str | UnsetType"),
+    ],
+)
+def test_get_neither_required_nor_nullable_type(type_hint: str, use_union_operator: bool, expected: str) -> None:
+    """Add UnsetType without relying on string prefix checks."""
+    assert get_neither_required_nor_nullable_type(type_hint, use_union_operator) == expected
+
+
+@pytest.mark.allow_direct_assert
+@pytest.mark.parametrize(
+    ("type_hint", "use_union_operator", "expected"),
+    [
+        ("Optional[str]", False, "Union[str, None, UnsetType]"),
+        ("Union[str, int]", False, "Union[str, int, UnsetType]"),
+        ("Union[str, None]", False, "Union[str, None, UnsetType]"),
+        (
+            "Annotated[Optional[str], Meta(min_length=1)]",
+            False,
+            "Union[Annotated[Optional[str], Meta(min_length=1)], UnsetType]",
+        ),
+        ("list[Union[str, int]]", False, "Union[list[Union[str, int]], UnsetType]"),
+        ("str | None", True, "str | None | UnsetType"),
+    ],
+)
+def test_add_unset_type(type_hint: str, use_union_operator: bool, expected: str) -> None:
+    """Add UnsetType to optional fields while preserving existing type hint shapes."""
+    assert _add_unset_type(type_hint, use_union_operator) == expected

--- a/tests/model/test_msgspec.py
+++ b/tests/model/test_msgspec.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from datamodel_code_generator.model.msgspec import _add_unset_type, get_neither_required_nor_nullable_type
+from datamodel_code_generator.model.msgspec import (
+    _add_unset_type,
+    _get_top_level_typing_args,
+    _get_top_level_typing_subscript,
+    get_neither_required_nor_nullable_type,
+)
 
 
 @pytest.mark.allow_direct_assert
@@ -47,3 +52,46 @@ def test_get_neither_required_nor_nullable_type(type_hint: str, use_union_operat
 def test_add_unset_type(type_hint: str, use_union_operator: bool, expected: str) -> None:
     """Add UnsetType to optional fields while preserving existing type hint shapes."""
     assert _add_unset_type(type_hint, use_union_operator) == expected
+
+
+@pytest.mark.allow_direct_assert
+@pytest.mark.parametrize(
+    ("type_hint", "expected"),
+    [
+        ("Optional[str]", ("Optional", "str")),
+        ("Union[str, int]", ("Union", "str, int")),
+        ("typing.Optional[str]", None),
+        ("list[Union[str, int]]", None),
+        ("str", None),
+        ("[", None),
+    ],
+)
+def test_get_top_level_typing_subscript(type_hint: str, expected: tuple[str, str] | None) -> None:
+    """Parse only top-level Optional and Union wrappers."""
+    assert _get_top_level_typing_subscript(type_hint) == expected
+
+
+@pytest.mark.allow_direct_assert
+@pytest.mark.parametrize(
+    ("type_hint", "expected_name", "expected"),
+    [
+        ("Optional[str]", "Optional", "str"),
+        ("Optional[str]", "Union", None),
+        ("list[str]", "Optional", None),
+    ],
+)
+def test_get_top_level_typing_args(type_hint: str, expected_name: str, expected: str | None) -> None:
+    """Return args only for the requested wrapper name."""
+    assert _get_top_level_typing_args(type_hint, expected_name) == expected
+
+
+@pytest.mark.allow_direct_assert
+def test_get_top_level_typing_subscript_without_source_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return None when ast cannot provide a source segment."""
+    monkeypatch.setattr("datamodel_code_generator.model.msgspec.ast.get_source_segment", lambda *_: None)
+    _get_top_level_typing_subscript.cache_clear()
+
+    try:
+        assert _get_top_level_typing_subscript("Optional[str]") is None
+    finally:
+        _get_top_level_typing_subscript.cache_clear()

--- a/tests/model/test_msgspec.py
+++ b/tests/model/test_msgspec.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import tokenize
-
 import pytest
 
 from datamodel_code_generator.model.msgspec import (
@@ -64,11 +62,13 @@ def test_add_unset_type(type_hint: str, use_union_operator: bool, expected: str)
     [
         ("Optional[str]", ("Optional", "str")),
         ("Union[str, int]", ("Union", "str, int")),
+        ("Optional[Literal[']']]", ("Optional", "Literal[']']")),
         ("Optional[tuple[*Ts]]", ("Optional", "tuple[*Ts]")),
         ("Union[tuple[*Ts], int]", ("Union", "tuple[*Ts], int")),
         ("typing.Optional[str]", None),
         ("list[Union[str, int]]", None),
         ("Optional[str] | None", None),
+        ("Optional[Literal['unterminated]", None),
         ("str", None),
         ("[", None),
     ],
@@ -90,18 +90,3 @@ def test_get_top_level_typing_subscript(type_hint: str, expected: tuple[str, str
 def test_get_top_level_typing_args(type_hint: str, expected_name: str, expected: str | None) -> None:
     """Return args only for the requested wrapper name."""
     assert _get_top_level_typing_args(type_hint, expected_name) == expected
-
-
-@pytest.mark.allow_direct_assert
-def test_get_top_level_typing_subscript_rejects_token_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Return None when the type hint cannot be tokenized."""
-    monkeypatch.setattr(
-        "datamodel_code_generator.model.msgspec.tokenize.generate_tokens",
-        lambda _: (_ for _ in ()).throw(tokenize.TokenError("bad", (1, 0))),
-    )
-    _get_top_level_typing_subscript.cache_clear()
-
-    try:
-        assert _get_top_level_typing_subscript("Optional[str]") is None
-    finally:
-        _get_top_level_typing_subscript.cache_clear()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of nullable/optional message type hints to include `UnsetType`, while preserving the original annotation structure (including `Optional[...]`, `Union[...]`, `Annotated[...]`, nested generics, and `|` syntax).

* **Tests**
  * Added parametrized coverage for type-hint parsing and `UnsetType` injection, including correct handling of top-level `Optional`/`Union` wrappers and graceful failure for unsupported or malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->