### PR TITLE
Use structured extra dict hints

### DIFF
--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -6,8 +6,9 @@ with support for Field() constraints and ConfigDict.
 
 from __future__ import annotations
 
-import ast
+import io
 import re
+import tokenize
 from collections import defaultdict
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
@@ -102,18 +103,46 @@ _ALIAS_GENERATOR_IMPORTS: dict[str, Import] = {
     AliasGenerator.ToPascal.value: IMPORT_ALIAS_GENERATOR_TO_PASCAL,
     AliasGenerator.ToSnake.value: IMPORT_ALIAS_GENERATOR_TO_SNAKE,
 }
+_IGNORED_TYPE_HINT_TOKEN_TYPES = frozenset({tokenize.ENDMARKER, tokenize.NEWLINE, tokenize.NL})
 
 
-def _replace_annotation_name(type_hint: str, name: ast.Name, replacement: str) -> str:
-    return f"{type_hint[: name.col_offset]}{replacement}{type_hint[name.end_col_offset :]}"
+def _replace_annotation_name(type_hint: str, start: int, end: int, replacement: str) -> str:
+    return f"{type_hint[:start]}{replacement}{type_hint[end:]}"
 
 
-def _get_leading_builtin_dict_name(expression: ast.AST) -> ast.Name | None:
-    match expression:
-        case ast.Subscript(value=ast.Name(id="dict") as dict_name):
-            return dict_name
-        case ast.BinOp(left=left, op=ast.BitOr()):
-            return _get_leading_builtin_dict_name(left)
+def _get_leading_builtin_dict_name_end(type_hint: str) -> int | None:
+    try:
+        tokens = [
+            token_info
+            for token_info in tokenize.generate_tokens(io.StringIO(type_hint).readline)
+            if token_info.type not in _IGNORED_TYPE_HINT_TOKEN_TYPES
+        ]
+    except tokenize.TokenError:
+        return None
+
+    match tokens:
+        case [name_token, open_token, *_] if (
+            name_token.type == tokenize.NAME
+            and name_token.string == "dict"
+            and name_token.start == (1, 0)
+            and open_token.type == tokenize.OP
+            and open_token.string == "["
+        ):
+            depth = 0
+            for index, token_info in enumerate(tokens[1:], start=1):
+                if token_info.type != tokenize.OP:
+                    continue
+                match token_info.string:
+                    case "[":
+                        depth += 1
+                    case "]":
+                        depth -= 1
+                        if depth == 0:
+                            match tokens[index + 1 :]:
+                                case [] | [tokenize.TokenInfo(type=tokenize.OP, string="|"), *_]:
+                                    return name_token.end[1]
+                                case _:
+                                    return None
         case _:
             return None
     return None  # pragma: no cover
@@ -121,14 +150,9 @@ def _get_leading_builtin_dict_name(expression: ast.AST) -> ast.Name | None:
 
 @lru_cache(maxsize=256)
 def _pydantic_extra_type_hint_for_builtin_dict(type_hint: str) -> str | None:
-    try:
-        expression = ast.parse(type_hint, mode="eval").body
-    except SyntaxError:  # pragma: no cover
+    if (dict_name_end := _get_leading_builtin_dict_name_end(type_hint)) is None:
         return None
-
-    if (dict_name := _get_leading_builtin_dict_name(expression)) is None or dict_name.col_offset != 0:
-        return None
-    return _replace_annotation_name(type_hint, dict_name, DICT)
+    return _replace_annotation_name(type_hint, 0, dict_name_end, DICT)
 
 
 def _alias_generator_name(value: Any) -> str | None:

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -6,9 +6,7 @@ with support for Field() constraints and ConfigDict.
 
 from __future__ import annotations
 
-import io
 import re
-import tokenize
 from collections import defaultdict
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
@@ -103,49 +101,65 @@ _ALIAS_GENERATOR_IMPORTS: dict[str, Import] = {
     AliasGenerator.ToPascal.value: IMPORT_ALIAS_GENERATOR_TO_PASCAL,
     AliasGenerator.ToSnake.value: IMPORT_ALIAS_GENERATOR_TO_SNAKE,
 }
-_IGNORED_TYPE_HINT_TOKEN_TYPES = frozenset({tokenize.ENDMARKER, tokenize.NEWLINE, tokenize.NL})
+_TYPE_HINT_QUOTE_CHARS = "'\""
 
 
 def _replace_annotation_name(type_hint: str, start: int, end: int, replacement: str) -> str:
     return f"{type_hint[:start]}{replacement}{type_hint[end:]}"
 
 
+def _is_escaped_position(type_hint: str, index: int) -> bool:
+    backslash_count = 0
+    while index - backslash_count > 0 and type_hint[index - backslash_count - 1] == "\\":
+        backslash_count += 1
+    return backslash_count % 2 == 1
+
+
+def _skip_string_literal(type_hint: str, index: int, quote: str) -> int:
+    quote_size = 3 if type_hint[index : index + 3] == quote * 3 else 1
+    quote_token = quote * quote_size
+    index += quote_size
+    while (next_index := type_hint.find(quote_token, index)) != -1:
+        if not _is_escaped_position(type_hint, next_index):
+            return next_index + quote_size
+        index = next_index + quote_size
+    return len(type_hint)
+
+
+def _find_subscript_end(type_hint: str, open_index: int) -> int | None:
+    depth = 0
+    index = open_index
+    while index < len(type_hint):
+        char = type_hint[index]
+        if char in _TYPE_HINT_QUOTE_CHARS:
+            index = _skip_string_literal(type_hint, index, char)
+            continue
+        match char:
+            case "[":
+                depth += 1
+            case "]":
+                depth -= 1
+                if depth == 0:
+                    return index
+        index += 1
+    return None
+
+
 def _get_leading_builtin_dict_name_end(type_hint: str) -> int | None:
-    try:
-        tokens = [
-            token_info
-            for token_info in tokenize.generate_tokens(io.StringIO(type_hint).readline)
-            if token_info.type not in _IGNORED_TYPE_HINT_TOKEN_TYPES
-        ]
-    except tokenize.TokenError:
+    if (open_index := type_hint.find("[")) == -1:
         return None
 
-    match tokens:
-        case [name_token, open_token, *_] if (
-            name_token.type == tokenize.NAME
-            and name_token.string == "dict"
-            and name_token.start == (1, 0)
-            and open_token.type == tokenize.OP
-            and open_token.string == "["
-        ):
-            depth = 0
-            for index, token_info in enumerate(tokens[1:], start=1):
-                if token_info.type != tokenize.OP:
-                    continue
-                match token_info.string:
-                    case "[":
-                        depth += 1
-                    case "]":
-                        depth -= 1
-                        if depth == 0:
-                            match tokens[index + 1 :]:
-                                case [] | [tokenize.TokenInfo(type=tokenize.OP, string="|"), *_]:
-                                    return name_token.end[1]
-                                case _:
-                                    return None
+    match type_hint[:open_index]:
+        case "dict":
+            if (close_index := _find_subscript_end(type_hint, open_index)) is None:
+                return None
+            match type_hint[close_index + 1 :].lstrip()[:1]:
+                case "" | "|":
+                    return open_index
+                case _:
+                    return None
         case _:
             return None
-    return None  # pragma: no cover
 
 
 @lru_cache(maxsize=256)

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -160,6 +160,7 @@ def _get_leading_builtin_dict_name_end(type_hint: str) -> int | None:
                     return None
         case _:
             return None
+    return None  # pragma: no cover
 
 
 @lru_cache(maxsize=256)

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -6,8 +6,10 @@ with support for Field() constraints and ConfigDict.
 
 from __future__ import annotations
 
+import ast
 import re
 from collections import defaultdict
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 from pydantic import Field, ValidationError, field_validator, model_validator
@@ -47,7 +49,7 @@ from datamodel_code_generator.model.pydantic_v2.imports import (
 )
 from datamodel_code_generator.model.pydantic_v2.version import PYDANTIC_V2_FIELD_DEPRECATED_NEEDS_JSON_SCHEMA_EXTRA
 from datamodel_code_generator.reference import ModelResolver
-from datamodel_code_generator.types import chain_as_tuple
+from datamodel_code_generator.types import DICT, chain_as_tuple
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -100,6 +102,32 @@ _ALIAS_GENERATOR_IMPORTS: dict[str, Import] = {
     AliasGenerator.ToPascal.value: IMPORT_ALIAS_GENERATOR_TO_PASCAL,
     AliasGenerator.ToSnake.value: IMPORT_ALIAS_GENERATOR_TO_SNAKE,
 }
+
+
+def _replace_annotation_name(type_hint: str, name: ast.Name, replacement: str) -> str:
+    return f"{type_hint[: name.col_offset]}{replacement}{type_hint[name.end_col_offset :]}"
+
+
+def _get_leading_builtin_dict_name(expression: ast.AST) -> ast.Name | None:
+    match expression:
+        case ast.Subscript(value=ast.Name(id="dict") as dict_name):
+            return dict_name
+        case ast.BinOp(left=left, op=ast.BitOr()):
+            return _get_leading_builtin_dict_name(left)
+        case _:
+            return None
+
+
+@lru_cache(maxsize=256)
+def _pydantic_extra_type_hint_for_builtin_dict(type_hint: str) -> str | None:
+    try:
+        expression = ast.parse(type_hint, mode="eval").body
+    except SyntaxError:  # pragma: no cover
+        return None
+
+    if (dict_name := _get_leading_builtin_dict_name(expression)) is None or dict_name.col_offset != 0:
+        return None
+    return _replace_annotation_name(type_hint, dict_name, DICT)
 
 
 def _alias_generator_name(value: Any) -> str | None:
@@ -254,9 +282,9 @@ class DataModelField(_PydanticBaseDataModelField):
     def pydantic_extra_type_hint(self) -> str:
         """Return a Dict-based type hint for Pydantic 2.0 typed extras."""
         type_hint = self.type_hint
-        if not type_hint.startswith("dict["):
-            return type_hint
-        return f"Dict[{type_hint.removeprefix('dict[')}"
+        if (dict_type_hint := _pydantic_extra_type_hint_for_builtin_dict(type_hint)) is not None:
+            return dict_type_hint
+        return type_hint
 
     def _process_data_in_str(self, data: dict[str, Any]) -> None:
         if self.const:

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -116,6 +116,7 @@ def _get_leading_builtin_dict_name(expression: ast.AST) -> ast.Name | None:
             return _get_leading_builtin_dict_name(left)
         case _:
             return None
+    return None  # pragma: no cover
 
 
 @lru_cache(maxsize=256)

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tokenize
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -35,6 +36,7 @@ from datamodel_code_generator.model.base import (
 from datamodel_code_generator.model.pydantic_base import DataModelField as PydanticBaseDataModelField
 from datamodel_code_generator.model.pydantic_v2 import BaseModel
 from datamodel_code_generator.model.pydantic_v2 import DataModelField as PydanticV2DataModelField
+from datamodel_code_generator.model.pydantic_v2.base_model import _pydantic_extra_type_hint_for_builtin_dict
 from datamodel_code_generator.model.pydantic_v2.imports import IMPORT_FIELD
 from datamodel_code_generator.reference import Reference
 from datamodel_code_generator.types import ANY, NONE, DataType, Types
@@ -217,6 +219,10 @@ def test_pydantic_v2_extra_type_hint_keeps_non_dict_hint() -> None:
             "Dict[str, list[str]]",
         ),
         (
+            DataType(type="tuple[*Ts]", is_dict=True, use_standard_collections=True),
+            "Dict[str, tuple[*Ts]]",
+        ),
+        (
             DataType(type="int", is_dict=True),
             "Dict[str, int]",
         ),
@@ -253,6 +259,20 @@ def test_pydantic_v2_extra_type_hint_uses_structured_dict(data_type: DataType, e
     )
 
     assert field.pydantic_extra_type_hint == expected
+
+
+def test_pydantic_extra_type_hint_for_builtin_dict_rejects_token_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test malformed token streams leave typed-extra annotations unchanged."""
+    monkeypatch.setattr(
+        "datamodel_code_generator.model.pydantic_v2.base_model.tokenize.generate_tokens",
+        lambda _: (_ for _ in ()).throw(tokenize.TokenError("bad", (1, 0))),
+    )
+    _pydantic_extra_type_hint_for_builtin_dict.cache_clear()
+
+    try:
+        assert _pydantic_extra_type_hint_for_builtin_dict("dict[str, int]") is None
+    finally:
+        _pydantic_extra_type_hint_for_builtin_dict.cache_clear()
 
 
 def test_rendered_pydantic_v2_field_reuses_field_string(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -192,6 +192,69 @@ def test_pydantic_v2_extra_type_hint_keeps_non_dict_hint() -> None:
     assert field.pydantic_extra_type_hint == "str"
 
 
+@pytest.mark.parametrize(
+    ("data_type", "expected"),
+    [
+        (
+            DataType(type="int", is_dict=True, use_standard_collections=True),
+            "Dict[str, int]",
+        ),
+        (
+            DataType(
+                type="int",
+                is_dict=True,
+                dict_key=DataType(type="int"),
+                use_standard_collections=True,
+            ),
+            "Dict[int, int]",
+        ),
+        (
+            DataType(
+                data_types=[DataType(type="str", is_list=True, use_standard_collections=True)],
+                is_dict=True,
+                use_standard_collections=True,
+            ),
+            "Dict[str, list[str]]",
+        ),
+        (
+            DataType(type="int", is_dict=True),
+            "Dict[str, int]",
+        ),
+        (
+            DataType(type="int", is_dict=True, use_standard_collections=True, use_generic_container=True),
+            "Mapping[str, int]",
+        ),
+        (
+            DataType(is_dict=True, use_standard_collections=True),
+            "dict",
+        ),
+        (
+            DataType(type="int", is_dict=True, is_optional=True, use_standard_collections=True),
+            "Optional[dict[str, int]]",
+        ),
+        (
+            DataType(
+                type="int",
+                is_dict=True,
+                is_optional=True,
+                use_standard_collections=True,
+                use_union_operator=True,
+            ),
+            "Dict[str, int] | None",
+        ),
+    ],
+)
+def test_pydantic_v2_extra_type_hint_uses_structured_dict(data_type: DataType, expected: str) -> None:
+    """Test typed-extra dict conversion follows the parsed type hint structure."""
+    field = PydanticV2DataModelField(
+        name="__pydantic_extra__",
+        data_type=data_type,
+        required=True,
+    )
+
+    assert field.pydantic_extra_type_hint == expected
+
+
 def test_rendered_pydantic_v2_field_reuses_field_string(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test built-in field proxy computes field and annotated values from one Field() string."""
     field = PydanticV2DataModelField(

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -265,6 +265,7 @@ def test_pydantic_v2_extra_type_hint_uses_structured_dict(data_type: DataType, e
     [
         ("dict[str, tuple[*Ts]]", "Dict[str, tuple[*Ts]]"),
         ("dict[str, Literal[']']] | None", "Dict[str, Literal[']']] | None"),
+        ("dict[str, Literal['\\'']]", "Dict[str, Literal['\\'']]"),
         ("dict[str, Literal['unterminated]", None),
         ("dict[str][int]", None),
     ],

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tokenize
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -261,18 +260,18 @@ def test_pydantic_v2_extra_type_hint_uses_structured_dict(data_type: DataType, e
     assert field.pydantic_extra_type_hint == expected
 
 
-def test_pydantic_extra_type_hint_for_builtin_dict_rejects_token_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test malformed token streams leave typed-extra annotations unchanged."""
-    monkeypatch.setattr(
-        "datamodel_code_generator.model.pydantic_v2.base_model.tokenize.generate_tokens",
-        lambda _: (_ for _ in ()).throw(tokenize.TokenError("bad", (1, 0))),
-    )
-    _pydantic_extra_type_hint_for_builtin_dict.cache_clear()
-
-    try:
-        assert _pydantic_extra_type_hint_for_builtin_dict("dict[str, int]") is None
-    finally:
-        _pydantic_extra_type_hint_for_builtin_dict.cache_clear()
+@pytest.mark.parametrize(
+    ("type_hint", "expected"),
+    [
+        ("dict[str, tuple[*Ts]]", "Dict[str, tuple[*Ts]]"),
+        ("dict[str, Literal[']']] | None", "Dict[str, Literal[']']] | None"),
+        ("dict[str, Literal['unterminated]", None),
+        ("dict[str][int]", None),
+    ],
+)
+def test_pydantic_extra_type_hint_for_builtin_dict_scans_subscript(type_hint: str, expected: str | None) -> None:
+    """Test typed-extra dict conversion does not depend on runtime AST grammar."""
+    assert _pydantic_extra_type_hint_for_builtin_dict(type_hint) == expected
 
 
 def test_rendered_pydantic_v2_field_reuses_field_string(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typed-extra `dict[...]` handling in Pydantic v2 by rewriting valid typed `dict[...]` annotations into the project’s `DICT[...]` form.
  * More reliably detects the correct `dict[...]` segment (including nested brackets) and preserves trailing annotation content, including `|` union continuations.

* **Tests**
  * Added coverage for typed-extra dict type-hint generation across structured dict/mapping/list/tuple value scenarios, including optional and union renderings.
  * Added tests to ensure malformed/unparseable `dict[...]` annotations are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->