### PR TITLE
Use structured None union removal

### DIFF
--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -392,68 +392,83 @@ def _is_python_type_annotation_node(node: ast.AST, *, allow_literal: bool) -> bo
     return result
 
 
-def _remove_none_from_union(type_: str, *, use_union_operator: bool) -> str:  # noqa: PLR0912
-    """Remove None from a Union type string, handling nested unions."""
-    if use_union_operator:
-        if " | " not in type_:
-            return type_
-        separator = "|"
-        inner_text = type_
-    else:
-        if not type_.startswith(UNION_PREFIX):
-            return type_
-        separator = ","
-        inner_text = type_[len(UNION_PREFIX) : -1]
+def _get_annotation_source_segment(source: str, node: ast.AST) -> str:
+    return ast.get_source_segment(source, node) or ast.unparse(node)
 
-    parts = []
-    inner_count = 0
-    current_part = ""
 
-    # With this variable we count any non-escaped round bracket, whenever we are inside a
-    # constraint string expression. Once found a part starting with `constr(`, we increment
-    # this counter for each non-escaped opening round bracket and decrement it for each
-    # non-escaped closing round bracket.
-    in_constr = 0
+def _get_union_subscript_parts(type_: str, expression: ast.AST) -> list[str] | None:
+    match expression:
+        case ast.Subscript(value=ast.Name(id=name), slice=slice_node) if name == UNION:
+            if isinstance(slice_node, ast.Tuple):
+                return [_get_annotation_source_segment(type_, elt) for elt in slice_node.elts]
+            return [_get_annotation_source_segment(type_, slice_node)]
+        case _:
+            return None
 
-    # Parse union parts carefully to handle nested structures
-    for char in inner_text:
-        current_part += char
-        if char == "[" and in_constr == 0:
-            inner_count += 1
-        elif char == "]" and in_constr == 0:
-            inner_count -= 1
-        elif char == "(":
-            if current_part.strip().startswith("constr(") and (len(current_part) < 2 or current_part[-2] != "\\"):  # noqa: PLR2004
-                in_constr += 1
-        elif char == ")":
-            if in_constr > 0 and (len(current_part) < 2 or current_part[-2] != "\\"):  # noqa: PLR2004
-                in_constr -= 1
-        elif char == separator and inner_count == 0 and in_constr == 0:
-            part = current_part[:-1].strip()
-            if part != NONE:
-                # Process nested unions recursively
-                # only UNION_PREFIX might be nested but not union_operator
-                if not use_union_operator and part.startswith(UNION_PREFIX):
-                    part = _remove_none_from_union(part, use_union_operator=False)
-                parts.append(part)
-            current_part = ""
 
-    part = current_part.strip()
-    if current_part and part != NONE:
-        # only UNION_PREFIX might be nested but not union_operator
-        if not use_union_operator and part.startswith(UNION_PREFIX):  # pragma: no cover
-            part = _remove_none_from_union(part, use_union_operator=False)
-        parts.append(part)
+def _get_union_operator_parts(type_: str, expression: ast.AST) -> list[str] | None:
+    match expression:
+        case ast.BinOp(left=left, op=ast.BitOr(), right=right):
+            parts: list[str] = []
+            for node in (left, right):
+                if nested_parts := _get_union_operator_parts(type_, node):
+                    parts.extend(nested_parts)
+                else:
+                    parts.append(_get_annotation_source_segment(type_, node))
+            return parts
+        case _:
+            return None
 
+
+def _remove_none_from_union_parts(parts: list[str], *, use_union_operator: bool) -> list[str]:
+    filtered_parts: list[str] = []
+    for part in parts:
+        if part == NONE:
+            continue
+        filtered_part = part
+        if not use_union_operator:
+            try:
+                expression = ast.parse(part, mode="eval").body
+            except SyntaxError:  # pragma: no cover
+                filtered_parts.append(part)
+                continue
+            if _get_union_subscript_parts(part, expression) is not None:
+                filtered_part = _remove_none_from_union(part, use_union_operator=False)
+        filtered_parts.append(filtered_part)
+    return filtered_parts
+
+
+def _join_union_parts(parts: list[str], *, use_union_operator: bool) -> str:
     if not parts:
         return NONE
     if len(parts) == 1:
         return parts[0]
-
     if use_union_operator:
         return UNION_OPERATOR_DELIMITER.join(parts)
-
     return f"{UNION_PREFIX}{UNION_DELIMITER.join(parts)}]"
+
+
+@lru_cache(maxsize=4096)
+def _remove_none_from_union(type_: str, *, use_union_operator: bool) -> str:
+    """Remove None from a Union type string, handling nested unions."""
+    if use_union_operator and UNION_OPERATOR_DELIMITER not in type_:
+        return type_
+    try:
+        expression = ast.parse(type_, mode="eval").body
+    except SyntaxError:
+        return type_
+
+    if use_union_operator:
+        parts = _get_union_operator_parts(type_, expression)
+    else:
+        parts = _get_union_subscript_parts(type_, expression)
+    if parts is None:
+        return type_
+
+    return _join_union_parts(
+        _remove_none_from_union_parts(parts, use_union_operator=use_union_operator),
+        use_union_operator=use_union_operator,
+    )
 
 
 @lru_cache(maxsize=4096)

--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -88,6 +88,11 @@ STANDARD_SET = "set"
 STANDARD_TUPLE = "tuple"
 STANDARD_FROZEN_SET = "frozenset"
 STR = "str"
+TYPE_PART_BRACKET_CHARS = "[]"
+TYPE_PART_COMPLEX_CHARS = "(){}'\""
+TYPE_PART_OPEN_CHARS = "[({"
+TYPE_PART_CLOSE_CHARS = "])}"
+TYPE_PART_QUOTE_CHARS = "'\""
 
 NOT_REQUIRED = "NotRequired"
 NOT_REQUIRED_PREFIX = f"{NOT_REQUIRED}["
@@ -392,32 +397,94 @@ def _is_python_type_annotation_node(node: ast.AST, *, allow_literal: bool) -> bo
     return result
 
 
-def _get_annotation_source_segment(source: str, node: ast.AST) -> str:
-    return ast.get_source_segment(source, node) or ast.unparse(node)
+def _split_bracketed_type_parts(type_: str, delimiter: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    for index, char in enumerate(type_):
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth = max(depth - 1, 0)
+        elif char == delimiter and depth == 0:
+            parts.append(type_[start:index].strip())
+            start = index + 1
+    parts.append(type_[start:].strip())
+    return parts
 
 
-def _get_union_subscript_parts(type_: str, expression: ast.AST) -> list[str] | None:
-    match expression:
-        case ast.Subscript(value=ast.Name(id=name), slice=slice_node) if name == UNION:
-            if isinstance(slice_node, ast.Tuple):
-                return [_get_annotation_source_segment(type_, elt) for elt in slice_node.elts]
-            return [_get_annotation_source_segment(type_, slice_node)]
-        case _:
-            return None
+def _is_escaped_position(type_: str, index: int) -> bool:
+    backslash_count = 0
+    while index - backslash_count > 0 and type_[index - backslash_count - 1] == "\\":
+        backslash_count += 1
+    return backslash_count % 2 == 1
 
 
-def _get_union_operator_parts(type_: str, expression: ast.AST) -> list[str] | None:
-    match expression:
-        case ast.BinOp(left=left, op=ast.BitOr(), right=right):
-            parts: list[str] = []
-            for node in (left, right):
-                if nested_parts := _get_union_operator_parts(type_, node):
-                    parts.extend(nested_parts)
-                else:
-                    parts.append(_get_annotation_source_segment(type_, node))
-            return parts
-        case _:
-            return None
+def _skip_string_literal(type_: str, index: int, quote: str) -> int:
+    quote_size = 3 if type_[index : index + 3] == quote * 3 else 1
+    quote_token = quote * quote_size
+    index += quote_size
+    while (next_index := type_.find(quote_token, index)) != -1:
+        if not _is_escaped_position(type_, next_index):
+            return next_index + quote_size
+        index = next_index + quote_size
+    return len(type_)
+
+
+def _split_complex_type_parts(type_: str, delimiter: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    index = 0
+    while index < len(type_):
+        char = type_[index]
+        if char in TYPE_PART_QUOTE_CHARS:
+            index = _skip_string_literal(type_, index, char)
+            continue
+        if char in TYPE_PART_OPEN_CHARS:
+            depth += 1
+        elif char in TYPE_PART_CLOSE_CHARS:
+            depth = max(depth - 1, 0)
+        elif char == delimiter and depth == 0:
+            parts.append(type_[start:index].strip())
+            start = index + 1
+        index += 1
+    parts.append(type_[start:].strip())
+    return parts
+
+
+def _get_union_subscript_parts(type_: str) -> list[str] | None:
+    if not type_.startswith(UNION_PREFIX) or not type_.endswith("]"):
+        return None
+    inner_type = type_[len(UNION_PREFIX) : -1]
+    if "," not in inner_type:
+        return [inner_type.strip()]
+    has_bracket = False
+    for char in inner_type:
+        if char in TYPE_PART_COMPLEX_CHARS:
+            return _split_complex_type_parts(inner_type, ",")
+        if char in TYPE_PART_BRACKET_CHARS:
+            has_bracket = True
+    if has_bracket:
+        return _split_bracketed_type_parts(inner_type, ",")
+    return [part.strip() for part in inner_type.split(",")]
+
+
+def _get_union_operator_parts(type_: str) -> list[str] | None:
+    if UNION_OPERATOR_DELIMITER not in type_:
+        return None
+    has_bracket = False
+    for char in type_:
+        if char in TYPE_PART_COMPLEX_CHARS:
+            parts = _split_complex_type_parts(type_, "|")
+            break
+        if char in TYPE_PART_BRACKET_CHARS:
+            has_bracket = True
+    else:
+        parts = _split_bracketed_type_parts(type_, "|") if has_bracket else [part.strip() for part in type_.split("|")]
+    if len(parts) == 1:
+        return None
+    return parts
 
 
 def _remove_none_from_union_parts(parts: list[str], *, use_union_operator: bool) -> list[str]:
@@ -426,14 +493,13 @@ def _remove_none_from_union_parts(parts: list[str], *, use_union_operator: bool)
         if part == NONE:
             continue
         filtered_part = part
-        if not use_union_operator:
-            try:
-                expression = ast.parse(part, mode="eval").body
-            except SyntaxError:  # pragma: no cover
-                filtered_parts.append(part)
-                continue
-            if _get_union_subscript_parts(part, expression) is not None:
-                filtered_part = _remove_none_from_union(part, use_union_operator=False)
+        if (
+            not use_union_operator
+            and NONE in part
+            and part.startswith(UNION_PREFIX)
+            and _get_union_subscript_parts(part)
+        ):
+            filtered_part = _remove_none_from_union(part, use_union_operator=False)
         filtered_parts.append(filtered_part)
     return filtered_parts
 
@@ -451,17 +517,17 @@ def _join_union_parts(parts: list[str], *, use_union_operator: bool) -> str:
 @lru_cache(maxsize=4096)
 def _remove_none_from_union(type_: str, *, use_union_operator: bool) -> str:
     """Remove None from a Union type string, handling nested unions."""
-    if use_union_operator and UNION_OPERATOR_DELIMITER not in type_:
-        return type_
-    try:
-        expression = ast.parse(type_, mode="eval").body
-    except SyntaxError:
-        return type_
+    match use_union_operator:
+        case True if NONE not in type_:
+            return type_
+        case True if UNION_OPERATOR_DELIMITER not in type_:
+            return type_
+        case False if NONE not in type_ and not type_.startswith(UNION_PREFIX):
+            return type_
+        case False if not type_.startswith(UNION_PREFIX):
+            return type_
 
-    if use_union_operator:
-        parts = _get_union_operator_parts(type_, expression)
-    else:
-        parts = _get_union_subscript_parts(type_, expression)
+    parts = _get_union_operator_parts(type_) if use_union_operator else _get_union_subscript_parts(type_)
     if parts is None:
         return type_
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -135,6 +135,16 @@ def test_chain_as_tuple_chains_multiple_iterables() -> None:
             False,
             "Union[constr(regex=r'\\['), str, int]",
         ),
+        (
+            "Union[Literal['a,b'], None]",
+            False,
+            "Literal['a,b']",
+        ),
+        (
+            "Union[Annotated[str, Field(description='a, b')], None]",
+            False,
+            "Annotated[str, Field(description='a, b')]",
+        ),
         # Complex nested types - union operator syntax
         ("List[str | None] | None", True, "List[str | None]"),
         (
@@ -161,6 +171,7 @@ def test_chain_as_tuple_chains_multiple_iterables() -> None:
         # Non-union types (should be returned as-is)
         ("str", False, "str"),
         ("List[str]", False, "List[str]"),
+        ("str|None", True, "str|None"),
     ],
 )
 def test_remove_none_from_union(type_str: str, use_union_operator: bool, expected: str) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,8 +13,14 @@ from datamodel_code_generator.reference import Reference
 from datamodel_code_generator.types import (
     DataType,
     _contains_decimal,
+    _get_union_operator_parts,
+    _get_union_subscript_parts,
+    _is_escaped_position,
     _remove_none_from_union,
+    _remove_none_from_union_parts,
     _skip_string_literal,
+    _split_bracketed_type_parts,
+    _split_complex_type_parts,
     chain_as_tuple,
     extract_qualified_names,
     get_optional_type,
@@ -193,6 +199,54 @@ def test_skip_string_literal_without_closing_quote_returns_end() -> None:
     type_str = '"unterminated'
 
     assert _skip_string_literal(type_str, 0, '"') == len(type_str)
+
+
+def test_type_part_helpers_parse_structured_segments() -> None:
+    """Test top-level type part helpers keep nested syntax intact."""
+    assert _split_bracketed_type_parts("List[str, int], None", ",") == ["List[str, int]", "None"]
+    assert _split_complex_type_parts("Callable[[int], str], None", ",") == ["Callable[[int], str]", "None"]
+    assert _split_complex_type_parts("Literal['a,b'], None", ",") == ["Literal['a,b']", "None"]
+    assert _skip_string_literal('"value"', 0, '"') == len('"value"')
+    assert _is_escaped_position(r'"a\""', 3)
+    assert not _is_escaped_position('"a"', 2)
+
+
+@pytest.mark.parametrize(
+    ("type_str", "expected"),
+    [
+        ("List[None]", None),
+        ("Union[str]", ["str"]),
+        ("Union[str, int, None]", ["str", "int", "None"]),
+        ("Union[Union[str, None], int]", ["Union[str, None]", "int"]),
+        ("Union[Literal['a,b'], None]", ["Literal['a,b']", "None"]),
+        ("Union[str, None", None),
+    ],
+)
+def test_get_union_subscript_parts(type_str: str, expected: list[str] | None) -> None:
+    """Test Union[...] part parsing."""
+    assert _get_union_subscript_parts(type_str) == expected
+
+
+@pytest.mark.parametrize(
+    ("type_str", "expected"),
+    [
+        ("str|None", None),
+        ('Literal[" | None"]', None),
+        ("str | int | None", ["str", "int", "None"]),
+        ("List[str | None] | None", ["List[str | None]", "None"]),
+        ("constr(pattern='0 | 1') | None", ["constr(pattern='0 | 1')", "None"]),
+    ],
+)
+def test_get_union_operator_parts(type_str: str, expected: list[str] | None) -> None:
+    """Test PEP 604 union part parsing."""
+    assert _get_union_operator_parts(type_str) == expected
+
+
+def test_remove_none_from_union_parts() -> None:
+    """Test structured filtering of already parsed union parts."""
+    assert _remove_none_from_union_parts(["None"], use_union_operator=False) == []
+    assert _remove_none_from_union_parts(["Union[str, None]", "int"], use_union_operator=False) == ["str", "int"]
+    assert _remove_none_from_union_parts(["str | None"], use_union_operator=True) == ["str | None"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -14,6 +14,7 @@ from datamodel_code_generator.types import (
     DataType,
     _contains_decimal,
     _remove_none_from_union,
+    _skip_string_literal,
     chain_as_tuple,
     extract_qualified_names,
     get_optional_type,
@@ -141,6 +142,11 @@ def test_chain_as_tuple_chains_multiple_iterables() -> None:
             "Literal['a,b']",
         ),
         (
+            'Union[Literal["a\\",b"], None]',
+            False,
+            'Literal["a\\",b"]',
+        ),
+        (
             "Union[Annotated[str, Field(description='a, b')], None]",
             False,
             "Annotated[str, Field(description='a, b')]",
@@ -171,12 +177,22 @@ def test_chain_as_tuple_chains_multiple_iterables() -> None:
         # Non-union types (should be returned as-is)
         ("str", False, "str"),
         ("List[str]", False, "List[str]"),
+        ("List[None]", False, "List[None]"),
+        ("Union[str, None", False, "Union[str, None"),
         ("str|None", True, "str|None"),
+        ('Literal[" | None"]', True, 'Literal[" | None"]'),
     ],
 )
 def test_remove_none_from_union(type_str: str, use_union_operator: bool, expected: str) -> None:
     """Test _remove_none_from_union function with various type strings."""
     assert _remove_none_from_union(type_str, use_union_operator=use_union_operator) == expected
+
+
+def test_skip_string_literal_without_closing_quote_returns_end() -> None:
+    """Test string literal scanning stops safely for invalid input."""
+    type_str = '"unterminated'
+
+    assert _skip_string_literal(type_str, 0, '"') == len(type_str)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved union type parsing to more reliably remove `None` from complex type expressions, including cases with literals and annotated types.

* **Tests**
  * Expanded automated coverage for `None` removal across additional edge cases (including escaped characters, operator vs subscript union forms, and unterminated strings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->