### PR TITLE
Use structured type rendering

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -418,13 +418,17 @@ class DataModelFieldBase(_BaseModel):
         return self.data_type.use_union_operator
 
     @property
-    def type_hint(self) -> str:  # noqa: PLR0911
+    def type_hint(self) -> str:
         """Get the type hint string for this field, including nullability."""
-        type_hint = self.data_type.type_hint
+        return self._type_hint_from_data_type(self.data_type)
+
+    def _type_hint_from_data_type(self, data_type: DataType) -> str:  # noqa: PLR0911
+        """Get the type hint string for a field data type, including nullability."""
+        type_hint = data_type.type_hint
 
         if not type_hint:
             return NONE
-        if self.has_default_factory or (self.data_type.is_optional and self.data_type.type != ANY):
+        if self.has_default_factory or (data_type.is_optional and data_type.type != ANY):
             return type_hint
         if self.nullable is not None:
             if self.nullable:
@@ -470,20 +474,26 @@ class DataModelFieldBase(_BaseModel):
         """Get all imports required for this field's type hint."""
         return self._collect_field_imports(needs_annotated=self.use_annotated and self.needs_annotated_import)
 
-    def _collect_field_imports(self, *, needs_annotated: bool) -> tuple[Import, ...]:
+    def _collect_field_imports(
+        self,
+        *,
+        needs_annotated: bool,
+        data_type: DataType | None = None,
+    ) -> tuple[Import, ...]:
         """Collect type-hint imports; needs_annotated is passed in so subclasses can precompute it."""
-        if self._can_collect_imports_without_type_hint(needs_annotated=needs_annotated):
-            needs_optional = self._needs_optional_import_without_type_hint()
-            if self._can_skip_data_type_imports():
+        data_type = data_type or self.data_type
+        if self._can_collect_imports_without_type_hint(needs_annotated=needs_annotated, data_type=data_type):
+            needs_optional = self._needs_optional_import_without_type_hint(data_type=data_type)
+            if self._can_skip_data_type_imports(data_type=data_type):
                 return (IMPORT_OPTIONAL,) if needs_optional else ()
 
-            imports = tuple(self.data_type.all_imports)
+            imports = tuple(data_type.all_imports)
             if needs_optional and IMPORT_OPTIONAL not in imports:
                 return chain_as_tuple(imports, (IMPORT_OPTIONAL,))
             return imports
 
-        requirements = self._typing_import_requirements(needs_annotated=needs_annotated)
-        imports = tuple(self.data_type.all_imports)
+        requirements = self._typing_import_requirements(needs_annotated=needs_annotated, data_type=data_type)
+        imports = tuple(data_type.all_imports)
         if requirements.any_ and IMPORT_ANY not in imports:
             imports = chain_as_tuple(requirements.leading_imports, imports)
 
@@ -493,14 +503,19 @@ class DataModelFieldBase(_BaseModel):
             return filtered_imports
         return chain_as_tuple(filtered_imports, missing_imports)
 
-    def _can_collect_imports_without_type_hint(self, *, needs_annotated: bool) -> bool:
+    def _can_collect_imports_without_type_hint(
+        self,
+        *,
+        needs_annotated: bool,
+        data_type: DataType | None = None,
+    ) -> bool:
         """Return whether imports can be collected without rendering the type hint."""
         if needs_annotated:
             return False
         if self.parent and self.parent.has_forward_reference:
             return False
 
-        data_type = self.data_type
+        data_type = data_type or self.data_type
         if data_type.use_serialize_as_any:
             return False
 
@@ -522,11 +537,17 @@ class DataModelFieldBase(_BaseModel):
                 return bool(names)
         return False
 
-    def _typing_import_requirements(self, *, needs_annotated: bool) -> _TypingImportRequirements:
-        requirements = self._data_type_typing_import_requirements(self.data_type)
+    def _typing_import_requirements(
+        self,
+        *,
+        needs_annotated: bool,
+        data_type: DataType | None = None,
+    ) -> _TypingImportRequirements:
+        data_type = data_type or self.data_type
+        requirements = self._data_type_typing_import_requirements(data_type)
         if needs_annotated:
             requirements = requirements.with_import_name(IMPORT_ANNOTATED.import_)
-        if not requirements.optional and self._needs_field_optional_import_from_structure():
+        if not requirements.optional and self._needs_field_optional_import_from_structure(data_type=data_type):
             requirements = requirements.with_import_name(IMPORT_OPTIONAL.import_)
         return requirements
 
@@ -560,7 +581,7 @@ class DataModelFieldBase(_BaseModel):
                 continue
             branch_keys.add(self._data_type_import_key(child))
 
-        if has_none:
+        if has_none and not data_type.preserve_union_member_order:
             data_type.is_optional = True
             if not data_type.use_union_operator:
                 requirements = requirements.with_import_name(IMPORT_OPTIONAL.import_)
@@ -585,8 +606,8 @@ class DataModelFieldBase(_BaseModel):
             return False
         return data_type.is_optional and self._data_type_renders_importable_hint(data_type)
 
-    def _needs_field_optional_import_from_structure(self) -> bool:
-        data_type = self.data_type
+    def _needs_field_optional_import_from_structure(self, *, data_type: DataType | None = None) -> bool:
+        data_type = data_type or self.data_type
         if (
             self._use_union_operator
             or self.has_default_factory
@@ -671,13 +692,14 @@ class DataModelFieldBase(_BaseModel):
             data_type.use_standard_collections,
             data_type.use_generic_container,
             data_type.use_union_operator,
+            data_type.preserve_union_member_order,
             data_type.use_serialize_as_any,
             data_type.discriminator,
         )
 
-    def _can_skip_data_type_imports(self) -> bool:
+    def _can_skip_data_type_imports(self, *, data_type: DataType | None = None) -> bool:
         """Return whether the simple DataType cannot contribute imports."""
-        data_type = self.data_type
+        data_type = data_type or self.data_type
         return not (
             data_type.import_
             or data_type.kwargs
@@ -692,18 +714,18 @@ class DataModelFieldBase(_BaseModel):
             or data_type.use_generic_container
         )
 
-    def _needs_optional_import_without_type_hint(self) -> bool:
+    def _needs_optional_import_without_type_hint(self, *, data_type: DataType | None = None) -> bool:
         """Return whether the field-level nullable wrapper needs typing.Optional."""
-        data_type = self.data_type
+        data_type = data_type or self.data_type
         if (
             self._use_union_operator
-            or not self._has_renderable_data_type_without_type_hint()
+            or not self._has_renderable_data_type_without_type_hint(data_type=data_type)
             or self.has_default_factory
             or (data_type.is_optional and data_type.type != ANY)
         ):
             return False
 
-        if self._reference_source_nullable_without_type_hint():
+        if self._reference_source_nullable_without_type_hint(data_type=data_type):
             return True
 
         match self.nullable:
@@ -715,17 +737,18 @@ class DataModelFieldBase(_BaseModel):
                 return bool(self.type_has_null) if self.required else bool(self.fall_back_to_nullable)
         return False  # pragma: no cover
 
-    def _reference_source_nullable_without_type_hint(self) -> bool:
+    def _reference_source_nullable_without_type_hint(self, *, data_type: DataType | None = None) -> bool:
         """Return whether a referenced non-alias model should make this type optional."""
-        reference = self.data_type.reference
+        data_type = data_type or self.data_type
+        reference = data_type.reference
         if reference is None:
             return False
         source = reference.source
         return not getattr(source, "is_alias", False) and bool(getattr(source, "nullable", False))
 
-    def _has_renderable_data_type_without_type_hint(self) -> bool:
+    def _has_renderable_data_type_without_type_hint(self, *, data_type: DataType | None = None) -> bool:
         """Return whether this simple DataType renders to something other than None."""
-        data_type = self.data_type
+        data_type = data_type or self.data_type
         return bool(
             data_type.alias
             or data_type.type

--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -585,9 +585,10 @@ class DataModelFieldBase(_BaseModel):
             data_type.is_optional = True
             if not data_type.use_union_operator:
                 requirements = requirements.with_import_name(IMPORT_OPTIONAL.import_)
-        if not branch_keys and data_type.data_types:
+        ordered_none_branch_count = int(data_type.preserve_union_member_order and has_none)
+        if not branch_keys and data_type.data_types and not ordered_none_branch_count:
             requirements = replace(requirements, any_=True)
-        if len(branch_keys) > 1 and not data_type.use_union_operator:
+        if len(branch_keys) + ordered_none_branch_count > 1 and not data_type.use_union_operator:
             requirements = requirements.with_import_name(IMPORT_UNION.import_)
         return requirements
 

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -338,10 +338,10 @@ class DataModelField(DataModelFieldBase):
             return self._unset_union_data_type()
         return self.data_type
 
-    def _imports_data_type(self) -> DataType:
+    def _imports_data_type(self, meta: str | None = None) -> DataType:
         if not (self._not_required and not self.nullable and self.use_annotated):
             return self._type_hint_data_type()
-        if (meta := self._get_meta_string()) is None:
+        if meta is None:
             return self._type_hint_data_type()
         return self._annotated_unset_union_data_type(self._annotated_type_hint(meta))
 
@@ -440,9 +440,10 @@ class DataModelField(DataModelFieldBase):
     @property
     def imports(self) -> tuple[Import, ...]:
         """Get imports from the structurally rendered msgspec annotation."""
+        meta = self._get_meta_string() if self.use_annotated else None
         return self._collect_field_imports(
-            needs_annotated=self.use_annotated and self.needs_annotated_import,
-            data_type=self._imports_data_type(),
+            needs_annotated=meta is not None,
+            data_type=self._imports_data_type(meta),
         )
 
     @property
@@ -522,11 +523,7 @@ class DataModelField(DataModelFieldBase):
         ClassVar fields with Meta need Annotated only when use_annotated is True.
         ClassVar fields without Meta don't need Annotated.
         """
-        if not self.annotated:
-            return False
-        if self.extras.get("is_classvar"):  # pragma: no cover
-            return self.use_annotated and self._get_meta_string() is not None
-        return True
+        return self.use_annotated and self._get_meta_string() is not None
 
     @property
     def needs_meta_import(self) -> bool:

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -77,7 +77,12 @@ def import_extender(cls: type[DataModelFieldBaseT]) -> type[DataModelFieldBaseT]
             extra_imports.append(IMPORT_MSGSPEC_CONVERT)
         if isinstance(self, DataModelField) and self.needs_meta_import:
             extra_imports.append(IMPORT_MSGSPEC_META)
-        if not self.required and not self.nullable and (self.default is None or self.default is UNDEFINED):
+        if (
+            isinstance(self, DataModelField)
+            and self._not_required
+            and not self.nullable
+            and (self.default is None or self.default is UNDEFINED)
+        ):
             extra_imports.append(IMPORT_MSGSPEC_UNSET)
         imports = original_imports.fget(self)  # ty: ignore
         if (

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -5,11 +5,11 @@ Generates Python models using msgspec.Struct for high-performance serialization.
 
 from __future__ import annotations
 
-from functools import lru_cache, wraps
+from functools import wraps
 from math import isfinite
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
 
-from datamodel_code_generator.imports import IMPORT_OPTIONAL, IMPORT_UNION, Import
+from datamodel_code_generator.imports import IMPORT_OPTIONAL, Import
 from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
 from datamodel_code_generator.model.base import UNDEFINED, BaseClassDataType, _nested_model_default_factory
 from datamodel_code_generator.model.imports import (
@@ -28,17 +28,10 @@ from datamodel_code_generator.model.types import DataTypeManager as _DataTypeMan
 from datamodel_code_generator.python_literal import represent_python_value
 from datamodel_code_generator.types import (
     NONE,
-    OPTIONAL_PREFIX,
-    UNION_DELIMITER,
-    UNION_OPERATOR_DELIMITER,
-    UNION_PREFIX,
-    _remove_none_from_union,
     chain_as_tuple,
     merge_normalized_constraint,
     normalize_integer_constraint,
 )
-
-UNSET_TYPE = "UnsetType"
 
 
 class _UNSET:
@@ -56,6 +49,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from datamodel_code_generator.reference import Reference
+    from datamodel_code_generator.types import DataType
 
 
 def has_field_assignment(field: DataModelFieldBase) -> bool:
@@ -83,12 +77,8 @@ def import_extender(cls: type[DataModelFieldBaseT]) -> type[DataModelFieldBaseT]
             extra_imports.append(IMPORT_MSGSPEC_CONVERT)
         if isinstance(self, DataModelField) and self.needs_meta_import:
             extra_imports.append(IMPORT_MSGSPEC_META)
-        if not self.required and not self.nullable:
-            extra_imports.append(IMPORT_MSGSPEC_UNSETTYPE)
-            if not self.data_type.use_union_operator:
-                extra_imports.append(IMPORT_UNION)
-            if self.default is None or self.default is UNDEFINED:
-                extra_imports.append(IMPORT_MSGSPEC_UNSET)
+        if not self.required and not self.nullable and (self.default is None or self.default is UNDEFINED):
+            extra_imports.append(IMPORT_MSGSPEC_UNSET)
         imports = original_imports.fget(self)  # ty: ignore
         if (
             isinstance(self, DataModelField)
@@ -212,35 +202,6 @@ class Constraints(_Constraints):
     """Constraint model for msgspec fields."""
 
 
-@lru_cache
-def get_neither_required_nor_nullable_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT001
-    """Get type hint for fields that are neither required nor nullable, using UnsetType."""
-    type_ = _remove_none_from_union(type_, use_union_operator=use_union_operator)
-    if type_.startswith(OPTIONAL_PREFIX):  # pragma: no cover
-        type_ = type_[len(OPTIONAL_PREFIX) : -1]
-
-    if not type_ or type_ == NONE:
-        return UNSET_TYPE
-    if use_union_operator:
-        return UNION_OPERATOR_DELIMITER.join((type_, UNSET_TYPE))
-    if type_.startswith(UNION_PREFIX):
-        return f"{type_[:-1]}{UNION_DELIMITER}{UNSET_TYPE}]"
-    return f"{UNION_PREFIX}{type_}{UNION_DELIMITER}{UNSET_TYPE}]"
-
-
-@lru_cache
-def _add_unset_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT001
-    """Add UnsetType to a type hint without removing None."""
-    if use_union_operator:
-        return f"{type_}{UNION_OPERATOR_DELIMITER}{UNSET_TYPE}"
-    if type_.startswith(UNION_PREFIX):  # pragma: no cover
-        return f"{type_[:-1]}{UNION_DELIMITER}{UNSET_TYPE}]"
-    if type_.startswith(OPTIONAL_PREFIX):  # pragma: no cover
-        inner_type = type_[len(OPTIONAL_PREFIX) : -1]
-        return f"{UNION_PREFIX}{inner_type}{UNION_DELIMITER}{NONE}{UNION_DELIMITER}{UNSET_TYPE}]"
-    return f"{UNION_PREFIX}{type_}{UNION_DELIMITER}{UNSET_TYPE}]"  # pragma: no cover
-
-
 @import_extender
 class DataModelField(DataModelFieldBase):
     """Field implementation for msgspec Struct models."""
@@ -278,6 +239,111 @@ class DataModelField(DataModelFieldBase):
         const = self.extras["const"]
         if self.data_type.type == "str" and isinstance(const, str):  # pragma: no cover
             self.replace_data_type(self.data_type.__class__(literals=[const]), clear_old_parent=False)
+
+    def _unset_type_data_type(self) -> DataType:
+        return self.data_type.__class__.from_import(IMPORT_MSGSPEC_UNSETTYPE)
+
+    def _ordered_union_data_type(self, data_types: list[DataType]) -> DataType:
+        if len(data_types) == 1:
+            return data_types[0]
+        return self.data_type.__class__(
+            data_types=data_types,
+            use_union_operator=self.data_type.use_union_operator,
+            preserve_union_member_order=True,
+        )
+
+    def _data_type_has_top_level_none(self, data_type: DataType) -> bool:
+        if data_type.is_optional or self._data_type_renders_none(data_type):
+            return True
+        if not data_type.is_union:
+            return False
+        return any(self._data_type_renders_none(child) for child in data_type.data_types)
+
+    @staticmethod
+    def _data_type_has_container(data_type: DataType) -> bool:
+        return any((
+            data_type.is_dict,
+            data_type.is_list,
+            data_type.is_set,
+            data_type.is_frozen_set,
+            data_type.is_mapping,
+            data_type.is_sequence,
+            data_type.is_tuple,
+        ))
+
+    def _data_type_is_plain_union(self, data_type: DataType) -> bool:
+        return data_type.is_union and not self._data_type_has_container(data_type)
+
+    def _copy_data_type(self, data_type: DataType) -> DataType:
+        copied = data_type.model_copy()
+        copied.parent = None
+        copied.children = []
+        copied.data_types = [self._copy_data_type(child) for child in data_type.data_types]
+        copied.literals = list(data_type.literals)
+        copied.enum_member_literals = list(data_type.enum_member_literals)
+        if data_type.dict_key:
+            copied.dict_key = self._copy_data_type(data_type.dict_key)
+        if data_type.kwargs:
+            copied.kwargs = dict(data_type.kwargs)
+        return copied
+
+    def _copy_data_type_without_top_level_none(self, data_type: DataType) -> DataType:
+        data_type = self._copy_data_type(data_type)
+        data_type.is_optional = False
+        if data_type.is_union:
+            data_type.data_types = [child for child in data_type.data_types if not self._data_type_renders_none(child)]
+        return data_type
+
+    def _unset_union_data_type(self) -> DataType:
+        unset_type = self._unset_type_data_type()
+        if self._data_type_renders_none(self.data_type):
+            return unset_type
+
+        data_types = []
+        has_none = self._data_type_has_top_level_none(self.data_type)
+        if not has_none and self._data_type_is_plain_union(self.data_type):
+            data_types.extend(self._copy_data_type(child) for child in self.data_type.data_types)
+        elif has_none:
+            base_data_type = self._copy_data_type_without_top_level_none(self.data_type)
+            if self._data_type_has_renderable_structure(base_data_type) and not self._data_type_renders_none(
+                base_data_type
+            ):
+                data_types.append(base_data_type)
+        else:
+            base_data_type = self._copy_data_type(self.data_type)
+            if self._data_type_has_renderable_structure(base_data_type) and not self._data_type_renders_none(
+                base_data_type
+            ):
+                data_types.append(base_data_type)
+        if has_none:
+            data_types.append(self.data_type.__class__(type=NONE))
+        data_types.append(unset_type)
+        return self._ordered_union_data_type(data_types)
+
+    def _annotated_type_hint(self, meta: str) -> str:
+        return f"Annotated[{self.data_type.type_hint}, {meta}]"
+
+    def _annotated_data_type(self, annotated_type: str) -> DataType:
+        return self.data_type.__class__(
+            type=annotated_type,
+            data_types=[self._copy_data_type(self.data_type)],
+            use_union_operator=self.data_type.use_union_operator,
+        )
+
+    def _annotated_unset_union_data_type(self, annotated_type: str) -> DataType:
+        return self._ordered_union_data_type([self._annotated_data_type(annotated_type), self._unset_type_data_type()])
+
+    def _type_hint_data_type(self) -> DataType:
+        if self._not_required and not self.nullable:
+            return self._unset_union_data_type()
+        return self.data_type
+
+    def _imports_data_type(self) -> DataType:
+        if not (self._not_required and not self.nullable and self.use_annotated):
+            return self._type_hint_data_type()
+        if (meta := self._get_meta_string()) is None:
+            return self._type_hint_data_type()
+        return self._annotated_unset_union_data_type(self._annotated_type_hint(meta))
 
     def _has_numeric_data_type(self, type_name: str) -> bool:
         """Return whether any field data type is the given numeric type."""
@@ -367,12 +433,17 @@ class DataModelField(DataModelFieldBase):
     @property
     def type_hint(self) -> str:
         """Return the type hint, using UnsetType for non-required non-nullable fields."""
-        type_hint = super().type_hint
         if self._not_required and not self.nullable:
-            if self.data_type.is_optional:
-                return _add_unset_type(type_hint, self.data_type.use_union_operator)
-            return get_neither_required_nor_nullable_type(type_hint, self.data_type.use_union_operator)
-        return type_hint
+            return self._unset_union_data_type().type_hint
+        return super().type_hint
+
+    @property
+    def imports(self) -> tuple[Import, ...]:
+        """Get imports from the structurally rendered msgspec annotation."""
+        return self._collect_field_imports(
+            needs_annotated=self.use_annotated and self.needs_annotated_import,
+            data_type=self._imports_data_type(),
+        )
 
     @property
     def _not_required(self) -> bool:
@@ -439,13 +510,10 @@ class DataModelField(DataModelFieldBase):
         if self.required:
             return f"Annotated[{self.type_hint}, {meta}]"
 
-        type_hint = self.data_type.type_hint
-        annotated_type = f"Annotated[{type_hint}, {meta}]"
+        annotated_type = self._annotated_type_hint(meta)
         if self.nullable:  # pragma: no cover
             return annotated_type
-        if self.data_type.is_optional:  # pragma: no cover
-            return _add_unset_type(annotated_type, self.data_type.use_union_operator)
-        return get_neither_required_nor_nullable_type(annotated_type, self.data_type.use_union_operator)
+        return self._annotated_unset_union_data_type(annotated_type).type_hint
 
     @property
     def needs_annotated_import(self) -> bool:

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -253,10 +253,10 @@ class DataModelField(_PydanticBaseDataModelField):
     @property
     def pydantic_extra_type_hint(self) -> str:
         """Return a Dict-based type hint for Pydantic 2.0 typed extras."""
-        type_hint = self.type_hint
-        if not type_hint.startswith("dict["):
-            return type_hint
-        return f"Dict[{type_hint.removeprefix('dict[')}"
+        data_type = self.data_type
+        if not (data_type.is_dict and data_type.use_standard_collections and not data_type.use_generic_container):
+            return self.type_hint
+        return self._type_hint_from_data_type(data_type.model_copy(update={"use_standard_collections": False}))
 
     def _process_data_in_str(self, data: dict[str, Any]) -> None:
         if self.const:

--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -525,6 +525,7 @@ class DataType(_BaseModel):
     use_standard_collections: bool = False
     use_generic_container: bool = False
     use_union_operator: bool = False
+    preserve_union_member_order: bool = False
     alias: Optional[str] = None  # noqa: UP045
     parent: Union[DataModelFieldBase, DataType, None] = None  # noqa: UP007
     children: list[DataType] = Field(default_factory=list)
@@ -831,6 +832,12 @@ class DataType(_BaseModel):
         use_base_type_hint: bool,
         wrap_discriminator: bool,
     ) -> str:
+        if self.preserve_union_member_order:
+            return self._render_ordered_union_type_hint(
+                use_base_type_hint=use_base_type_hint,
+                wrap_discriminator=wrap_discriminator,
+            )
+
         data_types: list[str] = []
         for data_type in self.data_types:
             data_type_type = data_type.base_type_hint if use_base_type_hint else data_type.type_hint
@@ -859,6 +866,34 @@ class DataType(_BaseModel):
             type_ = UNION_OPERATOR_DELIMITER.join(data_types)
         else:
             type_ = f"{UNION_PREFIX}{UNION_DELIMITER.join(data_types)}]"
+
+        if wrap_discriminator and self.discriminator:
+            type_ = f"Annotated[{type_}, Field(discriminator={self.discriminator!r})]"
+        return type_
+
+    def _render_ordered_union_type_hint(
+        self,
+        *,
+        use_base_type_hint: bool,
+        wrap_discriminator: bool,
+    ) -> str:
+        data_types: list[str] = []
+        for data_type in self.data_types:
+            data_type_type = data_type.base_type_hint if use_base_type_hint else data_type.type_hint
+            if not data_type_type or data_type_type in data_types:
+                continue
+            data_types.append(data_type_type)
+
+        match len(data_types):
+            case 0:
+                type_ = ANY
+                self.import_ = self.import_ or IMPORT_ANY
+            case 1:
+                type_ = data_types[0]
+            case _ if self.use_union_operator:
+                type_ = UNION_OPERATOR_DELIMITER.join(data_types)
+            case _:
+                type_ = f"{UNION_PREFIX}{UNION_DELIMITER.join(data_types)}]"
 
         if wrap_discriminator and self.discriminator:
             type_ = f"Annotated[{type_}, Field(discriminator={self.discriminator!r})]"

--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -878,10 +878,12 @@ class DataType(_BaseModel):
         wrap_discriminator: bool,
     ) -> str:
         data_types: list[str] = []
+        seen_data_types: set[str] = set()
         for data_type in self.data_types:
             data_type_type = data_type.base_type_hint if use_base_type_hint else data_type.type_hint
-            if not data_type_type or data_type_type in data_types:
+            if not data_type_type or data_type_type in seen_data_types:
                 continue
+            seen_data_types.add(data_type_type)
             data_types.append(data_type_type)
 
         match len(data_types):

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -320,7 +320,16 @@ def test_msgspec_unset_type_hint_handles_empty_and_simple_types() -> None:
     assert _msgspec_field(DataType()).type_hint == "UnsetType"
     assert _msgspec_field(DataType(type="str")).type_hint == "Union[str, UnsetType]"
     assert _msgspec_field(DataType(type="str", is_optional=True)).type_hint == "Union[str, None, UnsetType]"
-    assert _msgspec_field(DataType(is_optional=True)).type_hint == "Union[None, UnsetType]"
+    none_field = _msgspec_field(DataType(is_optional=True))
+    assert none_field.type_hint == "Union[None, UnsetType]"
+    assert none_field.imports == (IMPORT_MSGSPEC_UNSETTYPE, IMPORT_UNION, IMPORT_MSGSPEC_UNSET)
+
+
+def test_msgspec_unset_import_is_limited_to_struct_fields() -> None:
+    """Test msgspec UNSET value imports match Struct-only field emission."""
+    field = MsgspecDataModelField(name="value", data_type=DataType(type="str"), required=False)
+
+    assert IMPORT_MSGSPEC_UNSET not in field.imports
 
 
 def test_msgspec_data_type_copy_preserves_structural_children() -> None:

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -32,6 +32,9 @@ from datamodel_code_generator.model.base import (
     inline_comment_safe,
     sanitize_module_name,
 )
+from datamodel_code_generator.model.imports import IMPORT_MSGSPEC_META, IMPORT_MSGSPEC_UNSET, IMPORT_MSGSPEC_UNSETTYPE
+from datamodel_code_generator.model.msgspec import DataModelField as MsgspecDataModelField
+from datamodel_code_generator.model.msgspec import Struct as MsgspecStruct
 from datamodel_code_generator.model.pydantic_base import DataModelField as PydanticBaseDataModelField
 from datamodel_code_generator.model.pydantic_v2 import BaseModel
 from datamodel_code_generator.model.pydantic_v2 import DataModelField as PydanticV2DataModelField
@@ -192,6 +195,23 @@ def test_pydantic_v2_extra_type_hint_keeps_non_dict_hint() -> None:
     assert field.pydantic_extra_type_hint == "str"
 
 
+def test_pydantic_v2_extra_type_hint_uses_structured_root_dict() -> None:
+    """Test typed-extra type hint renders only the root dict as typing.Dict."""
+    item_type = DataType(type="str", is_list=True, use_standard_collections=True)
+    data_type = DataType(data_types=[item_type], is_dict=True, use_standard_collections=True)
+    field = PydanticV2DataModelField(
+        name="__pydantic_extra__",
+        data_type=data_type,
+        required=True,
+    )
+
+    assert field.type_hint == "dict[str, list[str]]"
+    assert field.pydantic_extra_type_hint == "Dict[str, list[str]]"
+    assert data_type.use_standard_collections is True
+    assert item_type.use_standard_collections is True
+    assert IMPORT_DICT in field.imports
+
+
 def test_rendered_pydantic_v2_field_reuses_field_string(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test built-in field proxy computes field and annotated values from one Field() string."""
     field = PydanticV2DataModelField(
@@ -277,6 +297,87 @@ def test_pydantic_v2_nested_discriminator_still_imports_field() -> None:
     )
 
     assert IMPORT_FIELD in field.imports
+
+
+def _msgspec_field(data_type: DataType, **kwargs: Any) -> MsgspecDataModelField:
+    field = MsgspecDataModelField(name="value", data_type=data_type, required=False, **kwargs)
+    MsgspecStruct(fields=[field], reference=Reference(path="Model", original_name="Model", name="Model"))
+    return field
+
+
+def test_msgspec_unset_type_hint_uses_structured_ordered_union() -> None:
+    """Test msgspec UnsetType is added through an ordered DataType union."""
+    data_type = DataType(data_types=[DataType(type="str"), DataType(type=NONE)])
+    field = _msgspec_field(data_type)
+
+    assert field.type_hint == "Union[str, None, UnsetType]"
+    assert data_type.preserve_union_member_order is False
+    assert field.imports == (IMPORT_MSGSPEC_UNSETTYPE, IMPORT_UNION, IMPORT_MSGSPEC_UNSET)
+
+
+def test_msgspec_unset_type_hint_handles_empty_and_simple_types() -> None:
+    """Test msgspec UnsetType structural unions cover empty and simple field types."""
+    assert _msgspec_field(DataType()).type_hint == "UnsetType"
+    assert _msgspec_field(DataType(type="str")).type_hint == "Union[str, UnsetType]"
+    assert _msgspec_field(DataType(type="str", is_optional=True)).type_hint == "Union[str, None, UnsetType]"
+    assert _msgspec_field(DataType(is_optional=True)).type_hint == "Union[None, UnsetType]"
+
+
+def test_msgspec_data_type_copy_preserves_structural_children() -> None:
+    """Test msgspec annotation copies preserve dict keys and kwargs without parent links."""
+    field = _msgspec_field(DataType(type="str"))
+    data_type = DataType(
+        type="Value",
+        is_dict=True,
+        dict_key=DataType(type="Key"),
+        kwargs={"strict": True},
+    )
+
+    copied = field._copy_data_type(data_type)
+
+    assert copied is not data_type
+    assert copied.parent is None
+    assert copied.children == []
+    assert copied.dict_key is not data_type.dict_key
+    assert copied.dict_key.type == "Key"
+    assert copied.kwargs == {"strict": True}
+
+
+def test_msgspec_annotated_unset_keeps_optional_inside_annotated() -> None:
+    """Test msgspec Annotated fields keep Optional inside the Annotated branch."""
+    field = _msgspec_field(
+        DataType(type="str", is_optional=True),
+        extras={"max_length": 5},
+        use_annotated=True,
+    )
+
+    assert field.annotated == "Union[Annotated[Optional[str], Meta(max_length=5)], UnsetType]"
+    assert field.imports == (
+        IMPORT_OPTIONAL,
+        IMPORT_MSGSPEC_UNSETTYPE,
+        IMPORT_UNION,
+        IMPORT_ANNOTATED,
+        IMPORT_MSGSPEC_META,
+        IMPORT_MSGSPEC_UNSET,
+    )
+
+
+def test_ordered_union_type_hint_handles_empty_and_discriminator() -> None:
+    """Test ordered union rendering keeps explicit order without Optional normalization."""
+    empty_union = DataType(data_types=[DataType(), DataType()], preserve_union_member_order=True)
+    deduplicated_union = DataType(
+        data_types=[DataType(type="str"), DataType(type="str")],
+        preserve_union_member_order=True,
+    )
+    discriminated_union = DataType(
+        data_types=[DataType(type="str"), DataType(type="int")],
+        discriminator="kind",
+        preserve_union_member_order=True,
+    )
+
+    assert empty_union.type_hint == ANY
+    assert deduplicated_union.type_hint == "str"
+    assert discriminated_union.type_hint == "Annotated[Union[str, int], Field(discriminator='kind')]"
 
 
 def test_data_model_exception() -> None:

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -361,6 +361,7 @@ def test_msgspec_annotated_unset_keeps_optional_inside_annotated() -> None:
     )
 
     assert field.annotated == "Union[Annotated[Optional[str], Meta(max_length=5)], UnsetType]"
+    assert field.needs_annotated_import is True
     assert field.imports == (
         IMPORT_OPTIONAL,
         IMPORT_MSGSPEC_UNSETTYPE,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for preserving explicit union member order in generated type hints, including ordered-union rendering with discriminator support.

* **Improvements**
  * Enhanced msgspec `Struct` field generation for unset and non-nullable scenarios, improving `UnsetType`/`UNSET` handling and ensuring `Optional[...]` is placed correctly inside `Annotated`.
  * Refined overall optionality and typing-import determination for more consistent union rendering.
  * Improved Pydantic v2 “extra” typing for structured root-dicts and improved standard-collection propagation.

* **Tests**
  * Expanded coverage for ordered unions, msgspec unset/annotated behavior, and Pydantic v2 extra typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->