### PR TITLE
Cache structured import requirements

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -309,6 +309,9 @@ class ConstraintsBase(_BaseModel):
 class DataModelFieldBase(_BaseModel):
     """Base class for model field representation and rendering."""
 
+    _FIELD_IMPORTS_CACHE_MAX_SIZE: ClassVar[int] = 4096
+    _field_imports_cache: ClassVar[dict[tuple[Any, ...], tuple[Import, ...]]] = {}
+
     model_config = ConfigDict(  # ty: ignore
         arbitrary_types_allowed=True,
         defer_build=True,
@@ -483,15 +486,33 @@ class DataModelFieldBase(_BaseModel):
         """Collect type-hint imports; needs_annotated is passed in so subclasses can precompute it."""
         data_type = data_type or self.data_type
         if self._can_collect_imports_without_type_hint(needs_annotated=needs_annotated, data_type=data_type):
-            needs_optional = self._needs_optional_import_without_type_hint(data_type=data_type)
-            if self._can_skip_data_type_imports(data_type=data_type):
-                return (IMPORT_OPTIONAL,) if needs_optional else ()
+            return self._collect_field_imports_without_type_hint(data_type=data_type)
 
-            imports = tuple(data_type.all_imports)
-            if needs_optional and IMPORT_OPTIONAL not in imports:
-                return chain_as_tuple(imports, (IMPORT_OPTIONAL,))
-            return imports
+        self._normalize_data_type_import_state(data_type)
+        cache_key = self._field_imports_cache_key(needs_annotated=needs_annotated, data_type=data_type)
+        if (cached_imports := self._field_imports_cache.get(cache_key)) is not None:
+            return cached_imports
+        imports = self._collect_field_imports_uncached(needs_annotated=needs_annotated, data_type=data_type)
+        self._set_cached_field_imports(cache_key, imports)
+        return imports
 
+    def _collect_field_imports_without_type_hint(self, *, data_type: DataType) -> tuple[Import, ...]:
+        needs_optional = self._needs_optional_import_without_type_hint(data_type=data_type)
+        if self._can_skip_data_type_imports(data_type=data_type):
+            return (IMPORT_OPTIONAL,) if needs_optional else ()
+
+        imports = tuple(data_type.all_imports)
+        if needs_optional and IMPORT_OPTIONAL not in imports:
+            return chain_as_tuple(imports, (IMPORT_OPTIONAL,))
+        return imports
+
+    def _collect_field_imports_uncached(
+        self,
+        *,
+        needs_annotated: bool,
+        data_type: DataType,
+    ) -> tuple[Import, ...]:
+        """Collect field imports after import-affecting DataType normalization."""
         requirements = self._typing_import_requirements(needs_annotated=needs_annotated, data_type=data_type)
         imports = tuple(data_type.all_imports)
         if requirements.any_ and IMPORT_ANY not in imports:
@@ -502,6 +523,54 @@ class DataModelFieldBase(_BaseModel):
         if not missing_imports:
             return filtered_imports
         return chain_as_tuple(filtered_imports, missing_imports)
+
+    def _normalize_data_type_import_state(self, data_type: DataType) -> None:
+        """Apply import-relevant DataType mutations before cache lookup."""
+        if data_type.reference:
+            data_type._apply_nullable_from_reference()  # noqa: SLF001
+
+        for child in data_type.data_types:
+            self._normalize_data_type_import_state(child)
+        if data_type.dict_key:
+            self._normalize_data_type_import_state(data_type.dict_key)
+
+        if not data_type.is_union or data_type.preserve_union_member_order:
+            return
+        if any(self._data_type_renders_none(child) for child in data_type.data_types):
+            data_type.is_optional = True
+
+    @staticmethod
+    def _import_key(import_: Import | None) -> tuple[str, str | None, str | None, str | None] | None:
+        if import_ is None:
+            return None
+        return (import_.import_, import_.from_, import_.alias, import_.reference_path)
+
+    @staticmethod
+    def _reference_source_import_key(reference: Reference | None) -> tuple[bool, bool] | None:
+        if reference is None:
+            return None
+        source = reference.source
+        return (bool(getattr(source, "nullable", False)), bool(getattr(source, "is_alias", False)))
+
+    def _field_imports_cache_key(self, *, needs_annotated: bool, data_type: DataType) -> tuple[Any, ...]:
+        return (
+            self.__class__,
+            needs_annotated,
+            self.nullable,
+            self.required,
+            self.type_has_null,
+            self.has_default_factory,
+            self.fall_back_to_nullable,
+            self._use_union_operator,
+            bool(self.parent and self.parent.has_forward_reference),
+            self._data_type_import_key(data_type),
+        )
+
+    def _set_cached_field_imports(self, cache_key: tuple[Any, ...], imports: tuple[Import, ...]) -> None:
+        cache = self._field_imports_cache
+        if len(cache) >= self._FIELD_IMPORTS_CACHE_MAX_SIZE:
+            del cache[next(iter(cache))]
+        cache[cache_key] = imports
 
     def _can_collect_imports_without_type_hint(
         self,
@@ -553,8 +622,6 @@ class DataModelFieldBase(_BaseModel):
 
     def _data_type_typing_import_requirements(self, data_type: DataType) -> _TypingImportRequirements:
         requirements = self._explicit_typing_import_requirements(data_type)
-        if data_type.reference:
-            data_type._apply_nullable_from_reference()  # noqa: SLF001
 
         if data_type.is_union:
             requirements = requirements.merge(self._union_typing_import_requirements(data_type))
@@ -581,10 +648,8 @@ class DataModelFieldBase(_BaseModel):
                 continue
             branch_keys.add(self._data_type_import_key(child))
 
-        if has_none and not data_type.preserve_union_member_order:
-            data_type.is_optional = True
-            if not data_type.use_union_operator:
-                requirements = requirements.with_import_name(IMPORT_OPTIONAL.import_)
+        if has_none and not data_type.preserve_union_member_order and not data_type.use_union_operator:
+            requirements = requirements.with_import_name(IMPORT_OPTIONAL.import_)
         ordered_none_branch_count = int(data_type.preserve_union_member_order and has_none)
         if not branch_keys and data_type.data_types and not ordered_none_branch_count:
             requirements = replace(requirements, any_=True)
@@ -673,14 +738,19 @@ class DataModelFieldBase(_BaseModel):
 
     def _data_type_import_key(self, data_type: DataType) -> tuple[Any, ...]:
         return (
+            data_type.__class__,
             data_type.alias,
             data_type.type,
+            self._import_key(data_type.import_),
             data_type.reference.path if data_type.reference else None,
+            self._reference_source_import_key(data_type.reference),
             tuple(self._data_type_import_key(child) for child in data_type.data_types),
             self._data_type_import_key(data_type.dict_key) if data_type.dict_key else None,
             tuple(data_type.literals),
             tuple(data_type.enum_member_literals),
             to_hashable(data_type.kwargs),
+            data_type.strict,
+            data_type.is_custom_type,
             data_type.is_optional,
             data_type.is_func,
             data_type.is_dict,

--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -5952,24 +5952,32 @@ class JsonSchemaParser(Parser["JSONSchemaParserConfig", "JsonSchemaFeatures"]):
 
         self.parse_raw_obj(model_name, models, [*path_parts, f"#/{reference_paths[0]}", *reference_paths[1:]])
 
-    def _known_schema_object_raw_keys(self) -> set[str]:
+    @staticmethod
+    @lru_cache(maxsize=16)
+    def _schema_object_raw_key_sets(
+        schema_object_type: type[JsonSchemaObject],
+    ) -> tuple[frozenset[str], frozenset[str]]:
         keys = {"definitions", "$defs"}
-        for name, field in self.SCHEMA_OBJECT_TYPE.get_fields().items():  # ty: ignore
+        for name, field in schema_object_type.get_fields().items():  # ty: ignore
             keys.add(name)
             if alias := getattr(field, "alias", None):
                 keys.add(alias)
-        return keys
-
-    def _has_schema_affecting_keywords(self, raw: dict[str, Any]) -> bool:
         metadata_keys = {
-            *self.SCHEMA_OBJECT_TYPE.__metadata_only_fields__,
+            *schema_object_type.__metadata_only_fields__,
             "extras",
-            self.SCHEMA_OBJECT_TYPE.__extra_key__,
+            schema_object_type.__extra_key__,
         }
         schema_affecting_keys = {
-            *self._known_schema_object_raw_keys(),
-            *self.SCHEMA_OBJECT_TYPE.__schema_affecting_extras__,
+            *keys,
+            *schema_object_type.__schema_affecting_extras__,
         } - metadata_keys
+        return frozenset(keys), frozenset(schema_affecting_keys)
+
+    def _known_schema_object_raw_keys(self) -> frozenset[str]:
+        return self._schema_object_raw_key_sets(self.SCHEMA_OBJECT_TYPE)[0]
+
+    def _has_schema_affecting_keywords(self, raw: dict[str, Any]) -> bool:
+        schema_affecting_keys = self._schema_object_raw_key_sets(self.SCHEMA_OBJECT_TYPE)[1]
         return any(str(key) in schema_affecting_keys for key in raw)
 
     def _is_version_definition_namespace_name(self, name: str) -> bool:  # noqa: PLR6301

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -707,6 +708,7 @@ def test_field_import_fast_path_collects_nullable_reference_import() -> None:
     field = DataModelFieldBase(name="user", data_type=DataType(reference=reference), required=True)
 
     assert field.imports == (IMPORT_OPTIONAL,)
+    assert field.data_type.is_optional is False
 
 
 def test_field_import_fast_path_ignores_nullable_alias_reference() -> None:
@@ -811,6 +813,88 @@ def test_field_import_fallback_collects_nullable_reference_in_union() -> None:
     )
 
     assert field.imports == (IMPORT_OPTIONAL, IMPORT_UNION)
+
+
+def test_field_import_cache_normalizes_union_on_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test cached import lookup still applies union Optional side effects."""
+    DataModelFieldBase._field_imports_cache.clear()
+    try:
+        primed_field = DataModelFieldBase(
+            name="a",
+            data_type=DataType(data_types=[DataType(type="str"), DataType(type=NONE)]),
+            required=True,
+        )
+
+        assert primed_field.imports == (IMPORT_OPTIONAL,)
+        assert primed_field.data_type.is_optional is True
+
+        uncached = Mock(side_effect=AssertionError("unexpected uncached import collection"))
+        monkeypatch.setattr(DataModelFieldBase, "_collect_field_imports_uncached", uncached)
+        cached_field = DataModelFieldBase(
+            name="a",
+            data_type=DataType(data_types=[DataType(type="str"), DataType(type=NONE)]),
+            required=True,
+        )
+
+        assert cached_field.data_type.is_optional is False
+        assert cached_field.imports == (IMPORT_OPTIONAL,)
+        assert cached_field.data_type.is_optional is True
+        uncached.assert_not_called()
+    finally:
+        DataModelFieldBase._field_imports_cache.clear()
+
+
+def test_field_import_cache_normalizes_nullable_reference_on_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test cached import lookup still applies reference nullable side effects."""
+    DataModelFieldBase._field_imports_cache.clear()
+    try:
+        primed_reference = Reference(path="#/definitions/User", name="User")
+        primed_reference.source = ReferenceSource(nullable=True)
+        primed_field = DataModelFieldBase(
+            name="user",
+            data_type=DataType(data_types=[DataType(reference=primed_reference), DataType(type="int")]),
+            required=True,
+        )
+
+        assert primed_field.imports == (IMPORT_OPTIONAL, IMPORT_UNION)
+        assert primed_field.data_type.data_types[0].is_optional is True
+
+        uncached = Mock(side_effect=AssertionError("unexpected uncached import collection"))
+        monkeypatch.setattr(DataModelFieldBase, "_collect_field_imports_uncached", uncached)
+        cached_reference = Reference(path="#/definitions/User", name="User")
+        cached_reference.source = ReferenceSource(nullable=True)
+        cached_field = DataModelFieldBase(
+            name="user",
+            data_type=DataType(data_types=[DataType(reference=cached_reference), DataType(type="int")]),
+            required=True,
+        )
+
+        assert cached_field.data_type.data_types[0].is_optional is False
+        assert cached_field.imports == (IMPORT_OPTIONAL, IMPORT_UNION)
+        assert cached_field.data_type.data_types[0].is_optional is True
+        uncached.assert_not_called()
+    finally:
+        DataModelFieldBase._field_imports_cache.clear()
+
+
+def test_field_import_cache_evicts_oldest_entry() -> None:
+    """Test the bounded field imports cache evicts the oldest entry."""
+    DataModelFieldBase._field_imports_cache.clear()
+    original_max_size = DataModelFieldBase._FIELD_IMPORTS_CACHE_MAX_SIZE
+    try:
+        DataModelFieldBase._FIELD_IMPORTS_CACHE_MAX_SIZE = 1
+        field = DataModelFieldBase(name="a", data_type=DataType(type="str"), required=True)
+        first_key: tuple[Any, ...] = ("first",)
+        second_key: tuple[Any, ...] = ("second",)
+
+        field._set_cached_field_imports(first_key, ())
+        field._set_cached_field_imports(second_key, (IMPORT_OPTIONAL,))
+
+        assert first_key not in DataModelFieldBase._field_imports_cache
+        assert DataModelFieldBase._field_imports_cache[second_key] == (IMPORT_OPTIONAL,)
+    finally:
+        DataModelFieldBase._FIELD_IMPORTS_CACHE_MAX_SIZE = original_max_size
+        DataModelFieldBase._field_imports_cache.clear()
 
 
 @pytest.mark.parametrize(

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -1262,6 +1262,26 @@ def test_json_schema_parser_extension(source_obj: dict[str, Any], generated_clas
     assert dump_templates(list(parser.results)) == generated_classes
 
 
+def test_json_schema_parser_schema_raw_key_cache_is_schema_object_specific() -> None:
+    """Test schema raw key caches are keyed by the exact schema object type."""
+
+    class AltJsonSchemaObject(JsonSchemaObject):
+        properties: Optional[dict[str, Union[AltJsonSchemaObject, bool]]] = None  # noqa: UP007, UP045
+        alt_type: Optional[str] = pydantic.Field(default=None, alias="altType")  # noqa: UP045
+
+    class AltJsonSchemaParser(JsonSchemaParser):
+        SCHEMA_OBJECT_TYPE = AltJsonSchemaObject
+
+    base_parser = JsonSchemaParser("")
+    alt_parser = AltJsonSchemaParser("")
+
+    assert "altType" not in base_parser._known_schema_object_raw_keys()
+    assert "altType" in alt_parser._known_schema_object_raw_keys()
+    assert base_parser._has_schema_affecting_keywords({"altType": "string"}) is False
+    assert alt_parser._has_schema_affecting_keywords({"altType": "string"}) is True
+    assert alt_parser._known_schema_object_raw_keys() is alt_parser._known_schema_object_raw_keys()
+
+
 def test_create_data_model_with_frozen_dataclasses() -> None:
     """Test _create_data_model when frozen_dataclasses attribute exists."""
     parser = JsonSchemaParser(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type import generation so nullable/union cases stay consistent even when import results are reused from cache.
  * Fixed JSON Schema “schema-affecting” keyword detection so it’s correctly scoped to each schema object shape.
* **Tests**
  * Expanded coverage for cache normalization and bounded cache eviction behavior.
  * Added a unit test ensuring JSON Schema raw-key caching is memoized per schema object type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->