### PR TITLE
Fix scripts module imports in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ playground = [
 version.source = "vcs"
 build.dev-mode-dirs = [ "src" ]
 build.targets.sdist.include = [
+  "/scripts",
   "/src",
   "/tests",
 ]

--- a/scripts/check_sdist_test_support.py
+++ b/scripts/check_sdist_test_support.py
@@ -1,0 +1,82 @@
+"""Check that source distributions include helper files required by tests."""
+
+from __future__ import annotations
+
+import argparse
+import tarfile
+from pathlib import Path, PurePosixPath
+
+EXCLUDED_SCRIPT_PARTS = frozenset({"__pycache__"})
+
+
+def _find_sdist(dist_dir: Path) -> Path:
+    match sorted(dist_dir.glob("*.tar.gz")):
+        case [sdist]:
+            return sdist
+        case []:
+            msg = f"No sdist archive found in {dist_dir}"
+            raise SystemExit(msg)
+        case sdists:
+            msg = "Expected one sdist archive, found:\n" + "\n".join(f"  - {path}" for path in sdists)
+            raise SystemExit(msg)
+    raise AssertionError
+
+
+def _archive_relative_path(member_name: str) -> PurePosixPath | None:
+    match PurePosixPath(member_name).parts:
+        case (_, *relative_parts) if relative_parts:
+            return PurePosixPath(*relative_parts)
+        case _:
+            return None
+    return None
+
+
+def _archive_files(sdist: Path) -> frozenset[PurePosixPath]:
+    with tarfile.open(sdist, "r:gz") as archive:
+        return frozenset(
+            path for member in archive.getmembers() if member.isfile() and (path := _archive_relative_path(member.name))
+        )
+
+
+def _contains_top_level(paths: frozenset[PurePosixPath], root: str) -> bool:
+    for path in paths:
+        match path.parts:
+            case (top_level, *_) if top_level == root:
+                return True
+            case _:
+                continue
+    return False
+
+
+def _local_script_files(root: Path) -> frozenset[PurePosixPath]:
+    return frozenset(
+        PurePosixPath(path.relative_to(root).as_posix())
+        for path in sorted((root / "scripts").rglob("*"))
+        if path.is_file() and not EXCLUDED_SCRIPT_PARTS.intersection(path.parts)
+    )
+
+
+def check_sdist_test_support(sdist: Path, root: Path) -> None:
+    """Fail when the sdist ships tests without the script helpers they import."""
+    archive_files = _archive_files(sdist)
+    if not _contains_top_level(archive_files, "tests"):
+        return
+
+    if not (missing_files := sorted(_local_script_files(root) - archive_files)):
+        return
+
+    msg = "sdist includes tests but is missing script helpers:\n" + "\n".join(f"  - {path}" for path in missing_files)
+    raise SystemExit(msg)
+
+
+def main() -> None:
+    """Run the sdist test-support check."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dist_dir", type=Path)
+    args = parser.parse_args()
+
+    check_sdist_test_support(_find_sdist(args.dist_dir), Path.cwd())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/expected/package_metadata/sdist_include_roots.txt
+++ b/tests/data/expected/package_metadata/sdist_include_roots.txt
@@ -1,0 +1,3 @@
+/scripts: scripts
+scripts/helpers: scripts
+: None

--- a/tests/data/expected/package_metadata/test_support_import_roots.txt
+++ b/tests/data/expected/package_metadata/test_support_import_roots.txt
@@ -1,0 +1,1 @@
+scripts

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,118 @@
+"""Tests for package metadata and source distribution configuration."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from datamodel_code_generator.util import load_toml
+from tests.conftest import assert_output
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS_ROOT = ROOT / "tests"
+EXPECTED_PACKAGE_METADATA_PATH = ROOT / "tests" / "data" / "expected" / "package_metadata"
+EXCLUDED_IMPORT_ROOTS = frozenset({"datamodel_code_generator", "tests"})
+
+
+def _load_pyproject() -> dict[str, Any]:
+    return cast("dict[str, Any]", load_toml(ROOT / "pyproject.toml"))
+
+
+def _sdist_include_root(entry: str) -> str | None:
+    match PurePosixPath(entry).parts:
+        case ("/", root, *_):
+            return root
+        case (root, *_) if root:
+            return root
+        case _:
+            return None
+    return None
+
+
+def _sdist_include_roots() -> frozenset[str]:
+    includes = cast(
+        "list[str]",
+        _load_pyproject()["tool"]["hatch"]["build"]["targets"]["sdist"]["include"],
+    )
+    return frozenset(root for entry in includes if (root := _sdist_include_root(entry)))
+
+
+def _is_test_source(path: Path) -> bool:
+    match path.relative_to(TESTS_ROOT).parts:
+        case ("data", *_):
+            return False
+        case (*_, file_name) if path.suffix == ".py" and (
+            file_name.startswith("test_") or file_name.endswith("_test.py")
+        ):
+            return True
+        case _:
+            return False
+    return False
+
+
+def _iter_test_sources() -> Iterator[Path]:
+    yield from (path for path in sorted(TESTS_ROOT.rglob("*.py")) if _is_test_source(path))
+
+
+def _iter_import_roots(path: Path) -> Iterator[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        match node:
+            case ast.Import(names=names):
+                yield from (alias.name.partition(".")[0] for alias in names)
+            case ast.ImportFrom(level=0, module=module) if module:
+                yield module.partition(".")[0]
+            case _:
+                continue
+
+
+def _is_local_support_import(root: str) -> bool:
+    if root in EXCLUDED_IMPORT_ROOTS:
+        return False
+
+    return (ROOT / root).is_dir() or (ROOT / f"{root}.py").is_file()
+
+
+def _local_test_support_import_roots() -> list[str]:
+    return sorted({
+        root for path in _iter_test_sources() for root in _iter_import_roots(path) if _is_local_support_import(root)
+    })
+
+
+def test_sdist_include_root_normalizes_entries() -> None:
+    """Sdist include paths normalize to their top-level archive roots."""
+    output = "\n".join(
+        f"{entry}: {_sdist_include_root(entry)}"
+        for entry in [
+            "/scripts",
+            "scripts/helpers",
+            "",
+        ]
+    )
+
+    assert_output(f"{output}\n", EXPECTED_PACKAGE_METADATA_PATH / "sdist_include_roots.txt")
+
+
+def test_sdist_includes_test_support_imports() -> None:
+    """Top-level helper packages imported by tests must ship with the sdist."""
+    import_roots = _local_test_support_import_roots()
+
+    assert_output(
+        "\n".join(import_roots) + "\n",
+        EXPECTED_PACKAGE_METADATA_PATH / "test_support_import_roots.txt",
+    )
+
+    if not (missing_roots := [root for root in import_roots if root not in _sdist_include_roots()]):
+        return
+
+    pytest.fail(  # pragma: no cover
+        "Tests import top-level support packages missing from tool.hatch.build.targets.sdist.include:\n"
+        + "\n".join(f"  - /{root}" for root in missing_roots),
+        pytrace=False,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -116,6 +116,7 @@ description = check that the long description is valid
 skip_install = true
 commands =
     uv build --sdist --wheel --out-dir {env_tmp_dir} .
+    python scripts/check_sdist_test_support.py {env_tmp_dir}
     twine check {env_tmp_dir}{/}*
     check-wheel-contents --no-config {env_tmp_dir}
 dependency_groups = pkg-meta


### PR DESCRIPTION
Fixes #3513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated packaging so `scripts/` is included in source distributions.
  * Added a packaging validation CLI to confirm source archives contain the expected test support files.

* **Bug Fixes**
  * Prevented missing test helper files from being omitted when publishing source archives.
  * Added automated checks to ensure sdist include roots and test support import roots match expected metadata.

* **Chores**
  * Extended the packaging test workflow to run the new source-archive validation before artifact checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->