### PR TITLE
Add CLI topic pages

### DIFF
--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -18,6 +18,17 @@ This documentation is auto-generated from test cases.
 | ⚙️ [General Options](general-options.md) | 18 | Utilities and meta options |
 | 📝 [Utility Options](utility-options.md) | 10 | Help, version, debug options |
 
+## 🎯 Focused Topics
+
+Use these pages when you know the workflow area but not the exact option name.
+
+| Topic | Options | Groups |
+|-------|---------|--------|
+| [Model Customization](topics/model-customization.md) | 23 | Model Naming, Model Reuse, Model Shape, Root Model |
+| [Template Customization](topics/template-customization.md) | 19 | Custom Templates, Generated Output, Imports, Output Formatting |
+| [Typing Customization](topics/typing-customization.md) | 20 | Imports, Collection Types, Type Alias, Type Mapping, Type Syntax |
+| [OpenAPI](topics/openapi.md) | 7 | OpenAPI Naming, OpenAPI Paths, OpenAPI Scopes, Read Only Write Only |
+
 ## All Options
 
 **Jump to:** [A](#a) · [B](#b) · [C](#c) · [D](#d) · [E](#e) · [F](#f) · [G](#g) · [H](#h) · [I](#i) · [K](#k) · [L](#l) · [M](#m) · [N](#n) · [O](#o) · [P](#p) · [R](#r) · [S](#s) · [T](#t) · [U](#u) · [V](#v) · [W](#w)

--- a/docs/cli-reference/topics/model-customization.md
+++ b/docs/cli-reference/topics/model-customization.md
@@ -1,0 +1,65 @@
+# Model Customization
+
+Choose model class shape, naming, reuse, and root-model behavior.
+
+Options are grouped from shared CLI metadata and link back to their generated reference sections.
+
+## Groups
+
+| Group | Options | Description |
+|-------|---------|-------------|
+| [Model Naming](#model-naming) | 9 | Class names, suffixes, prefixes, and duplicate-name behavior. |
+| [Model Reuse](#model-reuse) | 4 | Schema deduplication and shared generated modules. |
+| [Model Shape](#model-shape) | 6 | Output model family and compatibility targets. |
+| [Root Model](#root-model) | 4 | Root model creation, collapse, and alias behavior. |
+
+## Model Naming {#model-naming}
+
+Class names, suffixes, prefixes, and duplicate-name behavior.
+
+| Option | Description |
+|--------|-------------|
+| [`--allow-leading-underscore-class-name`](../model-customization.md#allow-leading-underscore-class-name) | Allow an explicitly specified root class name to start with an underscore. |
+| [`--class-name`](../model-customization.md#class-name) | Override the auto-generated class name with a custom name. |
+| [`--class-name-affix-scope`](../model-customization.md#class-name-affix-scope) | Control which classes receive the prefix/suffix. |
+| [`--class-name-prefix`](../model-customization.md#class-name-prefix) | Add a prefix to all generated class names. |
+| [`--class-name-suffix`](../model-customization.md#class-name-suffix) | Add a suffix to all generated class names. |
+| [`--duplicate-name-suffix`](../model-customization.md#duplicate-name-suffix) | Customize suffix for duplicate model names. |
+| [`--model-name-map`](../model-customization.md#model-name-map) | Rename generated model classes from a JSON mapping. |
+| [`--naming-strategy`](../model-customization.md#naming-strategy) | Use parent-prefixed naming strategy for duplicate model names. |
+| [`--parent-scoped-naming`](../model-customization.md#parent-scoped-naming) | Namespace models by their parent scope to avoid naming conflicts. |
+
+## Model Reuse {#model-reuse}
+
+Schema deduplication and shared generated modules.
+
+| Option | Description |
+|--------|-------------|
+| [`--collapse-reuse-models`](../model-customization.md#collapse-reuse-models) | Collapse duplicate models by replacing references instead of inheritance. |
+| [`--reuse-model`](../model-customization.md#reuse-model) | Reuse identical model definitions instead of generating duplicates. |
+| [`--reuse-scope`](../model-customization.md#reuse-scope) | Scope for model reuse detection (root or tree). |
+| [`--shared-module-name`](../general-options.md#shared-module-name) | Customize the name of the shared module for deduplicated models. |
+
+## Model Shape {#model-shape}
+
+Output model family and compatibility targets.
+
+| Option | Description |
+|--------|-------------|
+| [`--base-class`](../model-customization.md#base-class) | Specify a custom base class for generated models. |
+| [`--base-class-map`](../model-customization.md#base-class-map) | Specify different base classes for specific models via JSON mapping. |
+| [`--output-model-type`](../model-customization.md#output-model-type) | Select the output model type (Pydantic v2, Pydantic v2 dataclass, dataclasses, T... |
+| [`--target-pydantic-version`](../model-customization.md#target-pydantic-version) | Target Pydantic version for generated code compatibility. |
+| [`--target-python-version`](../model-customization.md#target-python-version) | Target Python version for generated code syntax and imports. |
+| [`--use-generic-base-class`](../model-customization.md#use-generic-base-class) | Generate a shared base class with model configuration to avoid repetition (DRY). |
+
+## Root Model {#root-model}
+
+Root model creation, collapse, and alias behavior.
+
+| Option | Description |
+|--------|-------------|
+| [`--collapse-root-models`](../model-customization.md#collapse-root-models) | Inline root model definitions instead of creating separate wrapper classes. |
+| [`--collapse-root-models-name-strategy`](../model-customization.md#collapse-root-models-name-strategy) | Select which name to keep when collapsing root models with object references. |
+| [`--skip-root-model`](../model-customization.md#skip-root-model) | Skip generation of root model when schema contains nested definitions. |
+| [`--use-root-model-sequence-interface`](../model-customization.md#use-root-model-sequence-interface) | Make non-null sequence-like Pydantic v2 RootModel classes implement collections.... |

--- a/docs/cli-reference/topics/openapi.md
+++ b/docs/cli-reference/topics/openapi.md
@@ -1,0 +1,49 @@
+# OpenAPI
+
+Handle OpenAPI operation naming, path selection, scopes, and readOnly/writeOnly behavior.
+
+Options are grouped from shared CLI metadata and link back to their generated reference sections.
+
+## Groups
+
+| Group | Options | Description |
+|-------|---------|-------------|
+| [OpenAPI Naming](#openapi-naming) | 2 | Operation and response model naming. |
+| [OpenAPI Paths](#openapi-paths) | 2 | Path selection and path parameter output. |
+| [OpenAPI Scopes](#openapi-scopes) | 1 | OpenAPI generation scopes. |
+| [Read Only Write Only](#read-only-write-only) | 2 | readOnly/writeOnly model behavior. |
+
+## OpenAPI Naming {#openapi-naming}
+
+Operation and response model naming.
+
+| Option | Description |
+|--------|-------------|
+| [`--use-operation-id-as-name`](../openapi-only-options.md#use-operation-id-as-name) | Use OpenAPI operationId as the generated function/class name. |
+| [`--use-status-code-in-response-name`](../openapi-only-options.md#use-status-code-in-response-name) | Include HTTP status code in response model names. |
+
+## OpenAPI Paths {#openapi-paths}
+
+Path selection and path parameter output.
+
+| Option | Description |
+|--------|-------------|
+| [`--include-path-parameters`](../openapi-only-options.md#include-path-parameters) | Include OpenAPI path parameters in generated parameter models. |
+| [`--openapi-include-paths`](../openapi-only-options.md#openapi-include-paths) | Filter OpenAPI paths to include in model generation. |
+
+## OpenAPI Scopes {#openapi-scopes}
+
+OpenAPI generation scopes.
+
+| Option | Description |
+|--------|-------------|
+| [`--openapi-scopes`](../openapi-only-options.md#openapi-scopes) | Specify OpenAPI scopes to generate (schemas, paths, parameters). |
+
+## Read Only Write Only {#read-only-write-only}
+
+readOnly/writeOnly model behavior.
+
+| Option | Description |
+|--------|-------------|
+| [`--read-only-write-only-model-type`](../openapi-only-options.md#read-only-write-only-model-type) | Generate separate request and response models for readOnly/writeOnly fields. |
+| [`--use-frozen-field`](../model-customization.md#use-frozen-field) | Generate frozen (immutable) field definitions for readOnly properties. |

--- a/docs/cli-reference/topics/template-customization.md
+++ b/docs/cli-reference/topics/template-customization.md
@@ -1,0 +1,61 @@
+# Template Customization
+
+Tune generated file headers, imports, decorators, templates, and formatting.
+
+Options are grouped from shared CLI metadata and link back to their generated reference sections.
+
+## Groups
+
+| Group | Options | Description |
+|-------|---------|-------------|
+| [Custom Templates](#custom-templates) | 3 | Custom templates and extra template data. |
+| [Generated Output](#generated-output) | 7 | Generated file headers and reproducible output. |
+| [Imports](#imports) | 4 | Generated imports and type-checking import behavior. |
+| [Output Formatting](#output-formatting) | 5 | Formatter selection, quote style, and string wrapping. |
+
+## Custom Templates {#custom-templates}
+
+Custom templates and extra template data.
+
+| Option | Description |
+|--------|-------------|
+| [`--custom-template-dir`](../template-customization.md#custom-template-dir) | Use custom Jinja2 templates for model generation. |
+| [`--extra-template-data`](../template-customization.md#extra-template-data) | Pass custom template variables via inline JSON or a JSON file path. |
+| [`--validators`](../template-customization.md#validators) | Add custom field validators to generated Pydantic v2 models. |
+
+## Generated Output {#generated-output}
+
+Generated file headers and reproducible output.
+
+| Option | Description |
+|--------|-------------|
+| [`--class-decorators`](../template-customization.md#class-decorators) | Add custom decorators to generated model classes. |
+| [`--custom-file-header`](../template-customization.md#custom-file-header) | Add custom header text to the generated file. |
+| [`--custom-file-header-path`](../template-customization.md#custom-file-header-path) | Add custom header content from file to generated code. |
+| [`--disable-timestamp`](../template-customization.md#disable-timestamp) | Disable timestamp in generated file header for reproducible output. |
+| [`--enable-command-header`](../template-customization.md#enable-command-header) | Include command-line options in file header for reproducibility. |
+| [`--enable-generated-header-marker`](../template-customization.md#enable-generated-header-marker) | Include the @generated marker in file header for generated-code tooling. |
+| [`--enable-version-header`](../template-customization.md#enable-version-header) | Include tool version information in file header. |
+
+## Imports {#imports}
+
+Generated imports and type-checking import behavior.
+
+| Option | Description |
+|--------|-------------|
+| [`--additional-imports`](../template-customization.md#additional-imports) | Add custom imports to generated output files. |
+| [`--no-use-type-checking-imports`](../template-customization.md#no-use-type-checking-imports) | Keep generated model imports available at runtime when using Ruff fixes. |
+| [`--use-exact-imports`](../template-customization.md#use-exact-imports) | Import exact types instead of modules. |
+| [`--use-type-checking-imports`](../template-customization.md#use-type-checking-imports) | Allow Ruff to move typing-only imports into TYPE_CHECKING blocks. |
+
+## Output Formatting {#output-formatting}
+
+Formatter selection, quote style, and string wrapping.
+
+| Option | Description |
+|--------|-------------|
+| [`--custom-formatters`](../template-customization.md#custom-formatters) | Apply custom Python code formatters to generated output. |
+| [`--custom-formatters-kwargs`](../template-customization.md#custom-formatters-kwargs) | Pass custom arguments to custom formatters via inline JSON or a JSON file path. |
+| [`--formatters`](../template-customization.md#formatters) | Specify code formatters to apply to generated output. |
+| [`--use-double-quotes`](../template-customization.md#use-double-quotes) | Use double quotes for string literals in generated code. |
+| [`--wrap-string-literal`](../template-customization.md#wrap-string-literal) | Wrap long string literals across multiple lines. |

--- a/docs/cli-reference/topics/typing-customization.md
+++ b/docs/cli-reference/topics/typing-customization.md
@@ -1,0 +1,70 @@
+# Typing Customization
+
+Control Python annotation syntax, collection types, imports, and type mappings.
+
+Options are grouped from shared CLI metadata and link back to their generated reference sections.
+
+## Groups
+
+| Group | Options | Description |
+|-------|---------|-------------|
+| [Imports](#imports) | 1 | Generated imports and type-checking import behavior. |
+| [Collection Types](#collection-types) | 5 | Collection and tuple/set generation. |
+| [Type Alias](#type-alias) | 2 | TypeAlias and root-model alias output. |
+| [Type Mapping](#type-mapping) | 9 | Scalar, date/time, and custom type mapping. |
+| [Type Syntax](#type-syntax) | 3 | Modern annotation syntax and Annotated usage. |
+
+## Imports {#imports}
+
+Generated imports and type-checking import behavior.
+
+| Option | Description |
+|--------|-------------|
+| [`--disable-future-imports`](../typing-customization.md#disable-future-imports) | Prevent automatic addition of __future__ imports in generated code. |
+
+## Collection Types {#collection-types}
+
+Collection and tuple/set generation.
+
+| Option | Description |
+|--------|-------------|
+| [`--no-use-standard-collections`](../typing-customization.md#no-use-standard-collections) | Use typing.Dict/List instead of built-in dict/list for container types. |
+| [`--use-generic-container-types`](../typing-customization.md#use-generic-container-types) | Use generic container types (Sequence, Mapping) for type hinting. |
+| [`--use-standard-collections`](../typing-customization.md#use-standard-collections) | Use built-in dict/list instead of typing.Dict/List. |
+| [`--use-tuple-for-fixed-items`](../typing-customization.md#use-tuple-for-fixed-items) | Generate tuple types for arrays with items array syntax. |
+| [`--use-unique-items-as-set`](../typing-customization.md#use-unique-items-as-set) | Generate set types for arrays with uniqueItems constraint. |
+
+## Type Alias {#type-alias}
+
+TypeAlias and root-model alias output.
+
+| Option | Description |
+|--------|-------------|
+| [`--use-root-model-type-alias`](../typing-customization.md#use-root-model-type-alias) | Generate RootModel as type alias format for better mypy support. |
+| [`--use-type-alias`](../typing-customization.md#use-type-alias) | Use TypeAlias instead of root models for type definitions (experimental). |
+
+## Type Mapping {#type-mapping}
+
+Scalar, date/time, and custom type mapping.
+
+| Option | Description |
+|--------|-------------|
+| [`--output-date-class`](../typing-customization.md#output-date-class) | Specify date class type for date schema fields. |
+| [`--output-datetime-class`](../typing-customization.md#output-datetime-class) | Specify datetime class type for date-time schema fields. |
+| [`--strict-types`](../typing-customization.md#strict-types) | Enable strict type validation for specified Python types. |
+| [`--type-mappings`](../typing-customization.md#type-mappings) | Override default type mappings for schema formats. |
+| [`--type-overrides`](../typing-customization.md#type-overrides) | Replace schema model types with custom Python types via JSON mapping. |
+| [`--use-decimal-for-multiple-of`](../typing-customization.md#use-decimal-for-multiple-of) | Generate Decimal types for fields with multipleOf constraint. |
+| [`--use-object-type`](../typing-customization.md#use-object-type) | Use object instead of Any for unspecified object and array values. |
+| [`--use-pendulum`](../typing-customization.md#use-pendulum) | Use pendulum types for date, time, and duration fields. |
+| [`--use-standard-primitive-types`](../typing-customization.md#use-standard-primitive-types) | Use Python standard library types for string formats instead of str. |
+
+## Type Syntax {#type-syntax}
+
+Modern annotation syntax and Annotated usage.
+
+| Option | Description |
+|--------|-------------|
+| [`--no-use-union-operator`](../typing-customization.md#no-use-union-operator) | Use Union\[X, Y\] / Optional\[X\] instead of X \| Y union operator. |
+| [`--use-annotated`](../typing-customization.md#use-annotated) | Use typing.Annotated for Field() with constraints. |
+| [`--use-union-operator`](../typing-customization.md#use-union-operator) | Use \| operator for Union types (PEP 604). |

--- a/scripts/build_cli_docs.py
+++ b/scripts/build_cli_docs.py
@@ -35,8 +35,11 @@ import operator
 from datamodel_code_generator.cli_options import (
     MANUAL_DOCS,
     OPTION_RELATION_KINDS,
+    OPTION_TOPIC_ALLOWED_GROUPS,
     CLIOptionMeta,
     OptionCategory,
+    OptionGroup,
+    OptionTopic,
     get_canonical_option,
     get_cli_doc_slug,
     get_cli_option_doc_name,
@@ -168,6 +171,7 @@ DATA_PATH = Path(__file__).parent.parent / "tests" / "data"
 EXPECTED_BASE_PATH = DATA_PATH / "expected"
 EXPECTED_PATH = EXPECTED_BASE_PATH / "main"
 DOCS_OUTPUT = Path(__file__).parent.parent / "docs" / "cli-reference"
+TOPICS_OUTPUT = DOCS_OUTPUT / "topics"
 MANUAL_DOCS_DIR = DOCS_OUTPUT / "manual"
 DOCS_ROOT = Path(__file__).parent.parent / "docs"
 
@@ -188,6 +192,34 @@ CATEGORY_EMOJIS = {
     OptionCategory.OPENAPI: "📘",
     OptionCategory.GENERAL: "⚙️",
 }
+
+TOPIC_DESCRIPTIONS = {
+    OptionTopic.MODEL_CUSTOMIZATION: "Choose model class shape, naming, reuse, and root-model behavior.",
+    OptionTopic.TEMPLATE_CUSTOMIZATION: "Tune generated file headers, imports, decorators, templates, and formatting.",
+    OptionTopic.TYPING_CUSTOMIZATION: "Control Python annotation syntax, collection types, imports, and type mappings.",
+    OptionTopic.OPENAPI: "Handle OpenAPI operation naming, path selection, scopes, and readOnly/writeOnly behavior.",
+}
+
+GROUP_DESCRIPTIONS = {
+    OptionGroup.MODEL_NAMING: "Class names, suffixes, prefixes, and duplicate-name behavior.",
+    OptionGroup.MODEL_REUSE: "Schema deduplication and shared generated modules.",
+    OptionGroup.MODEL_SHAPE: "Output model family and compatibility targets.",
+    OptionGroup.ROOT_MODEL: "Root model creation, collapse, and alias behavior.",
+    OptionGroup.CUSTOM_TEMPLATES: "Custom templates and extra template data.",
+    OptionGroup.GENERATED_OUTPUT: "Generated file headers and reproducible output.",
+    OptionGroup.IMPORTS: "Generated imports and type-checking import behavior.",
+    OptionGroup.OUTPUT_FORMATTING: "Formatter selection, quote style, and string wrapping.",
+    OptionGroup.COLLECTION_TYPES: "Collection and tuple/set generation.",
+    OptionGroup.TYPE_ALIAS: "TypeAlias and root-model alias output.",
+    OptionGroup.TYPE_MAPPING: "Scalar, date/time, and custom type mapping.",
+    OptionGroup.TYPE_SYNTAX: "Modern annotation syntax and Annotated usage.",
+    OptionGroup.OPENAPI_NAMING: "Operation and response model naming.",
+    OptionGroup.OPENAPI_PATHS: "Path selection and path parameter output.",
+    OptionGroup.OPENAPI_SCOPES: "OpenAPI generation scopes.",
+    OptionGroup.READ_ONLY_WRITE_ONLY: "readOnly/writeOnly model behavior.",
+}
+
+OPTION_TOPIC_ORDER = tuple(OPTION_TOPIC_ALLOWED_GROUPS)
 
 CATEGORY_RECIPES: dict[OptionCategory, tuple[CategoryRecipe, ...]] = {
     OptionCategory.BASE: (
@@ -1060,6 +1092,103 @@ def generate_quick_reference(
     return md
 
 
+TopicOptions = dict[OptionTopic, dict[OptionGroup, list[tuple[str, CLIDocOption]]]]
+
+
+def _title_from_slug(value: str) -> str:
+    """Return a display title for enum values stored as URL slugs."""
+    return value.replace("openapi", "OpenAPI").replace("-", " ").title().replace("Openapi", "OpenAPI")
+
+
+def _topic_title(topic: OptionTopic) -> str:
+    """Return a stable topic title."""
+    return _title_from_slug(topic.value)
+
+
+def _group_title(group: OptionGroup) -> str:
+    """Return a stable group title."""
+    return _title_from_slug(group.value)
+
+
+def _iter_topic_groups(topic: OptionTopic) -> tuple[OptionGroup, ...]:
+    """Return topic groups in enum order."""
+    allowed_groups = OPTION_TOPIC_ALLOWED_GROUPS.get(topic, frozenset())
+    return tuple(group for group in OptionGroup if group in allowed_groups)
+
+
+def _escape_table_cell(value: str) -> str:
+    """Escape Markdown syntax that is ambiguous inside generated tables."""
+    return value.replace("|", r"\|").replace("[", r"\[").replace("]", r"\]")
+
+
+def collect_topic_options(categories: dict[OptionCategory, dict[str, CLIDocOption]]) -> TopicOptions:
+    """Collect documented options by focused topic and subgroup."""
+    topics: TopicOptions = defaultdict(lambda: defaultdict(list))
+    for options in categories.values():
+        for option, cli_doc_option in options.items():
+            if not (meta := get_option_meta(option)):
+                continue
+            if meta.topic is None or meta.group is None:
+                continue
+            topics[meta.topic][meta.group].append((option, cli_doc_option))
+
+    for groups in topics.values():
+        for group_options in groups.values():
+            group_options.sort(key=operator.itemgetter(0))
+    return dict(topics)
+
+
+def generate_topic_index(topic_options: TopicOptions) -> str:
+    """Generate the CLI reference topic index section."""
+    if not topic_options:
+        return ""
+
+    md = "## 🎯 Focused Topics\n\n"
+    md += "Use these pages when you know the workflow area but not the exact option name.\n\n"
+    md += "| Topic | Options | Groups |\n"
+    md += "|-------|---------|--------|\n"
+    for topic in OPTION_TOPIC_ORDER:
+        if not (groups := topic_options.get(topic)):
+            continue
+        option_count = sum(len(options) for options in groups.values())
+        group_names = ", ".join(_group_title(group) for group in _iter_topic_groups(topic) if group in groups)
+        md += f"| [{_topic_title(topic)}](topics/{topic.value}.md) | {option_count} | {group_names} |\n"
+    return md + "\n"
+
+
+def generate_topic_page(topic: OptionTopic, groups: dict[OptionGroup, list[tuple[str, CLIDocOption]]]) -> str:
+    """Generate one focused CLI topic page."""
+    title = _topic_title(topic)
+    md = f"# {title}\n\n"
+    if description := TOPIC_DESCRIPTIONS.get(topic):
+        md += f"{description}\n\n"
+    md += "Options are grouped from shared CLI metadata and link back to their generated reference sections.\n\n"
+    md += "## Groups\n\n"
+    md += "| Group | Options | Description |\n"
+    md += "|-------|---------|-------------|\n"
+    for group in _iter_topic_groups(topic):
+        if group not in groups:
+            continue
+        md += f"| [{_group_title(group)}](#{get_cli_doc_slug(group.value)}) | {len(groups[group])} | "
+        md += f"{GROUP_DESCRIPTIONS.get(group, '')} |\n"
+    md += "\n"
+
+    for group in _iter_topic_groups(topic):
+        if not (options := groups.get(group)):
+            continue
+        md += f"## {_group_title(group)} {{#{get_cli_doc_slug(group.value)}}}\n\n"
+        if description := GROUP_DESCRIPTIONS.get(group):
+            md += f"{description}\n\n"
+        md += "| Option | Description |\n"
+        md += "|--------|-------------|\n"
+        for option, cli_doc_option in options:
+            option_description = cli_doc_option.get_option_description()
+            desc = summarize_description(option_description, DESC_LENGTH_LONG) if option_description else ""
+            md += f"| [`{option}`]({get_cli_option_doc_path(option, root='..')}) | {_escape_table_cell(desc)} |\n"
+        md += "\n"
+    return md
+
+
 def generate_index_page(
     categories: dict[OptionCategory, dict[str, CLIDocOption]],
     manual_docs: dict[str, str] | None = None,
@@ -1095,6 +1224,7 @@ def generate_index_page(
         md += f"| 📝 [Utility Options](utility-options.md) | {len(manual_docs)} | Help, version, debug options |\n"
 
     md += "\n"
+    md += generate_topic_index(collect_topic_options(categories))
     md += "## All Options\n\n"
     all_options: list[tuple[str, OptionCategory | None]] = []
     for category, options in categories.items():
@@ -1232,7 +1362,10 @@ def build_docs(*, check: bool = False) -> int:
 
     if not check:
         DOCS_OUTPUT.mkdir(parents=True, exist_ok=True)
+        TOPICS_OUTPUT.mkdir(parents=True, exist_ok=True)
         for old_file in DOCS_OUTPUT.glob("*.md"):
+            old_file.unlink()
+        for old_file in TOPICS_OUTPUT.glob("*.md"):
             old_file.unlink()
 
     generated = 0
@@ -1278,6 +1411,19 @@ def build_docs(*, check: bool = False) -> int:
             write_or_check(output_path, md, f"utility-options.md ({len(manual_docs)} options)")
         except (OSError, ValueError, KeyError) as e:
             print(f"Error generating utility-options.md: {e}", file=sys.stderr)
+            errors += 1
+
+    topic_options = collect_topic_options(categories)
+    for topic in OPTION_TOPIC_ORDER:
+        if not (groups := topic_options.get(topic)):
+            continue
+        try:
+            md = generate_topic_page(topic, groups)
+            output_path = TOPICS_OUTPUT / f"{topic.value}.md"
+            count = sum(len(options) for options in groups.values())
+            write_or_check(output_path, md, f"topics/{output_path.name} ({count} options)")
+        except (OSError, ValueError, KeyError) as e:
+            print(f"Error generating topics/{topic.value}.md: {e}", file=sys.stderr)
             errors += 1
 
     try:

--- a/tests/cli_doc/test_cli_options_sync.py
+++ b/tests/cli_doc/test_cli_options_sync.py
@@ -8,9 +8,15 @@ These tests verify that:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 from datamodel_code_generator import cli_options
 from datamodel_code_generator.arguments import arg_parser as argument_parser
@@ -40,7 +46,10 @@ from scripts.build_cli_docs import (
     CLIDocOption,
     _documented_related_option,
     _format_option_link,
+    collect_topic_options,
     generate_option_section,
+    generate_topic_index,
+    generate_topic_page,
     scan_docs_for_cli_option_tags,
 )
 
@@ -334,6 +343,96 @@ def test_category_page_omits_recipes_without_category_data(monkeypatch: pytest.M
     assert page.index("---") < page.index("## `--input`")
 
 
+def test_topic_pages_group_documented_options_by_metadata() -> None:
+    """Focused topic pages should group documented options by topic metadata."""
+    options = {
+        "--class-name": CLIDocOption(
+            option_name="--class-name",
+            examples=[
+                CLIDocExample(
+                    node_id="tests/cli_doc/test_cli_options_sync.py::test_class_name",
+                    option_description="Set class name.",
+                    cli_args=["--class-name", "Pet"],
+                    is_primary=True,
+                ),
+            ],
+        ),
+        "--output-model-type": CLIDocOption(
+            option_name="--output-model-type",
+            examples=[
+                CLIDocExample(
+                    node_id="tests/cli_doc/test_cli_options_sync.py::test_output_model_type",
+                    option_description="Set output model type.",
+                    cli_args=["--output-model-type", "pydantic_v2.BaseModel"],
+                    is_primary=True,
+                ),
+            ],
+        ),
+    }
+
+    topic_options = collect_topic_options({OptionCategory.MODEL: options})
+    page = generate_topic_page(
+        OptionTopic.MODEL_CUSTOMIZATION,
+        topic_options[OptionTopic.MODEL_CUSTOMIZATION],
+    )
+
+    _fail_if_missing("## Model Naming {#model-naming}", page, "model naming group")
+    _fail_if_missing("## Model Shape {#model-shape}", page, "model shape group")
+    _fail_if_missing("[`--class-name`](../model-customization.md#class-name)", page, "class name topic link")
+    _fail_if_missing(
+        "[`--output-model-type`](../model-customization.md#output-model-type)",
+        page,
+        "output model type topic link",
+    )
+
+
+def test_topic_index_lists_generated_topic_pages() -> None:
+    """CLI reference index should link to generated focused topic pages."""
+    option = CLIDocOption(
+        option_name="--use-union-operator",
+        examples=[
+            CLIDocExample(
+                node_id="tests/cli_doc/test_cli_options_sync.py::test_use_union_operator",
+                option_description="Use union operator.",
+                cli_args=["--use-union-operator"],
+                is_primary=True,
+            ),
+        ],
+    )
+
+    index = generate_topic_index(collect_topic_options({OptionCategory.TYPING: {"--use-union-operator": option}}))
+
+    _fail_if_missing(
+        "[Typing Customization](topics/typing-customization.md)",
+        index,
+        "typing topic index link",
+    )
+    _fail_if_missing("Type Syntax", index, "typing topic group label")
+
+
+def test_topic_page_escapes_markdown_table_descriptions() -> None:
+    """Focused topic tables should not turn type syntax into Markdown links."""
+    option = CLIDocOption(
+        option_name="--no-use-union-operator",
+        examples=[
+            CLIDocExample(
+                node_id="tests/cli_doc/test_cli_options_sync.py::test_no_use_union_operator",
+                option_description="Use Union[X, Y] / Optional[X] instead of X | Y union operator.",
+                cli_args=["--no-use-union-operator"],
+                is_primary=True,
+            ),
+        ],
+    )
+
+    topic_options = collect_topic_options({OptionCategory.TYPING: {"--no-use-union-operator": option}})
+    page = generate_topic_page(
+        OptionTopic.TYPING_CUSTOMIZATION,
+        topic_options[OptionTopic.TYPING_CUSTOMIZATION],
+    )
+
+    _fail_if_missing(r"Union\[X, Y\] / Optional\[X\] instead of X \| Y", page, "escaped type syntax")
+
+
 def test_option_section_renders_implies_and_requires_metadata() -> None:
     """Generated option docs should include relationship metadata from CLIOptionMeta."""
     section = generate_option_section(
@@ -510,6 +609,23 @@ class TestCLIOptionMetaSync:
                 allowed_groups,
                 f"{option} group for topic {topic.value!r}",
             )
+
+    def test_focused_topics_nav_matches_option_topics(self) -> None:
+        """Verify that focused topic docs stay linked from the site nav."""
+        root = Path(__file__).resolve().parents[2]
+        with (root / "zensical.toml").open("rb") as f:
+            nav = tomllib.load(f)["project"]["nav"]
+
+        cli_reference_nav = next(value for item in nav for title, value in item.items() if title == "CLI Reference")
+        focused_topics_nav = next(
+            value for item in cli_reference_nav for title, value in item.items() if title == "Focused Topics"
+        )
+        expected_nav = [
+            {build_cli_docs._topic_title(topic): f"cli-reference/topics/{topic.value}.md"}
+            for topic in build_cli_docs.OPTION_TOPIC_ORDER
+        ]
+
+        _fail_if_not_equal(focused_topics_nav, expected_nav, "Focused Topics nav")
 
     def test_all_argparse_options_are_documented_or_excluded(self) -> None:
         """Verify that all argparse options are either documented or explicitly excluded.

--- a/zensical.toml
+++ b/zensical.toml
@@ -21,6 +21,12 @@ nav = [
     { "GraphQL Options" = "cli-reference/graphql-only-options.md" },
     { "General Options" = "cli-reference/general-options.md" },
     { "Utility Options" = "cli-reference/utility-options.md" },
+    { "Focused Topics" = [
+      { "Model Customization" = "cli-reference/topics/model-customization.md" },
+      { "Template Customization" = "cli-reference/topics/template-customization.md" },
+      { "Typing Customization" = "cli-reference/topics/typing-customization.md" },
+      { "OpenAPI" = "cli-reference/topics/openapi.md" }
+    ]},
     { "Quick Reference" = "cli-reference/quick-reference.md" },
     { "Manual" = [
       { "Help" = "cli-reference/manual/help.md" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Focused Topics” section to the CLI reference, with dedicated pages for model, template, typing, and OpenAPI customization.
  * Topic pages group related options and link directly to the corresponding detailed option references.
* **Documentation**
  * Updated the CLI documentation navigation to surface the new focused topic pages.
* **Bug Fixes**
  * Improved rendering of option descriptions so special table-like syntax displays correctly (instead of becoming malformed links).
* **Tests**
  * Added coverage for focused topic page generation and index linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->