### PR TITLE
Add generation determinism guard

### DIFF
--- a/tests/main/test_generation_determinism.py
+++ b/tests/main/test_generation_determinism.py
@@ -61,16 +61,17 @@ def _assert_same_output(first: str, second: str, context: str) -> None:
     if first == second:
         return
 
-    diff = "\n".join(
-        difflib.unified_diff(
-            first.splitlines(),
-            second.splitlines(),
-            fromfile="first",
-            tofile="second",
-            lineterm="",
+    if first != second:  # pragma: no cover
+        diff = "\n".join(
+            difflib.unified_diff(
+                first.splitlines(),
+                second.splitlines(),
+                fromfile="first",
+                tofile="second",
+                lineterm="",
+            )
         )
-    )
-    pytest.fail(f"Generated output changed for {context}:\n{diff}", pytrace=False)
+        pytest.fail(f"Generated output changed for {context}:\n{diff}", pytrace=False)
 
 
 def _generate_output_with_hash_seed(input_path: Path, input_file_type: InputFileType, seed: str) -> str:

--- a/tests/main/test_generation_determinism.py
+++ b/tests/main/test_generation_determinism.py
@@ -101,12 +101,12 @@ def _generate_output_with_hash_seed(input_path: Path, input_file_type: InputFile
             text=True,
             timeout=HASH_SEED_TIMEOUT_SECONDS,
         )
-    except subprocess.TimeoutExpired:  # pragma: no cover
-        pytest.fail(
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover
+        message = (
             f"Generation timed out after {HASH_SEED_TIMEOUT_SECONDS}s for "
-            f"{input_path.as_posix()} with PYTHONHASHSEED={seed}",
-            pytrace=False,
+            f"{input_path.as_posix()} with PYTHONHASHSEED={seed}"
         )
+        raise AssertionError(message) from exc
     return result.stdout
 
 

--- a/tests/main/test_generation_determinism.py
+++ b/tests/main/test_generation_determinism.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import pytest
 
@@ -43,6 +43,18 @@ if not isinstance(result, str):
 sys.stdout.write(result)
 """
 
+HASH_SEED_TIMEOUT_SECONDS = 60
+DETERMINISM_CASES = [
+    pytest.param(
+        DeterminismCase(JSON_SCHEMA_DATA_PATH / "person.json", InputFileType.JsonSchema),
+        id="jsonschema-person",
+    ),
+    pytest.param(
+        DeterminismCase(OPEN_API_DATA_PATH / "api.yaml", InputFileType.OpenAPI),
+        id="openapi-api",
+    ),
+]
+
 
 def _generate_output(input_path: Path, input_file_type: InputFileType) -> str:
     result = generate(
@@ -51,53 +63,56 @@ def _generate_output(input_path: Path, input_file_type: InputFileType) -> str:
         disable_timestamp=True,
         formatters=[],
     )
-    if isinstance(result, str):
-        return result
+    if not isinstance(result, str):  # pragma: no cover
+        message = f"Expected generated output to be str, got {type(result).__name__}"
+        raise TypeError(message)
 
-    pytest.fail(f"Expected generated output to be str, got {type(result).__name__}")  # pragma: no cover
+    return result
+
+
+def _fail_with_diff(first: str, second: str, context: str) -> NoReturn:  # pragma: no cover
+    diff = "\n".join(
+        difflib.unified_diff(
+            first.splitlines(),
+            second.splitlines(),
+            fromfile="first",
+            tofile="second",
+            lineterm="",
+        )
+    )
+    pytest.fail(f"Generated output changed for {context}:\n{diff}", pytrace=False)
 
 
 def _assert_same_output(first: str, second: str, context: str) -> None:
     if first == second:
         return
 
-    if first != second:  # pragma: no cover
-        diff = "\n".join(
-            difflib.unified_diff(
-                first.splitlines(),
-                second.splitlines(),
-                fromfile="first",
-                tofile="second",
-                lineterm="",
-            )
-        )
-        pytest.fail(f"Generated output changed for {context}:\n{diff}", pytrace=False)
+    _fail_with_diff(first, second, context)
 
 
 def _generate_output_with_hash_seed(input_path: Path, input_file_type: InputFileType, seed: str) -> str:
     env = {**os.environ, "PYTHONHASHSEED": seed}
-    result = subprocess.run(
-        [sys.executable, "-c", HASH_SEED_SCRIPT, str(input_path), input_file_type.value],
-        check=True,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", HASH_SEED_SCRIPT, str(input_path), input_file_type.value],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=HASH_SEED_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:  # pragma: no cover
+        pytest.fail(
+            f"Generation timed out after {HASH_SEED_TIMEOUT_SECONDS}s for "
+            f"{input_path.as_posix()} with PYTHONHASHSEED={seed}",
+            pytrace=False,
+        )
     return result.stdout
 
 
 @pytest.mark.parametrize(
     "case",
-    [
-        pytest.param(
-            DeterminismCase(JSON_SCHEMA_DATA_PATH / "person.json", InputFileType.JsonSchema),
-            id="jsonschema-person",
-        ),
-        pytest.param(
-            DeterminismCase(OPEN_API_DATA_PATH / "api.yaml", InputFileType.OpenAPI),
-            id="openapi-api",
-        ),
-    ],
+    DETERMINISM_CASES,
 )
 def test_generate_output_is_repeatable(case: DeterminismCase) -> None:
     """Repeated generation in one process should be byte-stable."""
@@ -107,10 +122,13 @@ def test_generate_output_is_repeatable(case: DeterminismCase) -> None:
     _assert_same_output(first, second, case.input_path.as_posix())
 
 
-def test_generate_output_is_stable_across_hash_seeds() -> None:
+@pytest.mark.parametrize(
+    "case",
+    DETERMINISM_CASES,
+)
+def test_generate_output_is_stable_across_hash_seeds(case: DeterminismCase) -> None:
     """Representative output should not depend on hash iteration order."""
-    input_path = JSON_SCHEMA_DATA_PATH / "person.json"
-    seed_zero_output = _generate_output_with_hash_seed(input_path, InputFileType.JsonSchema, "0")
-    seed_one_output = _generate_output_with_hash_seed(input_path, InputFileType.JsonSchema, "1")
+    seed_zero_output = _generate_output_with_hash_seed(case.input_path, case.input_file_type, "0")
+    seed_one_output = _generate_output_with_hash_seed(case.input_path, case.input_file_type, "1")
 
-    _assert_same_output(seed_zero_output, seed_one_output, "jsonschema-person hash seeds")
+    _assert_same_output(seed_zero_output, seed_one_output, f"{case.input_path.as_posix()} hash seeds")

--- a/tests/main/test_generation_determinism.py
+++ b/tests/main/test_generation_determinism.py
@@ -87,7 +87,7 @@ def _assert_same_output(first: str, second: str, context: str) -> None:
     if first == second:
         return
 
-    _fail_with_diff(first, second, context)
+    _fail_with_diff(first, second, context)  # pragma: no cover
 
 
 def _generate_output_with_hash_seed(input_path: Path, input_file_type: InputFileType, seed: str) -> str:

--- a/tests/main/test_generation_determinism.py
+++ b/tests/main/test_generation_determinism.py
@@ -1,0 +1,115 @@
+"""Determinism guards for representative code generation paths."""
+
+from __future__ import annotations
+
+import difflib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from datamodel_code_generator import InputFileType, generate
+from tests.main.conftest import JSON_SCHEMA_DATA_PATH, OPEN_API_DATA_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DeterminismCase:
+    """Representative input for a deterministic generation check."""
+
+    input_path: Path
+    input_file_type: InputFileType
+
+
+HASH_SEED_SCRIPT = """
+from pathlib import Path
+import sys
+
+from datamodel_code_generator import InputFileType, generate
+
+result = generate(
+    input_=Path(sys.argv[1]),
+    input_file_type=InputFileType(sys.argv[2]),
+    disable_timestamp=True,
+    formatters=[],
+)
+if not isinstance(result, str):
+    raise TypeError(f"Expected generated output to be str, got {type(result).__name__}")
+sys.stdout.write(result)
+"""
+
+
+def _generate_output(input_path: Path, input_file_type: InputFileType) -> str:
+    result = generate(
+        input_=input_path,
+        input_file_type=input_file_type,
+        disable_timestamp=True,
+        formatters=[],
+    )
+    if isinstance(result, str):
+        return result
+
+    pytest.fail(f"Expected generated output to be str, got {type(result).__name__}")  # pragma: no cover
+
+
+def _assert_same_output(first: str, second: str, context: str) -> None:
+    if first == second:
+        return
+
+    diff = "\n".join(
+        difflib.unified_diff(
+            first.splitlines(),
+            second.splitlines(),
+            fromfile="first",
+            tofile="second",
+            lineterm="",
+        )
+    )
+    pytest.fail(f"Generated output changed for {context}:\n{diff}", pytrace=False)
+
+
+def _generate_output_with_hash_seed(input_path: Path, input_file_type: InputFileType, seed: str) -> str:
+    env = {**os.environ, "PYTHONHASHSEED": seed}
+    result = subprocess.run(
+        [sys.executable, "-c", HASH_SEED_SCRIPT, str(input_path), input_file_type.value],
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            DeterminismCase(JSON_SCHEMA_DATA_PATH / "person.json", InputFileType.JsonSchema),
+            id="jsonschema-person",
+        ),
+        pytest.param(
+            DeterminismCase(OPEN_API_DATA_PATH / "api.yaml", InputFileType.OpenAPI),
+            id="openapi-api",
+        ),
+    ],
+)
+def test_generate_output_is_repeatable(case: DeterminismCase) -> None:
+    """Repeated generation in one process should be byte-stable."""
+    first = _generate_output(case.input_path, case.input_file_type)
+    second = _generate_output(case.input_path, case.input_file_type)
+
+    _assert_same_output(first, second, case.input_path.as_posix())
+
+
+def test_generate_output_is_stable_across_hash_seeds() -> None:
+    """Representative output should not depend on hash iteration order."""
+    input_path = JSON_SCHEMA_DATA_PATH / "person.json"
+    seed_zero_output = _generate_output_with_hash_seed(input_path, InputFileType.JsonSchema, "0")
+    seed_one_output = _generate_output_with_hash_seed(input_path, InputFileType.JsonSchema, "1")
+
+    _assert_same_output(seed_zero_output, seed_one_output, "jsonschema-person hash seeds")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added determinism checks to ensure generated output is identical when re-run in the same Python process.
  * Added stability verification to confirm output is unchanged across different `PYTHONHASHSEED` values (run in a separate subprocess).
  * Improved diagnostics by reporting mismatches with unified diffs and added a timeout guard for the subprocess run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->