### PR TITLE
Shard Python 3.14 coverage job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,9 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tox_env: py314-parallel
-            name: "3.14"
-            coverage_name: "3.14"
           - tox_env: pydantic20
             name: pydantic20
             coverage_name: pydantic20
@@ -254,6 +251,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - tox_env: py314-parallel
+            name: "3.14"
+            os: ubuntu-24.04
+            coverage: true
+            shard: 1
+            shard_total: 2
+          - tox_env: py314-parallel
+            name: "3.14"
+            os: ubuntu-24.04
+            coverage: true
+            shard: 2
+            shard_total: 2
           - tox_env: py313-parallel
             name: "3.13"
             os: ubuntu-24.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -257,6 +257,7 @@ jobs:
             coverage: true
             shard: 1
             shard_total: 2
+            extra_tests: tests/cli_doc/test_cli_options_sync.py
           - tox_env: py314-parallel
             name: "3.14"
             os: ubuntu-24.04
@@ -401,6 +402,7 @@ jobs:
       SHARD_INDEX: ${{ matrix.shard }}
       SHARD_TOTAL: ${{ matrix.shard_total }}
       TOX_ENV: ${{ matrix.tox_env }}
+      EXTRA_TESTS: ${{ matrix.extra_tests }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -424,6 +426,9 @@ jobs:
         python scripts/select_ci_test_shard.py --write-recipe .tox/ci-shard-recipe.json
         python scripts/select_ci_test_shard.py "$SHARD_INDEX" "$SHARD_TOTAL" \
           --recipe .tox/ci-shard-recipe.json | tee .tox/ci-shard-tests.txt
+        if [ -n "$EXTRA_TESTS" ]; then
+          printf '%s\n' "$EXTRA_TESTS" >> .tox/ci-shard-tests.txt
+        fi
       shell: bash
     - name: Run sharded test suite
       run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Python 3.14 CI configuration on Ubuntu by refactoring the coverage setup from a single parallel configuration to explicit shard entries (shard 1 and shard 2).
  * Added environment variable support for including additional test paths in the sharding process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->