### PR TITLE
Cache unsupported subinterpreter checks

### DIFF
--- a/tests/main/conftest.py
+++ b/tests/main/conftest.py
@@ -1284,7 +1284,7 @@ def _get_concurrent_interpreters_module() -> Any | None:
     return interpreters
 
 
-_SUBINTERPRETER_UNSUPPORTED = False
+_SUBINTERPRETER_UNSUPPORTED: list[None] = []
 
 
 def _is_subinterpreter_unsupported_import_error(exception: BaseException) -> bool:
@@ -1304,7 +1304,6 @@ def _is_subinterpreter_unsupported_import_error(exception: BaseException) -> boo
 
 
 def _try_import_generated_output_in_subinterpreter(output_path: Path) -> bool:
-    global _SUBINTERPRETER_UNSUPPORTED  # noqa: PLW0603
     if _SUBINTERPRETER_UNSUPPORTED:
         return False
 
@@ -1318,7 +1317,7 @@ def _try_import_generated_output_in_subinterpreter(output_path: Path) -> bool:
     except Exception as exception:
         if _is_subinterpreter_unsupported_import_error(exception):
             # Keep import validation active when an extension dependency cannot run in subinterpreters.
-            _SUBINTERPRETER_UNSUPPORTED = True
+            _SUBINTERPRETER_UNSUPPORTED.append(None)
             return False
         raise
     finally:

--- a/tests/main/conftest.py
+++ b/tests/main/conftest.py
@@ -1284,19 +1284,30 @@ def _get_concurrent_interpreters_module() -> Any | None:
     return interpreters
 
 
+_SUBINTERPRETER_UNSUPPORTED = False
+
+
 def _is_subinterpreter_unsupported_import_error(exception: BaseException) -> bool:
     messages = [str(exception)]
-    excinfo = getattr(exception, "excinfo", None)
-    if excinfo is not None:
+    if (excinfo := getattr(exception, "excinfo", None)) is not None:
         messages.append(str(excinfo))
-    return any(
-        "does not support loading in subinterpreter" in message
-        or "does not support loading in subinterpreters" in message
-        for message in messages
-    )
+    for message in messages:
+        match message:
+            case str() if (
+                "does not support loading in subinterpreter" in message
+                or "does not support loading in subinterpreters" in message
+            ):
+                return True
+            case _:
+                continue
+    return False
 
 
 def _try_import_generated_output_in_subinterpreter(output_path: Path) -> bool:
+    global _SUBINTERPRETER_UNSUPPORTED  # noqa: PLW0603
+    if _SUBINTERPRETER_UNSUPPORTED:
+        return False
+
     interpreters = _get_concurrent_interpreters_module()
     if interpreters is None:
         return False
@@ -1307,6 +1318,7 @@ def _try_import_generated_output_in_subinterpreter(output_path: Path) -> bool:
     except Exception as exception:
         if _is_subinterpreter_unsupported_import_error(exception):
             # Keep import validation active when an extension dependency cannot run in subinterpreters.
+            _SUBINTERPRETER_UNSUPPORTED = True
             return False
         raise
     finally:

--- a/tests/main/test_exec_validation.py
+++ b/tests/main/test_exec_validation.py
@@ -62,6 +62,11 @@ class _FakeInterpreters:
         return interpreter
 
 
+@pytest.fixture(autouse=True)
+def _reset_subinterpreter_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main_conftest, "_SUBINTERPRETER_UNSUPPORTED", False)
+
+
 @_SKIP_BLACK
 def test_openapi_api_exec_current_version(output_file: Path) -> None:
     """Test that api.yaml schema generates executable code on current Python."""
@@ -194,6 +199,22 @@ def test_try_import_generated_output_falls_back_for_unsupported_subinterpreter_e
     monkeypatch.setattr(main_conftest, "_get_concurrent_interpreters_module", lambda: fake_interpreters)
 
     assert not _try_import_generated_output_in_subinterpreter(output_file)
+    assert fake_interpreters.instances[0].closed
+
+
+@pytest.mark.allow_direct_assert
+def test_try_import_generated_output_caches_unsupported_subinterpreter_extension(
+    output_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test subinterpreter-incompatible extensions are detected once per worker."""
+    fake_interpreters = _FakeInterpreters(
+        RuntimeError("ImportError: module _pydantic_core does not support loading in subinterpreter")
+    )
+    monkeypatch.setattr(main_conftest, "_get_concurrent_interpreters_module", lambda: fake_interpreters)
+
+    assert not _try_import_generated_output_in_subinterpreter(output_file)
+    assert not _try_import_generated_output_in_subinterpreter(output_file)
+    assert len(fake_interpreters.instances) == 1
     assert fake_interpreters.instances[0].closed
 
 

--- a/tests/main/test_exec_validation.py
+++ b/tests/main/test_exec_validation.py
@@ -156,6 +156,25 @@ def test_validate_output_files_imports_generated_file(tmp_path: Path, monkeypatc
 
 
 @pytest.mark.allow_direct_assert
+def test_validate_output_files_uses_successful_subinterpreter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test generated single-file outputs skip normal import after subinterpreter validation."""
+    sentinel = tmp_path / "sentinel.txt"
+    output_file = tmp_path / "output.py"
+    output_file.write_text(
+        f"from pathlib import Path\nPath({str(sentinel)!r}).write_text('imported', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    fake_interpreters = _FakeInterpreters()
+    monkeypatch.setattr(main_conftest, "_get_concurrent_interpreters_module", lambda: fake_interpreters)
+
+    _validate_output_files(output_file, get_current_version_args(), force_exec_validation=True)
+
+    assert not sentinel.exists()
+    assert output_file.name in fake_interpreters.instances[0].executed_code
+    assert fake_interpreters.instances[0].closed
+
+
+@pytest.mark.allow_direct_assert
 def test_validate_output_files_imports_generated_package_modules(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/main/test_exec_validation.py
+++ b/tests/main/test_exec_validation.py
@@ -64,7 +64,7 @@ class _FakeInterpreters:
 
 @pytest.fixture(autouse=True)
 def _reset_subinterpreter_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(main_conftest, "_SUBINTERPRETER_UNSUPPORTED", False)
+    monkeypatch.setattr(main_conftest, "_SUBINTERPRETER_UNSUPPORTED", [])
 
 
 @_SKIP_BLACK


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of when generated-output imports can’t run in subinterpreter environments, and avoids retrying after the first confirmed unsupported case.
  * Added caching so unsupported scenarios reuse the same decision instead of repeating setup.

* **Tests**
  * Added fixtures to reset the unsupported-import state before each test run.
  * Extended validation coverage to confirm successful subinterpreter execution doesn’t trigger the normal import side effect, and added checks that repeated unsupported attempts are cached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->