### PR TITLE
Register snapshot formats once

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1225,7 +1225,7 @@ def _isolate_builtin_formatter_config(
     monkeypatch.chdir(settings_path)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def _inline_snapshot_file_formats() -> None:
     register_format_alias(".py", ".txt")
     register_format_alias(".pyi", ".txt")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test setup so snapshot format registration runs once per test session instead of before every test, improving test efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->