### PR TITLE
Keep generate string input inline

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35738,8 +35738,9 @@ print(result)
 
 ### 📝 Reading Input From a File
 
-Pass a `Path` to `input_` for file input. A string passed to `input_` is treated
-as schema text.
+Pass a `Path` to `input_` for file input. Plain strings are treated as schema
+text; if a string points to an existing file and parsing fails, `generate()`
+warns and recommends using `Path`.
 
 ```python
 from pathlib import Path

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -35736,6 +35736,23 @@ result = generate(json_schema, config=config)
 print(result)
 ```
 
+### 📝 Reading Input From a File
+
+Pass a `Path` to `input_` for file input. A string passed to `input_` is treated
+as schema text.
+
+```python
+from pathlib import Path
+
+from datamodel_code_generator import InputFileType, generate
+
+result = generate(
+    input_=Path("example.json"),
+    input_file_type=InputFileType.JsonSchema,
+)
+print(result)
+```
+
 ### 📝 Multiple Module Output
 
 When the schema generates multiple modules, `generate()` returns a `GeneratedModules` dictionary mapping module path tuples to generated code:
@@ -35743,7 +35760,7 @@ When the schema generates multiple modules, `generate()` returns a `GeneratedMod
 ```python
 from datamodel_code_generator import InputFileType, generate, GenerateConfig, GeneratedModules
 
-# Your OpenAPI specification (string, Path, or dict)
+# Your OpenAPI specification (string schema text, Path, or dict)
 openapi_spec: str = "..."  # Replace with your actual OpenAPI spec
 
 # Schema that generates multiple modules (e.g., with $ref to other files)

--- a/docs/using_as_module.md
+++ b/docs/using_as_module.md
@@ -44,8 +44,9 @@ print(result)
 
 ### 📝 Reading Input From a File
 
-Pass a `Path` to `input_` for file input. A string passed to `input_` is treated
-as schema text.
+Pass a `Path` to `input_` for file input. Plain strings are treated as schema
+text; if a string points to an existing file and parsing fails, `generate()`
+warns and recommends using `Path`.
 
 ```python
 from pathlib import Path

--- a/docs/using_as_module.md
+++ b/docs/using_as_module.md
@@ -42,6 +42,23 @@ result = generate(json_schema, config=config)
 print(result)
 ```
 
+### 📝 Reading Input From a File
+
+Pass a `Path` to `input_` for file input. A string passed to `input_` is treated
+as schema text.
+
+```python
+from pathlib import Path
+
+from datamodel_code_generator import InputFileType, generate
+
+result = generate(
+    input_=Path("example.json"),
+    input_file_type=InputFileType.JsonSchema,
+)
+print(result)
+```
+
 ### 📝 Multiple Module Output
 
 When the schema generates multiple modules, `generate()` returns a `GeneratedModules` dictionary mapping module path tuples to generated code:
@@ -49,7 +66,7 @@ When the schema generates multiple modules, `generate()` returns a `GeneratedMod
 ```python
 from datamodel_code_generator import InputFileType, generate, GenerateConfig, GeneratedModules
 
-# Your OpenAPI specification (string, Path, or dict)
+# Your OpenAPI specification (string schema text, Path, or dict)
 openapi_spec: str = "..."  # Replace with your actual OpenAPI spec
 
 # Schema that generates multiple modules (e.g., with $ref to other files)

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -777,11 +777,23 @@ def _warn_if_input_string_points_to_existing_path(
 
     import warnings  # noqa: PLC0415
 
-    warnings.warn(
-        "`input_` strings are treated as schema text. "
-        "The value also resolves to an existing path; pass a `Path` object to read it as a file.",
-        stacklevel=3,
-    )
+    with contextlib.suppress(Warning):
+        warnings.warn(
+            "`input_` strings are treated as schema text. "
+            "The value also resolves to an existing path; pass a `Path` object to read it as a file.",
+            stacklevel=3,
+        )
+
+
+@contextlib.contextmanager
+def _warn_on_input_string_path_failure(
+    input_: Path | str | ParseResult | Mapping[str, Any] | list[Any],
+) -> Iterator[None]:
+    try:
+        yield
+    except Exception:
+        _warn_if_input_string_points_to_existing_path(input_)
+        raise
 
 
 def _create_parser_config(
@@ -1450,10 +1462,10 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             raise Error(msg) from exc
 
         try:
-            assert isinstance(input_text_, str)
-            input_file_type = infer_input_type(input_text_)
+            with _warn_on_input_string_path_failure(input_):
+                assert isinstance(input_text_, str)
+                input_file_type = infer_input_type(input_text_)
         except Exception as exc:
-            _warn_if_input_string_points_to_existing_path(input_)
             raise InvalidFileFormatError(exc) from exc
         else:
             print(  # noqa: T201
@@ -1465,23 +1477,17 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             if isinstance(input_, Path) and input_.is_file() and input_file_type not in RAW_DATA_TYPES:
                 input_text = input_text_
 
-    try:
+    with _warn_on_input_string_path_failure(input_):
         input_text = _normalize_raw_input(input_, input_text, input_file_type, config)
-    except Exception:
-        _warn_if_input_string_points_to_existing_path(input_)
-        raise
 
     if input_file_type == InputFileType.MCPTools:
-        try:
+        with _warn_on_input_string_path_failure(input_):
             source_override, input_file_type, skip_root_model = _convert_mcp_tools(
                 input_,
                 input_text,
                 config,
                 remote_text_cache,
             )
-        except Exception:
-            _warn_if_input_string_points_to_existing_path(input_)
-            raise
 
     if isinstance(input_, ParseResult) and input_file_type not in RAW_DATA_TYPES:
         input_text = None
@@ -1502,7 +1508,7 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
         _resolve_schema_versions(input_file_type, config.schema_version)
     )
 
-    try:
+    with _warn_on_input_string_path_failure(input_):
         parser = _build_parser(
             input_file_type,
             source,
@@ -1515,22 +1521,19 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             xmlschema_version=xmlschema_version,
             protobuf_version=protobuf_version,
         )
-    except Exception:
-        _warn_if_input_string_points_to_existing_path(input_)
-        raise
 
     with chdir(config.output):
         try:
-            results = parser.parse(
-                settings_path=config.settings_path,
-                disable_future_imports=config.disable_future_imports,
-                all_exports_scope=config.all_exports_scope,
-                all_exports_collision_strategy=config.all_exports_collision_strategy,
-                module_split_mode=config.module_split_mode,
-                collect_model_metadata=config.emit_model_metadata is not None,
-            )
+            with _warn_on_input_string_path_failure(input_):
+                results = parser.parse(
+                    settings_path=config.settings_path,
+                    disable_future_imports=config.disable_future_imports,
+                    all_exports_scope=config.all_exports_scope,
+                    all_exports_collision_strategy=config.all_exports_collision_strategy,
+                    module_split_mode=config.module_split_mode,
+                    collect_model_metadata=config.emit_model_metadata is not None,
+                )
         except Exception:
-            _warn_if_input_string_points_to_existing_path(input_)
             with contextlib.suppress(BaseException):
                 parser._dispose()  # noqa: SLF001
             raise

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -106,8 +106,6 @@ Maps module path tuples (e.g., ("models", "user.py")) to generated code strings.
 Returned by generate() when output=None and multiple modules are generated.
 """
 
-_SCHEMA_TEXT_START_CHARS = ("{", "[", "<")
-
 
 def _apply_generate_config_preset(config: GenerateConfig) -> GenerateConfig:
     """Return a generate config with preset defaults applied."""
@@ -761,21 +759,29 @@ def _generate_config_values(generate_config: GenerateConfig) -> dict[str, Any]:
     return values
 
 
-def _coerce_existing_path_input(
+def _warn_if_input_string_points_to_existing_path(
     input_: Path | str | ParseResult | Mapping[str, Any] | list[Any],
-) -> Path | str | ParseResult | Mapping[str, Any] | list[Any]:
-    if not isinstance(input_, str):
-        return input_
-    if not input_ or "\n" in input_ or "\r" in input_:
-        return input_
-    if (stripped := input_.lstrip()).startswith(_SCHEMA_TEXT_START_CHARS) or "://" in stripped:
-        return input_
+) -> None:
+    match input_:
+        case str() as input_text if input_text and "\n" not in input_text and "\r" not in input_text:
+            pass
+        case _:
+            return
     try:
-        path = Path(input_).expanduser()
+        path = Path(input_text).expanduser()
         path_exists = path.exists()
-    except (OSError, RuntimeError, ValueError):  # pragma: no cover
-        return input_
-    return path if path_exists else input_
+    except (OSError, RuntimeError, ValueError):
+        return
+    if not path_exists:
+        return
+
+    import warnings  # noqa: PLC0415
+
+    warnings.warn(
+        "`input_` strings are treated as schema text. "
+        "The value also resolves to an existing path; pass a `Path` object to read it as a file.",
+        stacklevel=3,
+    )
 
 
 def _create_parser_config(
@@ -1320,7 +1326,7 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
     (JSON, YAML, Dict, CSV) as input.
 
     Args:
-        input_: The input source (file path, string content, URL, dict,
+        input_: The input source (Path file input, string content, URL, dict,
             list of file paths, or MCP tools list when input_file_type is
             InputFileType.MCPTools).
         config: A GenerateConfig object with all options. Cannot be used together with **options.
@@ -1360,8 +1366,6 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
     custom_file_header = config.custom_file_header
     skip_root_model = config.skip_root_model
     source_override: Mapping[str, Any] | None = None
-
-    input_ = _coerce_existing_path_input(input_)
 
     if (
         isinstance(input_, list)
@@ -1449,6 +1453,7 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             assert isinstance(input_text_, str)
             input_file_type = infer_input_type(input_text_)
         except Exception as exc:
+            _warn_if_input_string_points_to_existing_path(input_)
             raise InvalidFileFormatError(exc) from exc
         else:
             print(  # noqa: T201
@@ -1460,15 +1465,23 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             if isinstance(input_, Path) and input_.is_file() and input_file_type not in RAW_DATA_TYPES:
                 input_text = input_text_
 
-    input_text = _normalize_raw_input(input_, input_text, input_file_type, config)
+    try:
+        input_text = _normalize_raw_input(input_, input_text, input_file_type, config)
+    except Exception:
+        _warn_if_input_string_points_to_existing_path(input_)
+        raise
 
     if input_file_type == InputFileType.MCPTools:
-        source_override, input_file_type, skip_root_model = _convert_mcp_tools(
-            input_,
-            input_text,
-            config,
-            remote_text_cache,
-        )
+        try:
+            source_override, input_file_type, skip_root_model = _convert_mcp_tools(
+                input_,
+                input_text,
+                config,
+                remote_text_cache,
+            )
+        except Exception:
+            _warn_if_input_string_points_to_existing_path(input_)
+            raise
 
     if isinstance(input_, ParseResult) and input_file_type not in RAW_DATA_TYPES:
         input_text = None
@@ -1489,18 +1502,22 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
         _resolve_schema_versions(input_file_type, config.schema_version)
     )
 
-    parser = _build_parser(
-        input_file_type,
-        source,
-        config,
-        additional_options,
-        data_model_types,
-        jsonschema_version=jsonschema_version,
-        openapi_version=openapi_version,
-        asyncapi_version=asyncapi_version,
-        xmlschema_version=xmlschema_version,
-        protobuf_version=protobuf_version,
-    )
+    try:
+        parser = _build_parser(
+            input_file_type,
+            source,
+            config,
+            additional_options,
+            data_model_types,
+            jsonschema_version=jsonschema_version,
+            openapi_version=openapi_version,
+            asyncapi_version=asyncapi_version,
+            xmlschema_version=xmlschema_version,
+            protobuf_version=protobuf_version,
+        )
+    except Exception:
+        _warn_if_input_string_points_to_existing_path(input_)
+        raise
 
     with chdir(config.output):
         try:
@@ -1512,6 +1529,11 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
                 module_split_mode=config.module_split_mode,
                 collect_model_metadata=config.emit_model_metadata is not None,
             )
+        except Exception:
+            _warn_if_input_string_points_to_existing_path(input_)
+            with contextlib.suppress(BaseException):
+                parser._dispose()  # noqa: SLF001
+            raise
         except BaseException:
             with contextlib.suppress(BaseException):
                 parser._dispose()  # noqa: SLF001

--- a/tests/data/expected/main/generate_accepts_path_input.py
+++ b/tests/data/expected/main/generate_accepts_path_input.py
@@ -2,13 +2,17 @@
 #   filename:  person.json
 
 from __future__ import annotations
-from pydantic import BaseModel, Field, conint
+
 from typing import Any
+
+from pydantic import BaseModel, Field, conint
 
 
 class Person(BaseModel):
     firstName: str | None = Field(None, description="The person's first name.")
     lastName: str | None = Field(None, description="The person's last name.")
-    age: conint(ge=0) | None = Field(None, description='Age in years which must be equal to or greater than zero.')
+    age: conint(ge=0) | None = Field(
+        None, description='Age in years which must be equal to or greater than zero.'
+    )
     friends: list[Any] | None = None
     comment: None = Field(None)

--- a/tests/data/expected/main/generate_keeps_existing_path_string_input.py
+++ b/tests/data/expected/main/generate_keeps_existing_path_string_input.py
@@ -2,6 +2,7 @@
 #   filename:  inline.yaml
 
 from __future__ import annotations
+
 from pydantic import RootModel
 
 

--- a/tests/data/expected/main/generate_keeps_non_path_string_input.py
+++ b/tests/data/expected/main/generate_keeps_non_path_string_input.py
@@ -2,6 +2,7 @@
 #   filename:  inline.yaml
 
 from __future__ import annotations
+
 from pydantic import BaseModel
 
 

--- a/tests/main/test_main_general.py
+++ b/tests/main/test_main_general.py
@@ -2869,45 +2869,79 @@ def test_generate_returns_string_when_output_none() -> None:
     )
 
 
-def test_generate_accepts_string_path(output_file: Path) -> None:
-    """Test generate() reads existing string paths as local schema files."""
-    result = generate(
-        input_=str(JSON_SCHEMA_DATA_PATH / "person.json"),
+def test_generate_accepts_path_input(output_file: Path) -> None:
+    """Test generate() reads Path inputs as local schema files."""
+    run_generate_file_and_assert(
+        input_path=JSON_SCHEMA_DATA_PATH / "person.json",
+        output_path=output_file,
         input_file_type=InputFileType.JsonSchema,
-        output=output_file,
         disable_timestamp=True,
-        formatters=[],
+        assert_func=assert_file_content,
+        expected_file="generate_accepts_path_input.py",
     )
-    assert_generate_wrote_file(result, output_file)
-    assert_file_content(output_file, "generate_accepts_string_path.py")
 
 
-def test_generate_keeps_non_path_string_input(output_file: Path) -> None:
+def test_generate_keeps_existing_path_string_input() -> None:
+    """Test generate() keeps existing path strings as inline source text."""
+    run_generate_and_assert(
+        input_=str(JSON_SCHEMA_DATA_PATH / "person.json"),
+        input_file_type=InputFileType.Yaml,
+        input_filename="inline.yaml",
+        disable_timestamp=True,
+        expected_file=EXPECTED_MAIN_PATH / "generate_keeps_existing_path_string_input.py",
+    )
+
+
+def test_generate_keeps_non_path_string_input() -> None:
     """Test generate() keeps non-path strings as inline source text."""
-    result = generate(
+    run_generate_and_assert(
         input_="name: Alice",
         input_file_type=InputFileType.Yaml,
         input_filename="inline.yaml",
-        output=output_file,
         disable_timestamp=True,
-        formatters=[],
+        expected_file=EXPECTED_MAIN_PATH / "generate_keeps_non_path_string_input.py",
     )
-    assert_generate_wrote_file(result, output_file)
-    assert_file_content(output_file, "generate_keeps_non_path_string_input.py")
 
 
-def test_generate_keeps_string_input_when_expanduser_fails(output_file: Path) -> None:
-    """Test generate() keeps inline strings when user expansion fails."""
-    result = generate(
-        input_="~this-user-should-not-exist-20260703/schema.yaml",
-        input_file_type=InputFileType.Yaml,
-        input_filename="inline.yaml",
-        output=output_file,
-        disable_timestamp=True,
-        formatters=[],
+def test_generate_warns_when_input_string_is_existing_path_on_failure(tmp_path: Path) -> None:
+    """Test failed string input warns when the value is an existing path."""
+    input_path = tmp_path / "schema.json"
+    input_path.write_text("{", encoding="utf-8")
+
+    with pytest.warns(UserWarning, match="Path"), pytest.raises(Error):
+        generate(
+            input_=str(input_path),
+            input_file_type=InputFileType.Json,
+            disable_timestamp=True,
+            formatters=[],
+        )
+
+
+def test_generate_does_not_warn_for_non_existing_path_string_on_failure(tmp_path: Path) -> None:
+    """Test failed string input only warns for values resolving to existing paths."""
+    invalid_input_path = tmp_path / "invalid.json"
+    invalid_input_path.write_text("{", encoding="utf-8")
+
+    failed_inputs: tuple[Path | str, ...] = (
+        invalid_input_path,
+        "not\njson",
+        str(tmp_path / "missing.json"),
+        "~this-user-should-not-exist-20260703/schema.json",
     )
-    assert_generate_wrote_file(result, output_file)
-    assert_file_content(output_file, "generate_keeps_unresolved_user_path_string_input.py")
+    for failed_input in failed_inputs:
+        with warnings.catch_warnings(record=True) as warning_records:
+            warnings.simplefilter("always")
+            with pytest.raises(Error):
+                generate(
+                    input_=failed_input,
+                    input_file_type=InputFileType.Json,
+                    disable_timestamp=True,
+                    formatters=[],
+                )
+        assert_warnings_do_not_contain(
+            warning_records,
+            "pass a `Path` object to read it as a file",
+        )
 
 
 def test_generate_returns_string_with_pydantic_v2() -> None:

--- a/tests/main/test_main_general.py
+++ b/tests/main/test_main_general.py
@@ -2917,6 +2917,22 @@ def test_generate_warns_when_input_string_is_existing_path_on_failure(tmp_path: 
         )
 
 
+def test_generate_warning_does_not_mask_original_error_with_strict_warning_filter(tmp_path: Path) -> None:
+    """Test strict warning filters do not replace the original generate error."""
+    input_path = tmp_path / "schema.json"
+    input_path.write_text("{", encoding="utf-8")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        with pytest.raises(Error):
+            generate(
+                input_=str(input_path),
+                input_file_type=InputFileType.Json,
+                disable_timestamp=True,
+                formatters=[],
+            )
+
+
 def test_generate_does_not_warn_for_non_existing_path_string_on_failure(tmp_path: Path) -> None:
     """Test failed string input only warns for values resolving to existing paths."""
     invalid_input_path = tmp_path / "invalid.json"


### PR DESCRIPTION
Fixes: #2381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/updated guidance for reading schema input from a file path.
  * Refreshed the multiple-module output example for clearer alignment.

* **Bug Fixes**
  * Improved input handling for strings that resemble file paths: they’re treated as inline schema text unless a path input is explicitly provided.
  * Added clearer warning behavior to help distinguish “string is schema text” vs “string points to an existing file” scenarios when parsing fails.

* **Tests**
  * Expanded coverage for `Path` vs string input behavior, including warning and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->