### PR TITLE
Skip docs preview deploy for dependabot PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,12 +16,12 @@ jobs:
     uses: ./.github/workflows/docs-deploy.yaml
     with:
       checkout_ref: ${{ github.event.pull_request.head.sha }}
-      # Fork PRs run the docs build only. Only same-repo PRs get a deploy
-      # branch and Cloudflare secrets for preview deployment.
-      deploy_branch: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('pr-{0}', github.event.pull_request.number) || '' }}
+      # Fork PRs and dependabot run the docs build only: they have no access to the
+      # Cloudflare secrets, so skip the deploy branch to avoid a failing wrangler step.
+      deploy_branch: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && format('pr-{0}', github.event.pull_request.number) || '' }}
     secrets:
-      CLOUDFLARE_API_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.CLOUDFLARE_API_TOKEN || '' }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ github.event.pull_request.head.repo.full_name == github.repository && secrets.CLOUDFLARE_ACCOUNT_ID || '' }}
+      CLOUDFLARE_API_TOKEN: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.CLOUDFLARE_API_TOKEN || '' }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.CLOUDFLARE_ACCOUNT_ID || '' }}
 
   build-production:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
@@ -36,7 +36,7 @@ jobs:
   comment-preview:
     runs-on: ubuntu-24.04
     needs: build-preview
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
Dependabot runs receive an empty `CLOUDFLARE_API_TOKEN` (secrets come from the separate Dependabot secret store), so the `wrangler pages deploy` step in `build-preview` fails on every dependabot PR:

```
ERROR: In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable
```

Gate the preview `deploy_branch`, the Cloudflare secrets, and the preview-comment job on `github.actor != 'dependabot[bot]'`, so dependabot PRs build the docs without attempting a deploy. Clears `build-preview / build-deploy` on e.g. #3540 and #3567 once they rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request preview handling so automated dependency updates no longer trigger deployment or preview comments.
  * Preview deployments now run only for same-repository pull requests from non-automated accounts, reducing unintended build activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->