### PR TITLE
Cache rendered template field values

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -984,16 +984,18 @@ def _get_environment(template_subdir: Path, custom_template_dir: Path | None) ->
     from jinja2 import ChoiceLoader, FileSystemLoader  # noqa: PLC0415
 
     loaders: list[FileSystemLoader] = []
+    has_custom_loader = False
 
     if custom_template_dir is not None:
         custom_dir = custom_template_dir / template_subdir
         if cached_path_exists(custom_dir):
             loaders.append(FileSystemLoader(str(custom_dir)))
+            has_custom_loader = True
 
     loaders.append(FileSystemLoader(str(TEMPLATE_DIR / template_subdir)))
 
     loader: ChoiceLoader | FileSystemLoader = ChoiceLoader(loaders) if len(loaders) > 1 else loaders[0]
-    return _build_environment(loader, auto_reload=custom_template_dir is not None)
+    return _build_environment(loader, auto_reload=has_custom_loader)
 
 
 @lru_cache

--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -220,27 +220,25 @@ def _safe_extra_template_data(extra_template_data: dict[str, Any]) -> dict[str, 
 class _RenderedDataModelField:
     """Proxy a field with a pre-rendered docstring for built-in templates."""
 
-    __slots__ = ("_cache", "_field", "docstring")
-
     def __init__(self, field: DataModelFieldBase, docstring: str) -> None:
-        self._field = field
-        self._cache: dict[str, Any] = {}
-        self.docstring = docstring
+        field_values = self.__dict__
+        field_values["_field"] = field
+        field_values["docstring"] = docstring
 
     def __getattr__(self, name: str) -> Any:
-        try:
-            return self._cache[name]
-        except KeyError:
-            if name in {"annotated", "field"} and (
-                rendered_field_values := getattr(self._field, "_rendered_field_values", None)
-            ):
-                field, annotated = rendered_field_values()
-                self._cache["field"] = field
-                self._cache["annotated"] = annotated
-                return self._cache[name]
-            value = getattr(self._field, name)
-            self._cache[name] = value
-            return value
+        field_values = self.__dict__
+        field = field_values["_field"]
+        if (
+            name in {"annotated", "field"}
+            and (rendered_field_values := getattr(field, "_rendered_field_values", None)) is not None
+        ):
+            rendered_field, annotated = rendered_field_values()
+            field_values["field"] = rendered_field
+            field_values["annotated"] = annotated
+            return field_values[name]
+        value = getattr(field, name)
+        field_values[name] = value
+        return value
 
 
 ALL_MODEL: str = "#all#"
@@ -965,13 +963,14 @@ def _nested_model_default_factory(field: DataModelFieldBase, model_cls: type[Dat
     return None
 
 
-def _build_environment(loader: Any) -> Environment:
+def _build_environment(loader: Any, *, auto_reload: bool = True) -> Environment:
     """Build a Jinja environment with built-in filters."""
     from jinja2 import Environment, select_autoescape  # noqa: PLC0415
 
     env = Environment(
         loader=loader,
         autoescape=select_autoescape(["html", "xml"]),
+        auto_reload=auto_reload,
     )
     env.filters["escape_docstring"] = escape_docstring  # For old custom templates
     env.filters["format_docstring"] = format_docstring
@@ -994,7 +993,7 @@ def _get_environment(template_subdir: Path, custom_template_dir: Path | None) ->
     loaders.append(FileSystemLoader(str(TEMPLATE_DIR / template_subdir)))
 
     loader: ChoiceLoader | FileSystemLoader = ChoiceLoader(loaders) if len(loaders) > 1 else loaders[0]
-    return _build_environment(loader)
+    return _build_environment(loader, auto_reload=custom_template_dir is not None)
 
 
 @lru_cache

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -24,6 +24,8 @@ from datamodel_code_generator.model.base import (
     DataModelFieldBase,
     TemplateBase,
     _annotation_typing_import_names,
+    _get_environment,
+    _get_environment_with_absolute_path,
     _RenderedDataModelField,
     _TypingImportRequirements,
     comment_safe,
@@ -283,6 +285,77 @@ def test_rendered_pydantic_v2_class_var_field_values_are_none() -> None:
     assert field.field is None
     assert rendered_field.field is None
     assert rendered_field.annotated is None
+
+
+def test_rendered_data_model_field_caches_delegated_attributes() -> None:
+    """Test delegated field attributes are stored directly on the rendered proxy."""
+
+    @dataclass
+    class DelegatedField:
+        """Test field with counted attribute access."""
+
+        calls: int = 0
+
+        @property
+        def value(self) -> str:
+            """Return a counted delegated value."""
+            self.calls += 1
+            return "cached value"
+
+    field = DelegatedField()
+    rendered_field = _RenderedDataModelField(field, "docstring")
+
+    assert rendered_field.docstring == "docstring"
+    assert rendered_field.value == "cached value"
+    assert rendered_field.value == "cached value"
+    assert field.calls == 1
+    assert rendered_field.__dict__["value"] == "cached value"
+
+
+def test_rendered_data_model_field_preserves_missing_attribute_errors() -> None:
+    """Test missing delegated field attributes still raise AttributeError."""
+    rendered_field = _RenderedDataModelField(object(), "")
+
+    with pytest.raises(AttributeError):
+        _ = rendered_field.missing
+
+
+def test_rendered_data_model_field_batches_field_and_annotated_values() -> None:
+    """Test field and annotated template values share one lazy render call."""
+
+    @dataclass
+    class RenderValuesField:
+        """Test field that batches rendered field values."""
+
+        calls: int = 0
+
+        def _rendered_field_values(self) -> tuple[str, str]:
+            """Return counted rendered values."""
+            self.calls += 1
+            return "field value", "annotated value"
+
+    field = RenderValuesField()
+    rendered_field = _RenderedDataModelField(field, "")
+
+    assert rendered_field.annotated == "annotated value"
+    assert rendered_field.field == "field value"
+    assert field.calls == 1
+    assert rendered_field.__dict__["field"] == "field value"
+    assert rendered_field.__dict__["annotated"] == "annotated value"
+
+
+def test_jinja_environment_auto_reload_only_for_custom_templates(tmp_path: Path) -> None:
+    """Test built-in templates disable Jinja auto-reload while custom templates keep it."""
+    _get_environment.cache_clear()
+    _get_environment_with_absolute_path.cache_clear()
+
+    builtin_environment = _get_environment(Path(), None)
+    custom_environment = _get_environment(Path(), tmp_path)
+    absolute_path_environment = _get_environment_with_absolute_path(tmp_path, Path())
+
+    assert builtin_environment.auto_reload is False
+    assert custom_environment.auto_reload is True
+    assert absolute_path_environment.auto_reload is True
 
 
 def test_pydantic_base_class_var_imports_do_not_require_field() -> None:

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -351,10 +351,12 @@ def test_jinja_environment_auto_reload_only_for_custom_templates(tmp_path: Path)
 
     builtin_environment = _get_environment(Path(), None)
     custom_environment = _get_environment(Path(), tmp_path)
+    missing_custom_subdir_environment = _get_environment(Path("pydantic_v2"), tmp_path)
     absolute_path_environment = _get_environment_with_absolute_path(tmp_path, Path())
 
     assert builtin_environment.auto_reload is False
     assert custom_environment.auto_reload is True
+    assert missing_custom_subdir_environment.auto_reload is False
     assert absolute_path_environment.auto_reload is True
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency when accessing generated field properties by caching computed attribute values on first use.
  * Template rendering now refreshes automatically only when using custom template directories (including absolute-path templates), improving responsiveness to template changes.
* **Tests**
  * Added unit coverage for cached attribute access, correct behavior for missing attributes, batching of related computed values, and Jinja auto-reload configuration across template scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->