### PR TITLE
Fix payload runtime validation exclusions

### DIFF
--- a/tests/main/payload_validation/conformance.py
+++ b/tests/main/payload_validation/conformance.py
@@ -112,6 +112,9 @@ PYDANTIC_V2_DATACLASS_MUTABLE_DEFAULT_EXCLUDED_CASES: Final[dict[str, str]] = {
     "jsonschema/root_model_default_value_branches.json": (
         "dataclass output needs default_factory handling for generated mutable defaults"
     ),
+    "jsonschema/unique_items_unhashable_default.json": (
+        "dataclass output needs default_factory handling for generated mutable defaults"
+    ),
     "openapi/allof_partial_override_deeply_nested_array.yaml::components.schemas.Thing": (
         "dataclass output needs default_factory handling for generated mutable defaults"
     ),

--- a/tests/main/payload_validation/constants.py
+++ b/tests/main/payload_validation/constants.py
@@ -269,6 +269,9 @@ PYDANTIC_V2_LEGACY_RUNTIME_ROUND_TRIP_EXCLUDED_CASES: dict[PayloadBackend, dict[
         "jsonschema/property_names_ref_enum.json": (
             "Pydantic before 2.5.0 emits JSON-mode serializer warnings for enum dictionary keys"
         ),
+        "jsonschema/type_overrides_dict_key.json": (
+            "Pydantic before 2.5.0 emits JSON-mode serializer warnings for enum dictionary keys"
+        ),
     },
 }
 


### PR DESCRIPTION
Fixes: #3596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation test coverage for mutable dataclass defaults.
  * Excluded a legacy round-trip case affected by enum dictionary-key serialization warnings in older Pydantic versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->