### PR TITLE
Decouple RootModel dependency ordering

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -1149,6 +1149,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     SUPPORTS_FIELD_RENAMING: ClassVar[bool] = False
     SUPPORTS_KW_ONLY: ClassVar[bool] = False
     SUPPORTS_BOOLEAN_LITERAL: ClassVar[bool] = True
+    REQUIRES_FIELD_DEPENDENCY_ORDERING: ClassVar[bool] = False
     REQUIRES_TAGGED_UNION_DISCRIMINATOR: ClassVar[bool] = False
     REQUIRES_ADDITIONAL_PROPERTIES_REFERENCE_CLASSES: ClassVar[bool] = False
     SUPPORTS_ANNOTATED_CONSTRAINTS: ClassVar[bool] = False

--- a/src/datamodel_code_generator/model/pydantic_v2/root_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/root_model.py
@@ -41,6 +41,7 @@ class RootModel(BaseModel):
     TEMPLATE_FILE_PATH: ClassVar[str] = "pydantic_v2/RootModel.jinja2"
     BASE_CLASS: ClassVar[str] = "pydantic.RootModel"
     IS_ROOT_MODEL: ClassVar[bool] = True
+    REQUIRES_FIELD_DEPENDENCY_ORDERING: ClassVar[bool] = True
     SUPPORTS_CONFIG_EXTRA: ClassVar[bool] = False
     SUPPORTS_ARBITRARY_TYPES_ALLOWED: ClassVar[bool] = False
 

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -103,7 +103,6 @@ _MSGSPEC_MODULE: Final = "datamodel_code_generator.model.msgspec"
 _PYDANTIC_V2_BASE_MODEL_MODULE: Final = "datamodel_code_generator.model.pydantic_v2.base_model"
 _PYDANTIC_V2_DATACLASS_MODULE: Final = "datamodel_code_generator.model.pydantic_v2.dataclass"
 _PYDANTIC_V2_MODULE: Final = "datamodel_code_generator.model.pydantic_v2"
-_PYDANTIC_V2_ROOT_MODEL_MODULE: Final = "datamodel_code_generator.model.pydantic_v2.root_model"
 _MODEL_MODULE_PREFIX: Final = "datamodel_code_generator.model."
 _CLASS_NAME_SEPARATOR_PATTERN: Final = re.compile(r"[^A-Za-z0-9]+")
 _TOP_LEVEL_FUTURE_IMPORT_PATTERN: Final = re.compile(r"(?m)^from __future__ import ")
@@ -139,10 +138,14 @@ def _is_pydantic_v2_dataclass(value: object | type[object]) -> bool:
     return _type_mro_contains_type(_model_type(value), module=_PYDANTIC_V2_DATACLASS_MODULE, name="DataClass")
 
 
+def _get_field_dependency_ordering_model_type(model_type: type[DataModel]) -> type[DataModel] | None:
+    """Return the configured model type when its fields require dependency ordering."""
+    return model_type if model_type.REQUIRES_FIELD_DEPENDENCY_ORDERING else None
+
+
 def _get_pydantic_v2_root_model_type(model_type: type[DataModel]) -> type[DataModel] | None:
-    if _type_mro_contains_type(model_type, module=_PYDANTIC_V2_ROOT_MODEL_MODULE, name="RootModel"):
-        return model_type
-    return None
+    """Return the field-ordering model type through the legacy compatibility helper."""
+    return _get_field_dependency_ordering_model_type(model_type)
 
 
 def _is_pydantic_v2_root_model(model: DataModel, root_model_type: type[DataModel] | None) -> bool:
@@ -1548,7 +1551,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         )
         self.data_model_type: type[DataModel] = config.data_model_type
         self.data_model_root_type: type[DataModel] = config.data_model_root_type
-        self.pydantic_v2_root_model_type: type[DataModel] | None = _get_pydantic_v2_root_model_type(
+        self.pydantic_v2_root_model_type: type[DataModel] | None = _get_field_dependency_ordering_model_type(
             self.data_model_root_type
         )
         self.data_model_field_type: type[DataModelFieldBase] = config.data_model_field_type

--- a/tests/parser/test_base.py
+++ b/tests/parser/test_base.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 from datamodel_code_generator.model.pydantic_v2 import BaseModel, DataModelField
 from datamodel_code_generator.model.pydantic_v2.root_model import RootModel
+from datamodel_code_generator.model.pydantic_v2.root_model_type_alias import RootModelTypeAlias
 from datamodel_code_generator.model.type_alias import TypeAlias, TypeAliasTypeBackport, TypeStatement
 from datamodel_code_generator.parser.base import (
     Child,
@@ -29,6 +30,7 @@ from datamodel_code_generator.parser.base import (
     T,
     _contains_model_reference,
     _find_field,
+    _get_pydantic_v2_root_model_type,
     _needs_validate_default,
     _unwrap_type_alias,
     add_model_path_to_list,
@@ -50,6 +52,12 @@ class A(DataModel):
 
 class B(DataModel):
     """Test data model class B."""
+
+
+class FieldDependencyModel(DataModel):
+    """Test model whose field references require definition ordering."""
+
+    REQUIRES_FIELD_DEPENDENCY_ORDERING = True
 
 
 class C(Parser):
@@ -82,6 +90,32 @@ def test_parser() -> None:
     assert c.base_class == "Base"
     # Test schema_features property of test stub
     assert c.schema_features.prefix_items is True
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected"),
+    [
+        pytest.param(B, None, id="default-model"),
+        pytest.param(RootModel, RootModel, id="root-model"),
+        pytest.param(RootModelTypeAlias, RootModelTypeAlias, id="root-model-type-alias"),
+        pytest.param(FieldDependencyModel, FieldDependencyModel, id="custom-capability"),
+    ],
+)
+def test_field_dependency_ordering_capability(
+    model_type: type[DataModel],
+    expected: type[DataModel] | None,
+) -> None:
+    """Resolve field dependency ordering without importing a concrete backend in the parser."""
+    assert _get_pydantic_v2_root_model_type(model_type) is expected
+
+
+def test_field_dependency_ordering_capability_is_inherited() -> None:
+    """External RootModel subclasses preserve the existing MRO-based behavior."""
+
+    class ExternalRootModel(RootModel):
+        pass
+
+    assert _get_pydantic_v2_root_model_type(ExternalRootModel) is ExternalRootModel
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Pydantic v2 root models and field dependency ordering during model generation.
  * Preserved compatibility for custom root-model subclasses and type aliases.

* **Tests**
  * Added coverage for dependency-ordering behavior across default, custom, aliased, and inherited model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->