### PR TITLE
Move discriminator policies to output models

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -313,6 +313,7 @@ class DataModelFieldBase(_BaseModel):
     _field_imports_cache: ClassVar[dict[tuple[Any, ...], tuple[Import, ...]]] = {}
     SUPPORTS_ANNOTATED_CONSTRAINTS: ClassVar[bool] = False
     ANNOTATED_CONSTRAINTS_CONTEXT: ClassVar[object | None] = None
+    SUPPORTS_DISCRIMINATOR: ClassVar[bool] = False
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -1146,6 +1147,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     IS_ROOT_MODEL: ClassVar[bool] = False
     SUPPORTS_GENERIC_BASE_CLASS: ClassVar[bool] = True
     SUPPORTS_DISCRIMINATOR: ClassVar[bool] = False
+    SUPPORTS_INHERITED_DISCRIMINATOR_ENUM: ClassVar[bool] = False
     SUPPORTS_FIELD_RENAMING: ClassVar[bool] = False
     SUPPORTS_KW_ONLY: ClassVar[bool] = False
     SUPPORTS_BOOLEAN_LITERAL: ClassVar[bool] = True
@@ -1173,6 +1175,14 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     ) -> DataModelFieldBase | None:
         """Create a model-specific typed extra field when supported."""
         return None
+
+    def apply_discriminator_tag(
+        self,
+        field: DataModelFieldBase,
+        field_name: str,
+        value: Any,
+    ) -> None:
+        """Apply an output-specific tagged-union discriminator when supported."""
 
     @classmethod
     def resolve_nested_constrained_model_type(

--- a/src/datamodel_code_generator/model/dataclass.py
+++ b/src/datamodel_code_generator/model/dataclass.py
@@ -70,6 +70,7 @@ class DataClass(_DataclassReuseMixin, DataModel):
     TEMPLATE_FILE_PATH: ClassVar[str] = "dataclass.jinja2"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = (IMPORT_DATACLASS,)
     SUPPORTS_DISCRIMINATOR: ClassVar[bool] = True
+    SUPPORTS_INHERITED_DISCRIMINATOR_ENUM: ClassVar[bool] = True
     SUPPORTS_KW_ONLY: ClassVar[bool] = True
 
     def __init__(  # noqa: PLR0913

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -103,6 +103,7 @@ class Struct(DataModel):
     BASE_CLASS_ALIAS: ClassVar[str] = "_Struct"
     DEFAULT_IMPORTS: ClassVar[tuple[Import, ...]] = ()
     SUPPORTS_DISCRIMINATOR: ClassVar[bool] = True
+    SUPPORTS_INHERITED_DISCRIMINATOR_ENUM: ClassVar[bool] = True
     SUPPORTS_KW_ONLY: ClassVar[bool] = True
     SUPPORTS_BOOLEAN_LITERAL: ClassVar[bool] = False
     REQUIRES_TAGGED_UNION_DISCRIMINATOR: ClassVar[bool] = True
@@ -160,6 +161,12 @@ class Struct(DataModel):
     def add_base_class_kwarg(self, name: str, value: str) -> None:
         """Add keyword argument to base class constructor."""
         self.extra_template_data["base_class_kwargs"][name] = value
+
+    def apply_discriminator_tag(self, field: DataModelFieldBase, field_name: str, value: Any) -> None:
+        """Configure msgspec's tag and exclude the discriminator from instance fields."""
+        self.add_base_class_kwarg("tag_field", f"'{field_name}'")
+        self.add_base_class_kwarg("tag", repr(value))
+        field.extras["is_classvar"] = True
 
     @classmethod
     def create_base_class_model(

--- a/src/datamodel_code_generator/model/pydantic_v2/base_model.py
+++ b/src/datamodel_code_generator/model/pydantic_v2/base_model.py
@@ -288,6 +288,7 @@ class DataModelField(_PydanticBaseDataModelField):
 
     SUPPORTS_ANNOTATED_CONSTRAINTS: ClassVar[bool] = True
     ANNOTATED_CONSTRAINTS_CONTEXT: ClassVar[object | None] = _ANNOTATED_CONSTRAINTS_CONTEXT
+    SUPPORTS_DISCRIMINATOR: ClassVar[bool] = True
     _EXCLUDE_FIELD_KEYS: ClassVar[set[str]] = {
         "alias",
         "default",
@@ -602,6 +603,7 @@ class BaseModel(BaseModelBase):
     BASE_CLASS_NAME: ClassVar[str] = "BaseModel"
     BASE_CLASS_ALIAS: ClassVar[str] = "_BaseModel"
     SUPPORTS_DISCRIMINATOR: ClassVar[bool] = True
+    SUPPORTS_INHERITED_DISCRIMINATOR_ENUM: ClassVar[bool] = True
     SUPPORTS_FIELD_RENAMING: ClassVar[bool] = True
     SUPPORTS_ANNOTATED_CONSTRAINTS: ClassVar[bool] = True
     ANNOTATED_CONSTRAINTS_CONTEXT: ClassVar[object | None] = _ANNOTATED_CONSTRAINTS_CONTEXT

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -1311,14 +1311,9 @@ def _get_enum_from_base(discriminator_model: DataModel, field_name: str) -> Enum
         if not base_class.reference or not base_class.reference.source:  # pragma: no cover
             continue
         base_model = base_class.reference.source
-        if not (
-            _is_dataclass_data_model(base_model)
-            or _is_msgspec_struct(base_model)
-            or _is_pydantic_v2_base_model(base_model)
-        ):  # pragma: no cover
+        if not isinstance(base_model, DataModel) or not base_model.SUPPORTS_INHERITED_DISCRIMINATOR_ENUM:
             continue
-        base_data_model = cast("DataModel", base_model)
-        for base_field in base_data_model.fields:  # pragma: no branch
+        for base_field in base_model.fields:  # pragma: no branch
             if field_name not in {base_field.original_name, base_field.name}:  # pragma: no cover
                 continue
             if enum_from_base := base_field.data_type.find_source(Enum):  # pragma: no branch
@@ -2288,7 +2283,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         can_retain_cache: bool,
     ) -> None:
         """Keep Pydantic v2 single-literal discriminator fields valid when forced optional."""
-        if not self.force_optional_for_required_fields or not _is_pydantic_v2_data_model_field(discriminator_field):
+        if not self.force_optional_for_required_fields or not discriminator_field.SUPPORTS_DISCRIMINATOR:
             return
 
         discriminator_field.default = literal
@@ -2357,10 +2352,12 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                         ):
                             has_one_literal = True
                             match discriminator_model:
-                                case _ if _is_msgspec_struct(discriminator_model):  # pragma: no cover
-                                    _add_msgspec_base_class_kwarg(discriminator_model, "tag_field", f"'{field_name}'")
-                                    _add_msgspec_base_class_kwarg(discriminator_model, "tag", repr(expected_value))
-                                    discriminator_field.extras["is_classvar"] = True
+                                case _ if discriminator_model.REQUIRES_TAGGED_UNION_DISCRIMINATOR:  # pragma: no cover
+                                    discriminator_model.apply_discriminator_tag(
+                                        discriminator_field,
+                                        field_name,
+                                        expected_value,
+                                    )
                                     _clear_model_imports_cache_if_retained(
                                         discriminator_model, can_retain_cache=can_retain_cache
                                     )
@@ -2375,11 +2372,13 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                             break
 
                         # For msgspec with const value but no literal (type: string + const case)
-                        if const_match and _is_msgspec_struct(discriminator_model):  # pragma: no cover
+                        if const_match and discriminator_model.REQUIRES_TAGGED_UNION_DISCRIMINATOR:  # pragma: no cover
                             has_one_literal = True
-                            _add_msgspec_base_class_kwarg(discriminator_model, "tag_field", f"'{field_name}'")
-                            _add_msgspec_base_class_kwarg(discriminator_model, "tag", repr(const_value))
-                            discriminator_field.extras["is_classvar"] = True
+                            discriminator_model.apply_discriminator_tag(
+                                discriminator_field,
+                                field_name,
+                                const_value,
+                            )
                             _clear_model_imports_cache_if_retained(
                                 discriminator_model, can_retain_cache=can_retain_cache
                             )
@@ -2798,7 +2797,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
                                 root_type_field.constraints, model_field.constraints
                             )
                         discriminator = root_type_field.extras.get("discriminator")
-                        if discriminator and _is_pydantic_v2_data_model_field(root_type_field):
+                        if discriminator and root_type_field.SUPPORTS_DISCRIMINATOR:
                             has_any_variant = any(_is_any_variant(dt) for dt in copied_data_type.data_types)
                             if not has_any_variant:  # pragma: no branch
                                 prop_name = (

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -35,6 +35,7 @@ from datamodel_code_generator.model.base import (
     inline_comment_safe,
     sanitize_module_name,
 )
+from datamodel_code_generator.model.dataclass import DataClass as DataclassModel
 from datamodel_code_generator.model.imports import IMPORT_MSGSPEC_META, IMPORT_MSGSPEC_UNSET, IMPORT_MSGSPEC_UNSETTYPE
 from datamodel_code_generator.model.msgspec import DataModelField as MsgspecDataModelField
 from datamodel_code_generator.model.msgspec import Struct as MsgspecStruct
@@ -44,6 +45,8 @@ from datamodel_code_generator.model.pydantic_v2 import DataModelField as Pydanti
 from datamodel_code_generator.model.pydantic_v2.base_model import (
     _strip_legacy_pydantic_extra_post_class_assignment,
 )
+from datamodel_code_generator.model.pydantic_v2.dataclass import DataClass as PydanticDataclassModel
+from datamodel_code_generator.model.pydantic_v2.dataclass import DataModelField as PydanticDataclassField
 from datamodel_code_generator.model.pydantic_v2.imports import IMPORT_FIELD, IMPORT_MISSING
 from datamodel_code_generator.model.typed_dict import DataModelField as TypedDictDataModelField
 from datamodel_code_generator.model.typed_dict import TypedDict as TypedDictModel
@@ -87,6 +90,80 @@ class ReferenceSource:
 
     nullable: bool
     is_alias: bool = False
+
+
+@pytest.mark.parametrize(
+    ("model_type", "supports_inherited_enum"),
+    [
+        pytest.param(DataModel, False, id="base"),
+        pytest.param(BaseModel, True, id="pydantic"),
+        pytest.param(DataclassModel, True, id="dataclass"),
+        pytest.param(MsgspecStruct, True, id="msgspec"),
+        pytest.param(PydanticDataclassModel, False, id="pydantic-dataclass"),
+        pytest.param(TypedDictModel, False, id="typed-dict"),
+    ],
+)
+def test_inherited_discriminator_enum_capability(
+    model_type: type[DataModel],
+    *,
+    supports_inherited_enum: bool,
+) -> None:
+    """Output models explicitly declare inherited discriminator enum support."""
+    assert model_type.SUPPORTS_INHERITED_DISCRIMINATOR_ENUM is supports_inherited_enum
+    external_model_type = type(f"External{model_type.__name__}", (model_type,), {})
+    assert external_model_type.SUPPORTS_INHERITED_DISCRIMINATOR_ENUM is supports_inherited_enum
+
+
+@pytest.mark.parametrize(
+    ("field_type", "supports_discriminator"),
+    [
+        pytest.param(DataModelFieldBase, False, id="base"),
+        pytest.param(PydanticV2DataModelField, True, id="pydantic"),
+        pytest.param(PydanticDataclassField, True, id="pydantic-dataclass"),
+        pytest.param(MsgspecDataModelField, False, id="msgspec"),
+        pytest.param(TypedDictDataModelField, False, id="typed-dict"),
+    ],
+)
+def test_discriminator_field_capability(
+    field_type: type[DataModelFieldBase],
+    *,
+    supports_discriminator: bool,
+) -> None:
+    """Only Pydantic fields opt in to Pydantic discriminator behavior."""
+    assert field_type.SUPPORTS_DISCRIMINATOR is supports_discriminator
+    external_field_type = type(f"External{field_type.__name__}", (field_type,), {})
+    assert external_field_type.SUPPORTS_DISCRIMINATOR is supports_discriminator
+
+
+def test_msgspec_apply_discriminator_tag() -> None:
+    """The msgspec model owns its tagged-union mutation policy."""
+    field = MsgspecDataModelField(name="kind", data_type=DataType(literals=["pet"]))
+    model = MsgspecStruct(
+        fields=[field],
+        reference=Reference(path="Pet", original_name="Pet", name="Pet"),
+    )
+
+    model.apply_discriminator_tag(field, "kind", "pet")
+
+    assert model.extra_template_data["base_class_kwargs"] == {
+        "tag_field": "'kind'",
+        "tag": "'pet'",
+    }
+    assert field.extras["is_classvar"] is True
+
+
+def test_default_apply_discriminator_tag_is_noop() -> None:
+    """Models without tagged unions leave fields and template data unchanged."""
+    field = TypedDictDataModelField(name="kind", data_type=DataType(literals=["pet"]))
+    model = TypedDictModel(
+        fields=[field],
+        reference=Reference(path="Pet", original_name="Pet", name="Pet"),
+    )
+
+    model.apply_discriminator_tag(field, "kind", "pet")
+
+    assert model.extra_template_data == {}
+    assert field.extras == {}
 
 
 template: str = """{%- for decorator in decorators -%}

--- a/tests/parser/test_base.py
+++ b/tests/parser/test_base.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from datamodel_code_generator.parser.schema_version import JsonSchemaFeatures
 
 from datamodel_code_generator.model.pydantic_v2 import BaseModel, DataModelField
+from datamodel_code_generator.model.pydantic_v2.dataclass import DataClass as PydanticDataclassModel
+from datamodel_code_generator.model.pydantic_v2.dataclass import DataModelField as PydanticDataclassField
 from datamodel_code_generator.model.pydantic_v2.root_model import RootModel
 from datamodel_code_generator.model.pydantic_v2.root_model_type_alias import RootModelTypeAlias
 from datamodel_code_generator.model.type_alias import TypeAlias, TypeAliasTypeBackport, TypeStatement
@@ -30,7 +32,9 @@ from datamodel_code_generator.parser.base import (
     T,
     _contains_model_reference,
     _find_field,
+    _get_enum_from_base,
     _get_pydantic_v2_root_model_type,
+    _is_pydantic_v2_data_model_field,
     _needs_validate_default,
     _unwrap_type_alias,
     add_model_path_to_list,
@@ -436,6 +440,42 @@ def parser_fixture() -> C:
 
 def _reference(path: str) -> Reference:
     return Reference(path=path, original_name=path, name=path)
+
+
+def test_pydantic_v2_data_model_field_compatibility_helper() -> None:
+    """Keep the public compatibility helper working with real field objects."""
+    pydantic_field = DataModelField(name="value", data_type=DataType(type="str"))
+    generic_field = DataModelFieldBase(name="value", data_type=DataType(type="str"))
+
+    assert _is_pydantic_v2_data_model_field(pydantic_field)
+    assert not _is_pydantic_v2_data_model_field(generic_field)
+
+
+def test_get_enum_from_base_skips_models_without_inherited_enum_capability() -> None:
+    """Do not inherit discriminator enums from output models that opt out."""
+    from datamodel_code_generator.model.enum import Enum
+
+    enum_reference = _reference("Kind")
+    Enum(fields=[], reference=enum_reference)
+    base_reference = _reference("Base")
+    base_model = PydanticDataclassModel(
+        fields=[
+            PydanticDataclassField(
+                name="kind",
+                original_name="kind",
+                data_type=DataType(reference=enum_reference),
+            )
+        ],
+        reference=base_reference,
+    )
+    child_model = BaseModel(
+        fields=[],
+        base_classes=[base_reference],
+        reference=_reference("Child"),
+    )
+
+    assert not base_model.SUPPORTS_INHERITED_DISCRIMINATOR_ENUM
+    assert _get_enum_from_base(child_model, "kind") is None
 
 
 def _create_override_required_models(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved discriminated-union generation across supported model formats.
  * Added tagged-union metadata for generated Msgspec structures, including discriminator field names and values.
  * Added support for inherited discriminator enums in supported dataclass, Msgspec, and Pydantic v2 models.

* **Bug Fixes**
  * Improved discriminator handling for optional fields and collapsed root models.
  * Standardized discriminator behavior across model types for more consistent generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->