### PR TITLE
Improve README and docs homepage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 🚀 Generate Python data models from schema definitions in seconds.
 
-🧪 Try it in your browser: [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/)
+📚 [Documentation](https://datamodel-code-generator.koxudaxi.dev/) ·
+🧪 [Playground](https://datamodel-code-generator.koxudaxi.dev/playground/) ·
+💼 [Maintainer available for work](https://koxudaxi.dev/?utm_source=github_readme&utm_medium=top&utm_campaign=open_to_work)
 
 > [!NOTE]
 > Playground privacy: Generation runs locally in your browser with Pyodide. Your schema and options are not sent to a
@@ -16,8 +18,6 @@
 [![codecov](https://codecov.io/gh/koxudaxi/datamodel-code-generator/graph/badge.svg?token=plzSSFb9Li)](https://codecov.io/gh/koxudaxi/datamodel-code-generator)
 ![license](https://img.shields.io/github/license/koxudaxi/datamodel-code-generator.svg)
 [![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://pydantic.dev)
-
-> 📣 💼 Maintainer update: Open to opportunities. 🔗 [koxudaxi.dev](https://koxudaxi.dev/?utm_source=github_readme&utm_medium=top&utm_campaign=open_to_work)
 
 ## ✨ What it does
 
@@ -211,7 +211,7 @@ See [Performance Benchmarks](https://datamodel-code-generator.koxudaxi.dev/perfo
 
 ## 📖 Documentation
 
-**👉 [datamodel-code-generator.koxudaxi.dev](https://datamodel-code-generator.koxudaxi.dev)**
+**👉 [Read the full documentation →](https://datamodel-code-generator.koxudaxi.dev/)**
 
 - 🧰 [Presets](https://datamodel-code-generator.koxudaxi.dev/presets/) - Recommended option bundles for modern output
 - 🚀 [Getting Started](https://datamodel-code-generator.koxudaxi.dev/getting-started/) - Installation and first model

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,12 @@
 
 🚀 Generate Python data models from schema definitions in seconds.
 
+<p>
+  <a class="md-button md-button--primary" href="getting-started.md">Getting Started</a>
+  <a class="md-button md-button--primary" href="playground.md">Open Playground</a>
+  <a class="md-button md-button--primary" href="https://koxudaxi.dev/?utm_source=dm_docs&utm_medium=top&utm_campaign=open_to_work">Maintainer available for work</a>
+</p>
+
 [![PyPI version](https://img.shields.io/pypi/v/datamodel-code-generator.svg)](https://pypi.python.org/pypi/datamodel-code-generator)
 [![Conda-forge](https://img.shields.io/conda/v/conda-forge/datamodel-code-generator)](https://anaconda.org/conda-forge/datamodel-code-generator)
 [![Downloads](https://api.pepy.tech/badge/datamodel-code-generator/month)](https://pepy.tech/projects/datamodel-code-generator)
@@ -33,10 +39,6 @@ in another Python file to a different output type.
 ## 🧪 Try It In Your Browser
 
 Generate models in your browser without installing anything.
-
-<p>
-  <a class="md-button md-button--primary" href="playground.md" target="_self">Open Playground</a>
-</p>
 
 !!! note "Playground privacy"
     Generation runs locally in your browser with Pyodide. Your schema and options are not sent to a backend. Shared

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4,6 +4,12 @@ Source: https://datamodel-code-generator.koxudaxi.dev/
 
 🚀 Generate Python data models from schema definitions in seconds.
 
+<p>
+  <a class="md-button md-button--primary" href="getting-started.md">Getting Started</a>
+  <a class="md-button md-button--primary" href="playground.md">Open Playground</a>
+  <a class="md-button md-button--primary" href="https://koxudaxi.dev/?utm_source=dm_docs&utm_medium=top&utm_campaign=open_to_work">Maintainer available for work</a>
+</p>
+
 [![PyPI version](https://img.shields.io/pypi/v/datamodel-code-generator.svg)](https://pypi.python.org/pypi/datamodel-code-generator)
 [![Conda-forge](https://img.shields.io/conda/v/conda-forge/datamodel-code-generator)](https://anaconda.org/conda-forge/datamodel-code-generator)
 [![Downloads](https://api.pepy.tech/badge/datamodel-code-generator/month)](https://pepy.tech/projects/datamodel-code-generator)
@@ -35,10 +41,6 @@ in another Python file to a different output type.
 ## 🧪 Try It In Your Browser
 
 Generate models in your browser without installing anything.
-
-<p>
-  <a class="md-button md-button--primary" href="playground.md" target="_self">Open Playground</a>
-</p>
 
 !!! note "Playground privacy"
     Generation runs locally in your browser with Pyodide. Your schema and options are not sent to a backend. Shared


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README callouts with links to Documentation, Playground, and Getting Started resources.
  * Refined documentation link wording for clearer navigation.
  * Added matching call-to-action links to the documentation homepage.
  * Removed redundant promotional messaging and duplicate Playground links.
  * Retained the existing Playground privacy information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->