### PR TITLE
Move dataclass ordering policies to output models

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -1159,6 +1159,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     SUPPORTS_INHERITED_DISCRIMINATOR_ENUM: ClassVar[bool] = False
     SUPPORTS_FIELD_RENAMING: ClassVar[bool] = False
     SUPPORTS_KW_ONLY: ClassVar[bool] = False
+    REQUIRES_MODEL_LEVEL_KW_ONLY: ClassVar[bool] = False
     SUPPORTS_BOOLEAN_LITERAL: ClassVar[bool] = True
     REQUIRES_FIELD_DEPENDENCY_ORDERING: ClassVar[bool] = False
     REQUIRES_TAGGED_UNION_DISCRIMINATOR: ClassVar[bool] = False
@@ -1194,6 +1195,13 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         value: Any,
     ) -> None:
         """Apply an output-specific tagged-union discriminator when supported."""
+
+    def has_keyword_only_definition(self) -> bool:  # noqa: PLR6301
+        """Return whether the model already makes inherited fields keyword-only."""
+        return False
+
+    def enable_model_keyword_only(self) -> None:
+        """Enable output-specific model-level keyword-only behavior when supported."""
 
     @classmethod
     def resolve_nested_constrained_model_type(

--- a/src/datamodel_code_generator/model/dataclass.py
+++ b/src/datamodel_code_generator/model/dataclass.py
@@ -37,6 +37,10 @@ def has_field_assignment(field: DataModelFieldBase) -> bool:
 
 
 class _DataclassReuseMixin:
+    def has_keyword_only_definition(self) -> bool:
+        """Return whether a dataclass declaration enables keyword-only fields."""
+        return bool(cast("DataModel", self).dataclass_arguments.get("kw_only"))
+
     def create_reuse_model(self, base_ref: Reference) -> DataModel:
         """Create inherited model with empty fields pointing to base reference."""
         model = cast("DataModel", self)

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -104,6 +104,7 @@ class Struct(DataModel):
     SUPPORTS_DISCRIMINATOR: ClassVar[bool] = True
     SUPPORTS_INHERITED_DISCRIMINATOR_ENUM: ClassVar[bool] = True
     SUPPORTS_KW_ONLY: ClassVar[bool] = True
+    REQUIRES_MODEL_LEVEL_KW_ONLY: ClassVar[bool] = True
     SUPPORTS_BOOLEAN_LITERAL: ClassVar[bool] = False
     REQUIRES_TAGGED_UNION_DISCRIMINATOR: ClassVar[bool] = True
     SUPPORTS_ANNOTATED_CONSTRAINTS: ClassVar[bool] = True
@@ -166,6 +167,14 @@ class Struct(DataModel):
         self.add_base_class_kwarg("tag_field", f"'{field_name}'")
         self.add_base_class_kwarg("tag", repr(value))
         field.extras["is_classvar"] = True
+
+    def has_keyword_only_definition(self) -> bool:
+        """Return whether msgspec's class declaration already enables keyword-only fields."""
+        return self.extra_template_data["base_class_kwargs"].get("kw_only") in {True, "True"}
+
+    def enable_model_keyword_only(self) -> None:
+        """Enable msgspec's class-level keyword-only option."""
+        self.add_base_class_kwarg("kw_only", "True")
 
     @classmethod
     def create_base_class_model(

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -159,10 +159,6 @@ def _is_pydantic_v2_dump_resolve_reference_action(value: object) -> bool:
     )
 
 
-def _add_msgspec_base_class_kwarg(model: DataModel, name: str, value: str) -> None:
-    cast("Any", model).add_base_class_kwarg(name, value)
-
-
 def __getattr__(name: str) -> Any:
     """Return compatibility model modules without importing them on parser load."""
     match name:
@@ -3050,8 +3046,8 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
             ):
                 continue
 
-            if _is_msgspec_struct(model):
-                _add_msgspec_base_class_kwarg(model, "kw_only", "True")
+            if model.REQUIRES_MODEL_LEVEL_KW_ONLY:
+                model.enable_model_keyword_only()
             elif self.target_python_version.has_kw_only_dataclass:
                 for field in model.fields:
                     if self.__is_new_required_field(field, inherited_names, field_has_assignment):
@@ -3072,10 +3068,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         """Get inherited field names and whether any has default. Returns None if not applicable."""
         if not model.SUPPORTS_KW_ONLY:
             return None
-        base_class_kw_only = None
-        if _is_msgspec_struct(model):
-            base_class_kw_only = model.extra_template_data.get("base_class_kwargs", {}).get("kw_only")
-        if not model.base_classes or model.dataclass_arguments.get("kw_only") or base_class_kw_only in {True, "True"}:
+        if not model.base_classes or model.has_keyword_only_definition():
             return None
 
         field_has_assignment = cls._get_field_assignment_checker(model)

--- a/tests/model/test_dataclass_ordering.py
+++ b/tests/model/test_dataclass_ordering.py
@@ -1,0 +1,94 @@
+"""Tests for output-owned dataclass field-ordering policies."""
+
+from __future__ import annotations
+
+import pytest
+
+from datamodel_code_generator.model.base import DataModel
+from datamodel_code_generator.model.dataclass import DataClass as StandardDataClass
+from datamodel_code_generator.model.dataclass import DataModelField as DataclassDataModelField
+from datamodel_code_generator.model.dataclass import has_field_assignment as has_dataclass_field_assignment
+from datamodel_code_generator.model.msgspec import Struct as MsgspecStruct
+from datamodel_code_generator.model.msgspec import has_field_assignment as has_msgspec_field_assignment
+from datamodel_code_generator.model.pydantic_v2.base_model import BaseModel as PydanticBaseModel
+from datamodel_code_generator.model.pydantic_v2.dataclass import DataClass as PydanticDataClass
+from datamodel_code_generator.reference import Reference
+from datamodel_code_generator.types import DataType
+
+
+@pytest.mark.allow_direct_assert
+def test_dataclass_ordering_capabilities_are_owned_by_output_models() -> None:
+    """Output models should declare how inherited assignment conflicts are fixed."""
+
+    class ExternalStruct(MsgspecStruct):
+        """External msgspec backend inheriting the built-in ordering policy."""
+
+    assert DataModel.REQUIRES_MODEL_LEVEL_KW_ONLY is False
+    assert StandardDataClass.REQUIRES_MODEL_LEVEL_KW_ONLY is False
+    assert PydanticDataClass.REQUIRES_MODEL_LEVEL_KW_ONLY is False
+    assert MsgspecStruct.REQUIRES_MODEL_LEVEL_KW_ONLY is True
+    assert ExternalStruct.REQUIRES_MODEL_LEVEL_KW_ONLY is True
+    assert MsgspecStruct.has_keyword_only_definition is not DataModel.has_keyword_only_definition
+    assert MsgspecStruct.enable_model_keyword_only is not DataModel.enable_model_keyword_only
+    assert ExternalStruct.has_keyword_only_definition is MsgspecStruct.has_keyword_only_definition
+    assert ExternalStruct.enable_model_keyword_only is MsgspecStruct.enable_model_keyword_only
+
+
+@pytest.mark.allow_direct_assert
+def test_dataclass_field_assignment_policy_keeps_legacy_helpers() -> None:
+    """Model hooks should preserve both backend helper contracts."""
+    required = DataclassDataModelField(name="required", data_type=DataType(type="str"), required=True)
+    defaulted = DataclassDataModelField(
+        name="defaulted",
+        data_type=DataType(type="str"),
+        default="value",
+        required=False,
+    )
+
+    assert StandardDataClass.FIELD_ASSIGNMENT_CHECKER(required) is has_dataclass_field_assignment(required) is False
+    assert StandardDataClass.FIELD_ASSIGNMENT_CHECKER(defaulted) is has_dataclass_field_assignment(defaulted) is True
+    assert MsgspecStruct.FIELD_ASSIGNMENT_CHECKER(required) is has_msgspec_field_assignment(required) is False
+    assert MsgspecStruct.FIELD_ASSIGNMENT_CHECKER(defaulted) is has_msgspec_field_assignment(defaulted) is True
+
+
+@pytest.mark.allow_direct_assert
+def test_dataclass_keyword_only_definition_uses_model_owned_metadata() -> None:
+    """Each backend should interpret only its own keyword-only metadata."""
+    data_class = StandardDataClass(
+        fields=[],
+        reference=Reference(path="Model", original_name="Model", name="Model"),
+        dataclass_arguments={"kw_only": True},
+    )
+    pydantic_model = PydanticBaseModel(
+        fields=[],
+        reference=Reference(path="PydanticModel", original_name="PydanticModel", name="PydanticModel"),
+    )
+    pydantic_data_class = PydanticDataClass(
+        fields=[],
+        reference=Reference(
+            path="PydanticDataClass",
+            original_name="PydanticDataClass",
+            name="PydanticDataClass",
+        ),
+        dataclass_arguments={"kw_only": True},
+    )
+    struct = MsgspecStruct(
+        fields=[],
+        reference=Reference(path="Struct", original_name="Struct", name="Struct"),
+    )
+
+    assert data_class.has_keyword_only_definition() is True
+    assert pydantic_model.has_keyword_only_definition() is False
+    assert pydantic_data_class.has_keyword_only_definition() is True
+    assert struct.has_keyword_only_definition() is False
+
+    struct.add_base_class_kwarg("tag", "'kind'")
+    struct.enable_model_keyword_only()
+    struct.enable_model_keyword_only()
+
+    assert struct.has_keyword_only_definition() is True
+    assert struct.extra_template_data["base_class_kwargs"] == {"tag": "'kind'", "kw_only": "True"}
+
+    struct.extra_template_data["base_class_kwargs"]["kw_only"] = True
+
+    assert struct.has_keyword_only_definition() is True

--- a/tests/parser/test_imports.py
+++ b/tests/parser/test_imports.py
@@ -69,6 +69,29 @@ def test_generation_import_does_not_load_pydantic_v2_dependency_policy() -> None
 
 
 @pytest.mark.allow_direct_assert
+def test_field_assignment_checker_does_not_load_output_model_generators() -> None:
+    """Resolving an output-owned ordering hook should not import concrete backends."""
+    module_names = (
+        "datamodel_code_generator.model.dataclass",
+        "datamodel_code_generator.model.msgspec",
+    )
+    code = (
+        "import sys\n"
+        "from datamodel_code_generator.parser.base import Parser\n"
+        "class ExternalModel:\n"
+        "    @staticmethod\n"
+        "    def FIELD_ASSIGNMENT_CHECKER(field):\n"
+        "        return field == 'assigned'\n"
+        "checker = Parser._get_field_assignment_checker(ExternalModel())\n"
+        "assert checker('assigned') is True\n"
+        f"module_names = {module_names!r}\n"
+        "print('\\n'.join(name for name in module_names if name in sys.modules))\n"
+    )
+
+    assert _run_import_probe(code) == "\n"
+
+
+@pytest.mark.allow_direct_assert
 def test_parser_model_compatibility_attributes_remain_available() -> None:
     """Parser modules should keep moved compatibility attributes available."""
     code = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced generated model handling for keyword-only fields across supported output formats.
  * Automatically enables keyword-only behavior for applicable msgspec structures.
* **Bug Fixes**
  * Corrected dataclass field-ordering and keyword-only interpretation when mixing required and default-valued fields.
  * Ensured keyword-only settings are determined by the active output model backend.
* **Tests**
  * Added coverage for field ordering, keyword-only configuration ownership, and backend import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->