### PR TITLE
Share model constraints across output backends

### DIFF
--- a/src/datamodel_code_generator/model/_constraints.py
+++ b/src/datamodel_code_generator/model/_constraints.py
@@ -1,0 +1,36 @@
+"""Shared field-constraint models for output backends."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field
+
+from datamodel_code_generator.model.base import ConstraintsBase
+from datamodel_code_generator.types import UnionIntFloat  # noqa: TC001 # needed for pydantic
+
+_LEGACY_MODULE = "datamodel_code_generator.model.pydantic_base"
+
+
+class Constraints(ConstraintsBase):
+    """Pydantic field constraints (gt, ge, lt, le, regex, etc.)."""
+
+    gt: Optional[UnionIntFloat] = Field(None, alias="exclusiveMinimum")  # noqa: UP045
+    ge: Optional[UnionIntFloat] = Field(None, alias="minimum")  # noqa: UP045
+    lt: Optional[UnionIntFloat] = Field(None, alias="exclusiveMaximum")  # noqa: UP045
+    le: Optional[UnionIntFloat] = Field(None, alias="maximum")  # noqa: UP045
+    multiple_of: Optional[float] = Field(None, alias="multipleOf")  # noqa: UP045
+    min_items: Optional[int] = Field(None, alias="minItems")  # noqa: UP045
+    max_items: Optional[int] = Field(None, alias="maxItems")  # noqa: UP045
+    min_length: Optional[int] = Field(None, alias="minLength")  # noqa: UP045
+    max_length: Optional[int] = Field(None, alias="maxLength")  # noqa: UP045
+    regex: Optional[str] = Field(None, alias="pattern")  # noqa: UP045
+
+
+class PatternConstraints(Constraints):
+    regex: Optional[str] = Field(None, alias="regex")  # noqa: UP045
+    pattern: Optional[str] = Field(None, alias="pattern")  # noqa: UP045
+
+
+Constraints.__module__ = _LEGACY_MODULE
+PatternConstraints.__module__ = _LEGACY_MODULE

--- a/src/datamodel_code_generator/model/dataclass.py
+++ b/src/datamodel_code_generator/model/dataclass.py
@@ -14,9 +14,9 @@ from datamodel_code_generator._format_types import (
     PythonVersionMin,
 )
 from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
+from datamodel_code_generator.model._constraints import Constraints  # noqa: TC001 # needed for pydantic
 from datamodel_code_generator.model.base import UNDEFINED, _has_field_assignment, _nested_model_default_factory
 from datamodel_code_generator.model.imports import IMPORT_DATACLASS, IMPORT_FIELD
-from datamodel_code_generator.model.pydantic_base import Constraints  # noqa: TC001 # needed for pydantic
 from datamodel_code_generator.model.types import DataTypeManager as _DataTypeManager
 from datamodel_code_generator.python_literal import represent_python_value
 from datamodel_code_generator.reference import Reference

--- a/src/datamodel_code_generator/model/msgspec.py
+++ b/src/datamodel_code_generator/model/msgspec.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar
 
 from datamodel_code_generator.imports import IMPORT_OPTIONAL, Import
 from datamodel_code_generator.model import DataModel, DataModelFieldBase, _rebuild_model_with_datamodel_namespace
+from datamodel_code_generator.model._constraints import PatternConstraints as _Constraints
 from datamodel_code_generator.model.base import UNDEFINED, BaseClassDataType, _nested_model_default_factory
 from datamodel_code_generator.model.imports import (
     IMPORT_MSGSPEC_CONVERT,
@@ -19,9 +20,6 @@ from datamodel_code_generator.model.imports import (
     IMPORT_MSGSPEC_STRUCT,
     IMPORT_MSGSPEC_UNSET,
     IMPORT_MSGSPEC_UNSETTYPE,
-)
-from datamodel_code_generator.model.pydantic_base import (
-    PatternConstraints as _Constraints,
 )
 from datamodel_code_generator.model.type_alias import TypeAliasBase
 from datamodel_code_generator.model.types import DataTypeManager as _DataTypeManager

--- a/src/datamodel_code_generator/model/pydantic_base.py
+++ b/src/datamodel_code_generator/model/pydantic_base.py
@@ -10,25 +10,23 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-from pydantic import Field  # noqa: F401
+from pydantic import Field as _Field
 
 from datamodel_code_generator import cached_path_exists
 from datamodel_code_generator.model import (
     UNDEFINED,
-    ConstraintsBase,  # noqa: F401 # legacy public import
     DataModel,
     DataModelFieldBase,
     _rebuild_model_with_datamodel_namespace,
 )
-from datamodel_code_generator.model._constraints import (
-    Constraints,  # noqa: TC001 # needed for pydantic
-    PatternConstraints,  # noqa: F401 # legacy public import
-)
+from datamodel_code_generator.model import ConstraintsBase as _ConstraintsBase
+from datamodel_code_generator.model._constraints import Constraints
+from datamodel_code_generator.model._constraints import PatternConstraints as _PatternConstraints
 from datamodel_code_generator.model._pydantic_imports import IMPORT_ANYURL, IMPORT_FIELD
 from datamodel_code_generator.model.base import _nested_model_default_factory
 from datamodel_code_generator.python_literal import represent_python_value
+from datamodel_code_generator.types import UnionIntFloat as _UnionIntFloat
 from datamodel_code_generator.types import (
-    UnionIntFloat,  # noqa: F401 # legacy public import
     chain_as_tuple,
     merge_normalized_constraint,
     normalize_integer_constraint,
@@ -40,6 +38,12 @@ if TYPE_CHECKING:
     from datamodel_code_generator.imports import Import
     from datamodel_code_generator.reference import Reference
     from datamodel_code_generator.types import DataType
+
+# Preserve names that were historically importable from this module.
+Field = _Field
+ConstraintsBase = _ConstraintsBase
+PatternConstraints = _PatternConstraints
+UnionIntFloat = _UnionIntFloat
 
 
 class DataModelField(DataModelFieldBase):

--- a/src/datamodel_code_generator/model/pydantic_base.py
+++ b/src/datamodel_code_generator/model/pydantic_base.py
@@ -10,21 +10,25 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-from pydantic import Field
+from pydantic import Field  # noqa: F401
 
 from datamodel_code_generator import cached_path_exists
 from datamodel_code_generator.model import (
     UNDEFINED,
-    ConstraintsBase,
+    ConstraintsBase,  # noqa: F401 # legacy public import
     DataModel,
     DataModelFieldBase,
     _rebuild_model_with_datamodel_namespace,
+)
+from datamodel_code_generator.model._constraints import (
+    Constraints,  # noqa: TC001 # needed for pydantic
+    PatternConstraints,  # noqa: F401 # legacy public import
 )
 from datamodel_code_generator.model._pydantic_imports import IMPORT_ANYURL, IMPORT_FIELD
 from datamodel_code_generator.model.base import _nested_model_default_factory
 from datamodel_code_generator.python_literal import represent_python_value
 from datamodel_code_generator.types import (
-    UnionIntFloat,
+    UnionIntFloat,  # noqa: F401 # legacy public import
     chain_as_tuple,
     merge_normalized_constraint,
     normalize_integer_constraint,
@@ -36,26 +40,6 @@ if TYPE_CHECKING:
     from datamodel_code_generator.imports import Import
     from datamodel_code_generator.reference import Reference
     from datamodel_code_generator.types import DataType
-
-
-class Constraints(ConstraintsBase):
-    """Pydantic field constraints (gt, ge, lt, le, regex, etc.)."""
-
-    gt: Optional[UnionIntFloat] = Field(None, alias="exclusiveMinimum")  # noqa: UP045
-    ge: Optional[UnionIntFloat] = Field(None, alias="minimum")  # noqa: UP045
-    lt: Optional[UnionIntFloat] = Field(None, alias="exclusiveMaximum")  # noqa: UP045
-    le: Optional[UnionIntFloat] = Field(None, alias="maximum")  # noqa: UP045
-    multiple_of: Optional[float] = Field(None, alias="multipleOf")  # noqa: UP045
-    min_items: Optional[int] = Field(None, alias="minItems")  # noqa: UP045
-    max_items: Optional[int] = Field(None, alias="maxItems")  # noqa: UP045
-    min_length: Optional[int] = Field(None, alias="minLength")  # noqa: UP045
-    max_length: Optional[int] = Field(None, alias="maxLength")  # noqa: UP045
-    regex: Optional[str] = Field(None, alias="pattern")  # noqa: UP045
-
-
-class PatternConstraints(Constraints):  # noqa: D101
-    regex: Optional[str] = Field(None, alias="regex")  # noqa: UP045
-    pattern: Optional[str] = Field(None, alias="pattern")  # noqa: UP045
 
 
 class DataModelField(DataModelFieldBase):

--- a/tests/data/expected/model/constraints_boundary.txt
+++ b/tests/data/expected/model/constraints_boundary.txt
@@ -1,0 +1,1 @@
+No neutral-layer pydantic_base imports.

--- a/tests/data/expected/model/constraints_boundary_violations.txt
+++ b/tests/data/expected/model/constraints_boundary_violations.txt
@@ -1,0 +1,3 @@
+forbidden.py:1: from datamodel_code_generator.model.pydantic_base import ...
+forbidden.py:2: import datamodel_code_generator.model.pydantic_base
+forbidden.py:3: from datamodel_code_generator.model import pydantic_base

--- a/tests/data/expected/model/constraints_compatibility.txt
+++ b/tests/data/expected/model/constraints_compatibility.txt
@@ -1,0 +1,33 @@
+Constraints identity: True
+PatternConstraints identity: True
+Field identity: True
+ConstraintsBase identity: True
+UnionIntFloat identity: True
+Constraints:
+  repr: <class 'datamodel_code_generator.model.pydantic_base.Constraints'>
+  module: datamodel_code_generator.model.pydantic_base
+  qualname: Constraints
+  doc: 'Pydantic field constraints (gt, ge, lt, le, regex, etc.).'
+  mro: ['datamodel_code_generator.model.pydantic_base.Constraints', 'datamodel_code_generator.model.base.ConstraintsBase', 'datamodel_code_generator.reference._BaseModel', 'pydantic.main.BaseModel', 'builtins.object']
+  annotations: {'gt': 'Optional[UnionIntFloat]', 'ge': 'Optional[UnionIntFloat]', 'lt': 'Optional[UnionIntFloat]', 'le': 'Optional[UnionIntFloat]', 'multiple_of': 'Optional[float]', 'min_items': 'Optional[int]', 'max_items': 'Optional[int]', 'min_length': 'Optional[int]', 'max_length': 'Optional[int]', 'regex': 'Optional[str]'}
+  resolved_annotations: ['_exclude_fields', '_pass_fields', 'ge', 'gt', 'le', 'lt', 'max_items', 'max_length', 'min_items', 'min_length', 'multiple_of', 'regex', 'unique_items']
+  fields: [('unique_items', 'uniqueItems'), ('gt', 'exclusiveMinimum'), ('ge', 'minimum'), ('lt', 'exclusiveMaximum'), ('le', 'maximum'), ('multiple_of', 'multipleOf'), ('min_items', 'minItems'), ('max_items', 'maxItems'), ('min_length', 'minLength'), ('max_length', 'maxLength'), ('regex', 'pattern')]
+  dump: {'minimum': 1, 'minItems': 2, 'pattern': 'x'}
+  schema_sha256: b62938b01628cfbb1dadd7241b470e7b8476ba68a27e604ab3fdf0886d969b65
+  pickle_path: True
+  pickle_identity: True
+  pickle_dump: {'minimum': 1, 'minItems': 2, 'pattern': 'x'}
+PatternConstraints:
+  repr: <class 'datamodel_code_generator.model.pydantic_base.PatternConstraints'>
+  module: datamodel_code_generator.model.pydantic_base
+  qualname: PatternConstraints
+  doc: None
+  mro: ['datamodel_code_generator.model.pydantic_base.PatternConstraints', 'datamodel_code_generator.model.pydantic_base.Constraints', 'datamodel_code_generator.model.base.ConstraintsBase', 'datamodel_code_generator.reference._BaseModel', 'pydantic.main.BaseModel', 'builtins.object']
+  annotations: {'regex': 'Optional[str]', 'pattern': 'Optional[str]'}
+  resolved_annotations: ['_exclude_fields', '_pass_fields', 'ge', 'gt', 'le', 'lt', 'max_items', 'max_length', 'min_items', 'min_length', 'multiple_of', 'pattern', 'regex', 'unique_items']
+  fields: [('unique_items', 'uniqueItems'), ('gt', 'exclusiveMinimum'), ('ge', 'minimum'), ('lt', 'exclusiveMaximum'), ('le', 'maximum'), ('multiple_of', 'multipleOf'), ('min_items', 'minItems'), ('max_items', 'maxItems'), ('min_length', 'minLength'), ('max_length', 'maxLength'), ('regex', 'regex'), ('pattern', 'pattern')]
+  dump: {'minimum': 1, 'minItems': 2, 'pattern': 'x'}
+  schema_sha256: 2ddfd965e7edbd2218523c966890e93df7e316fbdbefda6c6453b5ef545e9b74
+  pickle_path: True
+  pickle_identity: True
+  pickle_dump: {'minimum': 1, 'minItems': 2, 'pattern': 'x'}

--- a/tests/data/expected/model/constraints_imports.txt
+++ b/tests/data/expected/model/constraints_imports.txt
@@ -1,0 +1,6 @@
+dataclass pydantic_base loaded: False
+dataclass constraint module: datamodel_code_generator.model.pydantic_base
+msgspec pydantic_base loaded: False
+msgspec constraint base module: datamodel_code_generator.model.pydantic_base
+legacy constraints identity: True
+legacy pattern identity: True

--- a/tests/data/model/constraints_boundary/forbidden.py
+++ b/tests/data/model/constraints_boundary/forbidden.py
@@ -1,0 +1,3 @@
+from datamodel_code_generator.model.pydantic_base import Constraints
+import datamodel_code_generator.model.pydantic_base
+from datamodel_code_generator.model import pydantic_base

--- a/tests/model/test_constraints.py
+++ b/tests/model/test_constraints.py
@@ -1,0 +1,146 @@
+"""Compatibility tests for shared field-constraint models."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+from typing import get_type_hints
+
+from pydantic import Field
+
+from datamodel_code_generator.model import ConstraintsBase, pydantic_base
+from datamodel_code_generator.model._constraints import Constraints as SharedConstraints
+from datamodel_code_generator.model._constraints import PatternConstraints as SharedPatternConstraints
+from datamodel_code_generator.model.pydantic_base import Constraints as LegacyConstraints
+from datamodel_code_generator.model.pydantic_base import PatternConstraints as LegacyPatternConstraints
+from datamodel_code_generator.types import UnionIntFloat
+from tests.conftest import assert_output
+
+SOURCE_PATH = Path(__file__).parents[2] / "src" / "datamodel_code_generator"
+BOUNDARY_FIXTURE_PATH = Path(__file__).parents[1] / "data" / "model" / "constraints_boundary"
+EXPECTED_MODEL_PATH = Path(__file__).parents[1] / "data" / "expected" / "model"
+
+
+def _find_neutral_pydantic_base_imports(source_path: Path) -> list[str]:
+    violations = []
+    for source_file in source_path.rglob("*.py"):
+        relative_path = source_file.relative_to(source_path)
+        if relative_path == Path("model/pydantic_base.py") or relative_path.parts[:2] == ("model", "pydantic_v2"):
+            continue
+
+        for node in ast.walk(ast.parse(source_file.read_text(encoding="utf-8"))):
+            match node:
+                case ast.ImportFrom(module=module) if module and (
+                    module == "pydantic_base" or module.endswith("model.pydantic_base")
+                ):
+                    violations.append(f"{relative_path}:{node.lineno}: from {module} import ...")
+                case ast.ImportFrom(module=module, names=names, level=level) if forbidden_names := [
+                    name.name for name in names if name.name == "pydantic_base"
+                ]:
+                    import_from = "." * level + (module or "")
+                    violations.extend(
+                        f"{relative_path}:{node.lineno}: from {import_from} import {forbidden_name}"
+                        for forbidden_name in forbidden_names
+                    )
+                case ast.Import(names=names) if forbidden_names := [
+                    name.name for name in names if name.name == "datamodel_code_generator.model.pydantic_base"
+                ]:
+                    violations.extend(
+                        f"{relative_path}:{node.lineno}: import {forbidden_name}" for forbidden_name in forbidden_names
+                    )
+    return violations
+
+
+def test_constraint_public_surface_compatibility() -> None:
+    """Keep legacy imports, metadata, schemas, and pickles compatible."""
+    lines = [
+        f"Constraints identity: {SharedConstraints is LegacyConstraints}",
+        f"PatternConstraints identity: {SharedPatternConstraints is LegacyPatternConstraints}",
+        f"Field identity: {pydantic_base.Field is Field}",
+        f"ConstraintsBase identity: {pydantic_base.ConstraintsBase is ConstraintsBase}",
+        f"UnionIntFloat identity: {pydantic_base.UnionIntFloat is UnionIntFloat}",
+    ]
+    for constraint_type in (LegacyConstraints, LegacyPatternConstraints):
+        value = constraint_type.model_validate({"minimum": 1, "pattern": "x", "minItems": 2})
+        payload = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        restored = pickle.loads(payload)
+        canonical_schema = json.dumps(
+            constraint_type.model_json_schema(),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        lines.extend((
+            f"{constraint_type.__name__}:",
+            f"  repr: {constraint_type!r}",
+            f"  module: {constraint_type.__module__}",
+            f"  qualname: {constraint_type.__qualname__}",
+            f"  doc: {constraint_type.__doc__!r}",
+            f"  mro: {[f'{base.__module__}.{base.__qualname__}' for base in constraint_type.__mro__]!r}",
+            f"  annotations: {constraint_type.__annotations__!r}",
+            f"  resolved_annotations: {sorted(get_type_hints(constraint_type))!r}",
+            f"  fields: {[(name, field.alias) for name, field in constraint_type.model_fields.items()]!r}",
+            f"  dump: {value.model_dump(mode='json', by_alias=True, exclude_unset=True)!r}",
+            f"  schema_sha256: {hashlib.sha256(canonical_schema.encode()).hexdigest()}",
+            f"  pickle_path: {b'datamodel_code_generator.model.pydantic_base' in payload}",
+            f"  pickle_identity: {restored.__class__ is constraint_type}",
+            f"  pickle_dump: {restored.model_dump(mode='json', by_alias=True, exclude_unset=True)!r}",
+        ))
+
+    assert_output("\n".join(lines) + "\n", EXPECTED_MODEL_PATH / "constraints_compatibility.txt")
+
+
+def test_neutral_model_imports_do_not_load_pydantic_backend() -> None:
+    """Keep dataclass and msgspec cold imports independent of the Pydantic backend."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import sys
+from datamodel_code_generator.model import dataclass as dataclass_model
+
+print(f"dataclass pydantic_base loaded: {'datamodel_code_generator.model.pydantic_base' in sys.modules}")
+print(f"dataclass constraint module: {dataclass_model.Constraints.__module__}")
+
+from datamodel_code_generator.model import msgspec as msgspec_model
+
+print(f"msgspec pydantic_base loaded: {'datamodel_code_generator.model.pydantic_base' in sys.modules}")
+print(f"msgspec constraint base module: {msgspec_model.Constraints.__mro__[1].__module__}")
+
+from datamodel_code_generator.model._constraints import Constraints, PatternConstraints
+from datamodel_code_generator.model.pydantic_base import Constraints as LegacyConstraints
+from datamodel_code_generator.model.pydantic_base import PatternConstraints as LegacyPatternConstraints
+
+print(f"legacy constraints identity: {LegacyConstraints is Constraints}")
+print(f"legacy pattern identity: {LegacyPatternConstraints is PatternConstraints}")
+""",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert_output(result.stdout, EXPECTED_MODEL_PATH / "constraints_imports.txt")
+
+
+def test_only_pydantic_backend_imports_pydantic_base() -> None:
+    """Prevent neutral layers from depending on the Pydantic backend again."""
+    violations = _find_neutral_pydantic_base_imports(SOURCE_PATH)
+    assert_output(
+        "".join(f"{violation}\n" for violation in violations) or "No neutral-layer pydantic_base imports.\n",
+        EXPECTED_MODEL_PATH / "constraints_boundary.txt",
+    )
+
+
+def test_pydantic_base_boundary_detector_reports_forbidden_imports() -> None:
+    """Keep both supported import forms covered by an external fixture."""
+    violations = _find_neutral_pydantic_base_imports(BOUNDARY_FIXTURE_PATH)
+    assert_output(
+        "".join(f"{violation}\n" for violation in violations),
+        EXPECTED_MODEL_PATH / "constraints_boundary_violations.txt",
+    )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized shared constraint models (including JSON-schema/OpenAPI-style field names like `minimum`, `pattern`, `minLength`, `maxItems`) for consistent behavior across outputs.
  - Updated pydantic, dataclass, and msgspec paths to use the shared constraint definitions.
  - Preserved legacy import compatibility through module identity handling and re-exports.

- **Tests**
  - Added compatibility, deterministic schema, and pickle round-trip coverage for constraint models.
  - Added import-boundary checks to ensure neutral model types don’t load backend-specific modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->