### PR TITLE
Move template reference metadata to output models

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -42,7 +42,7 @@ from datamodel_code_generator.types import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Collection, Iterator
 
     from jinja2 import Environment, Template
 
@@ -54,6 +54,7 @@ _TYPING_IMPORT_NAMES: frozenset[str] = frozenset({
     IMPORT_OPTIONAL.import_,
     IMPORT_UNION.import_,
 })
+_ADDITIONAL_PROPERTIES_REFERENCE_CLASSES_TEMPLATE_DATA_KEY = "additionalPropertiesReferenceClasses"
 _MODULE_NAME_INVALID_CHAR_PATTERN = re.compile(r"[^0-9a-zA-Z_]")
 _MODULE_NAME_INVALID_CHAR_WITH_DOTS_PATTERN = re.compile(r"[^0-9a-zA-Z_.]")
 
@@ -1210,6 +1211,19 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     ) -> type[DataModel]:
         """Return the model type used for nested constrained values."""
         return configured_root_model_type
+
+    @staticmethod
+    def _store_additional_properties_reference_classes(
+        extra_template_data: dict[str, Any],
+        reference_classes: set[str],
+    ) -> None:
+        """Store parse-time additional-properties dependencies in model-owned metadata."""
+        extra_template_data[_ADDITIONAL_PROPERTIES_REFERENCE_CLASSES_TEMPLATE_DATA_KEY] = reference_classes
+
+    @property
+    def _additional_properties_reference_classes(self) -> Collection[str]:
+        """Return model-owned dependencies contributed by additional properties."""
+        return self.extra_template_data.get(_ADDITIONAL_PROPERTIES_REFERENCE_CLASSES_TEMPLATE_DATA_KEY, ())
 
     def __init__(  # noqa: PLR0913
         self,

--- a/src/datamodel_code_generator/model/typed_dict.py
+++ b/src/datamodel_code_generator/model/typed_dict.py
@@ -115,7 +115,7 @@ class TypedDict(DataModel):
         if additional_props is False and not is_base_class:
             typed_dict_kwargs["closed"] = "True"
         elif additional_props_type and not is_base_class:
-            if self.extra_template_data.get("additionalPropertiesReferenceClasses"):
+            if len(self._additional_properties_reference_classes):
                 typed_dict_kwargs["extra_items"] = repr(additional_props_type)
             else:
                 typed_dict_kwargs["extra_items"] = additional_props_type

--- a/src/datamodel_code_generator/parser/_output_context.py
+++ b/src/datamodel_code_generator/parser/_output_context.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from datamodel_code_generator.model.base import DataModel, DataModelFieldBase
     from datamodel_code_generator.types import DataTypeManager
 
@@ -78,3 +80,20 @@ class OutputModelContext:
     def resolve_nested_constrained_model_type(self) -> type[DataModel]:
         """Return the root model used for an inline constrained value."""
         return self._data_model_type.resolve_nested_constrained_model_type(self._data_model_root_type)
+
+    def _store_additional_properties_reference_classes(
+        self,
+        extra_template_data: dict[str, Any],
+        reference_classes: set[str],
+    ) -> None:
+        """Store parse-time dependencies through every possible output model type."""
+        store_data_model_metadata = self._data_model_type._store_additional_properties_reference_classes  # noqa: SLF001
+        store_data_model_metadata(extra_template_data, reference_classes)
+        if self._data_model_root_type is self._data_model_type:
+            return
+        store_root_model_metadata = (
+            self._data_model_root_type._store_additional_properties_reference_classes  # noqa: SLF001
+        )
+        if store_root_model_metadata is store_data_model_metadata:
+            return
+        store_root_model_metadata(extra_template_data, reference_classes)

--- a/src/datamodel_code_generator/parser/generation.py
+++ b/src/datamodel_code_generator/parser/generation.py
@@ -16,6 +16,8 @@ Contributor guide:
   ``model.reference.name`` directly in parser code.
 * Read dependency facts through ``GenerationIndex``. Parser post-processing
   should not treat ``Reference.children`` as the source of truth.
+* Treat output template metadata as opaque. Read model-owned dependency
+  metadata through ``DataModel`` capability methods.
 * Preserve output compatibility first. Store/index queries must reproduce the
   existing parse order, naming order, canonical model selection, and
   tie-break behavior before they replace a direct object traversal.
@@ -459,7 +461,9 @@ class GenerationIndex:
             for data_type_id in facts.data_types_by_model.get(model_id, ())
             if (reference := (fact := facts.data_type_facts[data_type_id]).reference) is not None
             if include_dict_key_references or fact.role != "dict_key"
-        ) | frozenset(model.extra_template_data.get("additionalPropertiesReferenceClasses", ()))
+        )
+        if len(additional_properties_references := model._additional_properties_reference_classes):  # noqa: SLF001
+            reference_classes = reference_classes.union(additional_properties_references)
         self._reference_classes_cache[model_id] = reference_classes
         return reference_classes
 

--- a/src/datamodel_code_generator/parser/jsonschema.py
+++ b/src/datamodel_code_generator/parser/jsonschema.py
@@ -2225,7 +2225,10 @@ class JsonSchemaParser(Parser["JSONSchemaParserConfig", "JsonSchemaFeatures"]):
                         if data_type.reference
                     }
                 ):
-                    self.extra_template_data[path]["additionalPropertiesReferenceClasses"] = reference_classes
+                    self._output_model_context._store_additional_properties_reference_classes(  # noqa: SLF001
+                        self.extra_template_data[path],
+                        reference_classes,
+                    )
                 if not self.target_python_version.has_typed_dict_closed:  # pragma: no branch
                     self.extra_template_data[path]["use_typeddict_backport"] = True
 

--- a/tests/parser/test_generation.py
+++ b/tests/parser/test_generation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+from collections import defaultdict
 from operator import iadd, imul
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,6 +20,7 @@ from datamodel_code_generator.model.pydantic_v2.version import (
     PYDANTIC_V2_ROOT_MODEL_DICT_KEY_FORWARD_REF_NEEDS_SORTING,
 )
 from datamodel_code_generator.model.type_alias import TypeAliasTypeBackport
+from datamodel_code_generator.model.typed_dict import TypedDict
 from datamodel_code_generator.parser.generation import (
     GENERATION_STORE_MUTATION_METHODS,
     GenerationStore,
@@ -117,6 +120,55 @@ def test_generation_store_import_cache_contract_covers_mutation_surface() -> Non
     assert (
         IMPORT_CACHE_CLEARING_MUTATION_METHODS | IMPORT_CACHE_NEUTRAL_MUTATION_METHODS
     ) == GENERATION_STORE_MUTATION_METHODS
+
+
+def test_parser_layers_treat_output_template_metadata_as_opaque() -> None:
+    """Parser facts must use model capabilities instead of backend template keys."""
+    generation_path = Path(__file__).parents[2] / "src/datamodel_code_generator/parser/generation.py"
+    jsonschema_path = generation_path.with_name("jsonschema.py")
+    attributes = {
+        node.attr
+        for node in ast.walk(ast.parse(generation_path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Attribute)
+    }
+
+    assert "extra_template_data" not in attributes
+    assert all(
+        "additionalPropertiesReferenceClasses" not in path.read_text(encoding="utf-8")
+        for path in (generation_path, jsonschema_path)
+    )
+
+
+def test_generation_index_does_not_use_metadata_collection_truthiness() -> None:
+    """Consume every model-owned dependency even when a collection overrides truthiness."""
+
+    class FalseyReferenceClasses(frozenset[str]):
+        def __bool__(self) -> bool:
+            return False
+
+    reference_classes = FalseyReferenceClasses({"Metadata"})
+    assert not reference_classes
+
+    class MetadataModel(TypedDict):
+        @property
+        def _additional_properties_reference_classes(self) -> frozenset[str]:
+            return reference_classes
+
+    model = MetadataModel(
+        fields=[],
+        reference=Reference(path="Model", original_name="Model", name="Model"),
+        extra_template_data=defaultdict(dict, {"Model": {"additionalPropertiesType": "Metadata"}}),
+    )
+    store = GenerationStore()
+    store.register_model(model)
+
+    assert {
+        "reference_classes": store.index.reference_classes_for_model(model),
+        "typed_dict_kwargs": model.extra_template_data["typed_dict_kwargs"],
+    } == snapshot({
+        "reference_classes": frozenset({"Metadata"}),
+        "typed_dict_kwargs": {"extra_items": "'Metadata'"},
+    })
 
 
 def test_generation_store_indexes_model_and_reference_order() -> None:

--- a/tests/parser/test_output_context.py
+++ b/tests/parser/test_output_context.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from typing import TYPE_CHECKING, Any
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -15,9 +16,9 @@ from datamodel_code_generator.model.base import UNDEFINED, DataModel, DataModelF
 from datamodel_code_generator.model.type_alias import TypeAliasTypeBackport
 from datamodel_code_generator.parser._output_context import OutputModelContext
 from datamodel_code_generator.parser.jsonschema import JsonSchemaObject, JsonSchemaParser
+from datamodel_code_generator.reference import Reference
 
 if TYPE_CHECKING:
-    from datamodel_code_generator.reference import Reference
     from datamodel_code_generator.types import DataType
 
 _OUTPUT_CAPABILITIES: dict[DataModelType, tuple[bool, bool, bool, bool]] = {
@@ -220,6 +221,89 @@ def test_mixed_builtin_generation_contexts_fail_closed_for_annotated_constraints
     assert context.supports_boolean_literals is expected_capabilities[1]
     assert context.requires_tagged_union_discriminator is expected_capabilities[2]
     assert context.requires_additional_properties_reference_classes is expected_capabilities[3]
+
+
+@pytest.mark.allow_direct_assert
+def test_output_context_stores_reference_metadata_for_data_and_root_model_types() -> None:
+    """Keep custom data and root model metadata encodings aligned with either output shape."""
+    model_types = get_data_model_types(
+        DataModelType.TypingTypedDict,
+        target_python_version=PythonVersion.PY_311,
+    )
+
+    def store_metadata(
+        model_type: type[DataModel],
+        extra_template_data: dict[str, Any],
+        reference_classes: set[str],
+    ) -> None:
+        extra_template_data[model_type.__dict__["_test_reference_key"]] = reference_classes
+
+    def metadata_references(model: DataModel) -> Any:
+        return model.extra_template_data.get(type(model).__dict__["_test_reference_key"], ())
+
+    def custom_model_type(name: str, base: type[DataModel], key: str) -> type[DataModel]:
+        return cast(
+            "type[DataModel]",
+            type(
+                name,
+                (base,),
+                {
+                    "_additional_properties_reference_classes": property(metadata_references),
+                    "_store_additional_properties_reference_classes": classmethod(store_metadata),
+                    "_test_reference_key": key,
+                },
+            ),
+        )
+
+    data_model_type = custom_model_type("CustomDataModel", model_types.data_model, "data_model_references")
+    root_model_type = custom_model_type("CustomRootModel", model_types.root_model, "root_model_references")
+    context = OutputModelContext.from_generation_types(
+        data_model_type=data_model_type,
+        data_model_root_type=root_model_type,
+        data_model_field_type=model_types.field_model,
+        data_type_manager_type=model_types.data_type_manager,
+        configured_types_are_builtin=False,
+        use_annotated=False,
+    )
+    reference_classes = {"Dependency"}
+    separate_metadata: dict[str, Any] = {}
+    shared_metadata: dict[str, Any] = {}
+
+    context._store_additional_properties_reference_classes(separate_metadata, reference_classes)
+    OutputModelContext.from_generation_types(
+        data_model_type=data_model_type,
+        data_model_root_type=data_model_type,
+        data_model_field_type=model_types.field_model,
+        data_type_manager_type=model_types.data_type_manager,
+        configured_types_are_builtin=False,
+        use_annotated=False,
+    )._store_additional_properties_reference_classes(shared_metadata, reference_classes)
+
+    data_model = data_model_type(
+        fields=[],
+        reference=Reference(path="DataModel", original_name="DataModel", name="DataModel"),
+        extra_template_data=defaultdict(dict, {"DataModel": separate_metadata}),
+    )
+    root_model = root_model_type(
+        fields=[],
+        reference=Reference(path="RootModel", original_name="RootModel", name="RootModel"),
+        extra_template_data=defaultdict(dict, {"RootModel": separate_metadata}),
+    )
+
+    assert {
+        "metadata": separate_metadata,
+        "data_model_references": set(data_model._additional_properties_reference_classes),
+        "root_model_references": set(root_model._additional_properties_reference_classes),
+        "shared_metadata": shared_metadata,
+    } == {
+        "metadata": {
+            "data_model_references": {"Dependency"},
+            "root_model_references": {"Dependency"},
+        },
+        "data_model_references": {"Dependency"},
+        "root_model_references": {"Dependency"},
+        "shared_metadata": {"data_model_references": {"Dependency"}},
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation of closed `TypedDict` definitions when schemas use “additional properties” reference classes.
  * Preserved “additional properties” reference-class metadata correctly across data models and root models.
  * Ensured reference-class dependencies are handled reliably without relying on collection truthiness.
* **Tests**
  * Added parser and output-context tests to verify correct metadata handling and generated output behavior.
* **Documentation**
  * Clarified that output-template metadata is treated as opaque by the generator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->