### PR TITLE
Reuse remote schema connections

### DIFF
--- a/src/datamodel_code_generator/http.py
+++ b/src/datamodel_code_generator/http.py
@@ -7,9 +7,11 @@ file:// URLs are handled without additional dependencies.
 
 from __future__ import annotations
 
+import contextlib
 import socket
 import ssl
-from collections.abc import Iterable, Sequence
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Sequence
 from ipaddress import IPv4Address, IPv6Address, IPv6Network, ip_address
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Protocol, cast, overload
@@ -40,7 +42,13 @@ class _HTTPResponse(Protocol):
     text: str
 
 
+class _HTTPCookies(Protocol):
+    def clear(self) -> None: ...
+
+
 class _HTTPXClient(Protocol):
+    cookies: _HTTPCookies
+
     def __enter__(self) -> Self: ...
 
     def __exit__(
@@ -59,9 +67,17 @@ class _HTTPXClient(Protocol):
         params: Sequence[tuple[str, str]] | None,
     ) -> _HTTPResponse: ...
 
+    def close(self) -> None: ...
+
 
 class _HTTPXClientFactory(Protocol):
-    def __call__(self, *, transport: httpx.BaseTransport, timeout: float) -> _HTTPXClient: ...
+    def __call__(
+        self,
+        *,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float,
+        verify: bool = True,
+    ) -> _HTTPXClient: ...
 
 
 class _HTTPXURLJoiner(Protocol):
@@ -126,6 +142,8 @@ def _get_httpx() -> _HTTPXModule:
 
 DEFAULT_HTTP_TIMEOUT = 30.0
 MAX_HTTP_REDIRECTS = 20
+_HTTP_FETCH_CLIENT_CACHE_MAX_SIZE = 32
+_HTTP_FETCH_DNS_CACHE_MAX_SIZE = 128
 _HTTP_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 _SENSITIVE_REDIRECT_HEADERS = frozenset({"authorization", "cookie", "proxy-authorization"})
 _UNSAFE_HOST_NAMES = frozenset({"localhost"})
@@ -416,12 +434,13 @@ def _build_pinned_transport(
     )
 
     class _PinnedHTTPTransport(httpx_runtime.BaseTransport):
-        """Request-scoped transport bound to a pinned httpcore connection pool."""
+        """Transport bound to a pinned httpcore connection pool."""
 
         def __init__(self) -> None:
             """Create the pool with the pinned backend.
 
-            The transport is created per fetch, so validated addresses do not leak into unrelated requests.
+            Parser sessions cache this transport only for the matching validated host,
+            address set, TLS policy, and timeout.
             """
             self._pool = httpcore.ConnectionPool(
                 ssl_context=_create_ssl_context(verify=verify),
@@ -461,10 +480,131 @@ def _build_pinned_transport(
             )
 
         def close(self) -> None:
-            """Close the request-scoped connection pool and release sockets."""
+            """Close the pinned connection pool and release sockets."""
             self._pool.close()
 
     return _PinnedHTTPTransport()
+
+
+class _HTTPFetchSession:
+    """Reuse validated DNS results and HTTP connection pools for one parser run.
+
+    The session is deliberately private and parser-scoped. Public ``get_body()``
+    calls keep their request-scoped behavior, while parsers can reuse connections
+    across distinct remote references without sharing network state globally.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty size- and parser-lifetime-bounded caches."""
+        self._dns_cache: OrderedDict[str, tuple[IPv4Address | IPv6Address, ...]] = OrderedDict()
+        self._clients: OrderedDict[
+            tuple[str | None, tuple[IPv4Address | IPv6Address, ...], bool, float],
+            _HTTPXClient,
+        ] = OrderedDict()
+
+    def __enter__(self) -> Self:
+        """Return this parser-scoped session."""
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        """Close every cached connection pool."""
+        self.close()
+
+    def get_ips_from_host(self, host: str) -> tuple[IPv4Address | IPv6Address, ...]:
+        """Return a successful DNS result cached for this parser run."""
+        if (cached_ips := self._dns_cache.get(host)) is not None:
+            self._dns_cache.move_to_end(host)
+            return cached_ips
+        if not (resolved_ips := _get_ips_from_host(host)):
+            return resolved_ips
+        self._dns_cache[host] = resolved_ips
+        if len(self._dns_cache) > _HTTP_FETCH_DNS_CACHE_MAX_SIZE:
+            self._dns_cache.popitem(last=False)
+        return resolved_ips
+
+    def get_response(  # noqa: PLR0913
+        self,
+        httpx_module: _HTTPXModule,
+        url: str,
+        *,
+        headers: Sequence[tuple[str, str]] | None,
+        verify: bool,
+        follow_redirects: bool,
+        query_parameters: Sequence[tuple[str, str]] | None,
+        timeout: float,
+        pinned_host: str | None,
+        pinned_ips: tuple[IPv4Address | IPv6Address, ...],
+    ) -> _HTTPResponse:
+        """Fetch through a connection pool isolated by DNS pin and TLS policy."""
+        key = (pinned_host, pinned_ips, verify, timeout)
+        if (client := self._clients.get(key)) is None:
+            if pinned_host is not None and pinned_ips:
+                transport = _build_pinned_transport(
+                    pinned_host=pinned_host,
+                    pinned_ips=pinned_ips,
+                    verify=verify,
+                )
+                client = httpx_module.Client(transport=transport, timeout=timeout)
+            else:
+                client = httpx_module.Client(timeout=timeout, verify=verify)
+            self._clients[key] = client
+            if len(self._clients) > _HTTP_FETCH_CLIENT_CACHE_MAX_SIZE:
+                _, evicted_client = self._clients.popitem(last=False)
+                with contextlib.suppress(Exception):
+                    evicted_client.close()
+        else:
+            self._clients.move_to_end(key)
+        try:
+            return client.get(
+                url,
+                headers=headers,
+                follow_redirects=follow_redirects,
+                params=query_parameters,
+            )
+        finally:
+            cookie_cleanup_failed = True
+            with contextlib.suppress(Exception):
+                client.cookies.clear()
+                cookie_cleanup_failed = False
+            if cookie_cleanup_failed:
+                if self._clients.get(key) is client:
+                    del self._clients[key]
+                with contextlib.suppress(Exception):
+                    client.close()
+
+    def get_body(  # noqa: PLR0913
+        self,
+        url: str,
+        headers: Sequence[tuple[str, str]] | None = None,
+        ignore_tls: bool = False,  # noqa: FBT001, FBT002
+        query_parameters: Sequence[tuple[str, str]] | None = None,
+        timeout: float = DEFAULT_HTTP_TIMEOUT,
+        *,
+        allow_private_network: bool = False,
+    ) -> str:
+        """Fetch one URL while reusing this parser run's validated resources."""
+        return _get_body(
+            url,
+            headers,
+            ignore_tls,
+            query_parameters,
+            timeout,
+            allow_private_network=allow_private_network,
+            session=self,
+        )
+
+    def close(self) -> None:
+        """Close cached clients and discard validated DNS results."""
+        clients, self._clients = self._clients, OrderedDict()
+        self._dns_cache.clear()
+        for client in clients.values():
+            with contextlib.suppress(Exception):
+                client.close()
 
 
 def _get_http_response(  # noqa: PLR0913
@@ -532,6 +672,7 @@ def _validate_url_for_fetch(
     url: str,
     *,
     allow_private_network: bool,
+    resolve_host: Callable[[str], tuple[IPv4Address | IPv6Address, ...]] = _get_ips_from_host,
 ) -> tuple[str, tuple[IPv4Address | IPv6Address, ...]] | None:
     """Validate a fetch URL and return DNS pinning data when pinning is required.
 
@@ -567,7 +708,7 @@ def _validate_url_for_fetch(
         )
         raise SchemaFetchError(msg)
 
-    ips = _get_ips_from_host(host)
+    ips = resolve_host(host)
     if not ips:
         msg = _format_private_network_error(
             url=url,
@@ -667,14 +808,47 @@ def get_body(  # noqa: PLR0913
     can be narrowed before the next request. Once a redirect crosses origins, scoped credentials are removed
     from `current_headers` and are not restored on later hops.
     """
+    return _get_body(
+        url,
+        headers,
+        ignore_tls,
+        query_parameters,
+        timeout,
+        allow_private_network=allow_private_network,
+    )
+
+
+def _get_body(  # noqa: PLR0913
+    url: str,
+    headers: Sequence[tuple[str, str]] | None,
+    ignore_tls: bool,  # noqa: FBT001
+    query_parameters: Sequence[tuple[str, str]] | None,
+    timeout: float,
+    *,
+    allow_private_network: bool,
+    session: _HTTPFetchSession | None = None,
+) -> str:
+    """Fetch one schema body, optionally reusing parser-scoped network state."""
     httpx_module = _get_httpx()
+    match session:
+        case None:
+            resolve_host = _get_ips_from_host
+            get_response = _get_http_response
+        case _:
+            resolve_host = session.get_ips_from_host
+            get_response = session.get_response
+
     current_url = url
     current_headers = headers
     for redirect_count in range(MAX_HTTP_REDIRECTS + 1):
-        validated_host = _validate_url_for_fetch(current_url, allow_private_network=allow_private_network)
+        validated_host = _validate_url_for_fetch(
+            current_url,
+            allow_private_network=allow_private_network,
+            resolve_host=resolve_host,
+        )
         pinned_host, pinned_ips = validated_host if validated_host is not None else (None, ())
         try:
-            response = _get_http_response(
+            response = get_response(
                 httpx_module,
                 current_url,
                 headers=current_headers,
@@ -685,9 +859,9 @@ def get_body(  # noqa: PLR0913
                 pinned_host=pinned_host,
                 pinned_ips=pinned_ips,
             )
-        except Exception as e:
-            msg = f"Failed to fetch {current_url}: {e}"
-            raise SchemaFetchError(msg) from e
+        except Exception as exc:
+            msg = f"Failed to fetch {current_url}: {exc}"
+            raise SchemaFetchError(msg) from exc
         if (redirect_url := _get_redirect_url(httpx_module, current_url, response)) is None:
             break
         current_headers = _get_redirect_headers(current_headers, current_url, redirect_url)

--- a/src/datamodel_code_generator/http.py
+++ b/src/datamodel_code_generator/http.py
@@ -43,7 +43,8 @@ class _HTTPResponse(Protocol):
 
 
 class _HTTPCookies(Protocol):
-    def clear(self) -> None: ...
+    def clear(self) -> None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class _HTTPXClient(Protocol):
@@ -67,7 +68,8 @@ class _HTTPXClient(Protocol):
         params: Sequence[tuple[str, str]] | None,
     ) -> _HTTPResponse: ...
 
-    def close(self) -> None: ...
+    def close(self) -> None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class _HTTPXClientFactory(Protocol):
@@ -77,7 +79,8 @@ class _HTTPXClientFactory(Protocol):
         transport: httpx.BaseTransport | None = None,
         timeout: float,
         verify: bool = True,
-    ) -> _HTTPXClient: ...
+    ) -> _HTTPXClient:
+        raise NotImplementedError  # pragma: no cover
 
 
 class _HTTPXURLJoiner(Protocol):
@@ -830,13 +833,11 @@ def _get_body(  # noqa: PLR0913
 ) -> str:
     """Fetch one schema body, optionally reusing parser-scoped network state."""
     httpx_module = _get_httpx()
-    match session:
-        case None:
-            resolve_host = _get_ips_from_host
-            get_response = _get_http_response
-        case _:
-            resolve_host = session.get_ips_from_host
-            get_response = session.get_response
+    resolve_host = _get_ips_from_host
+    get_response = _get_http_response
+    if session is not None:
+        resolve_host = session.get_ips_from_host
+        get_response = session.get_response
 
     current_url = url
     current_headers = headers

--- a/src/datamodel_code_generator/parser/base.py
+++ b/src/datamodel_code_generator/parser/base.py
@@ -8,6 +8,7 @@ code generation.
 from __future__ import annotations
 
 import builtins
+import contextlib
 import operator
 import os.path
 import re
@@ -90,6 +91,7 @@ if TYPE_CHECKING:
     from datamodel_code_generator._types import ParserConfigDict
     from datamodel_code_generator.config import ParserConfig
     from datamodel_code_generator.format import CodeFormatter
+    from datamodel_code_generator.http import _HTTPFetchSession
     from datamodel_code_generator.model_metadata import GeneratedModelMetadata, ModelFieldMetadata, ModelMetadata
 ParserConfigT = TypeVar("ParserConfigT", bound="ParserConfig")
 
@@ -1419,6 +1421,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
     _config_class_name: ClassVar[str] = "ParserConfig"
     _cache_local_sources_during_parse: ClassVar[bool] = False
     _cache_parsed_sources_from_path: ClassVar[bool] = False
+    _http_fetch_session: _HTTPFetchSession | None = None
 
     @classmethod
     def _get_config_class(cls) -> type[ParserConfig]:
@@ -1926,19 +1929,24 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         return self.base_class or None
 
     def _get_text_from_url(self, url: str) -> str:
-        from datamodel_code_generator.http import DEFAULT_HTTP_TIMEOUT, get_body  # noqa: PLC0415
+        def fetch(remote_url: str) -> str:
+            from datamodel_code_generator.http import DEFAULT_HTTP_TIMEOUT, _HTTPFetchSession  # noqa: PLC0415
 
-        timeout = self.http_timeout if self.http_timeout is not None else DEFAULT_HTTP_TIMEOUT
-        return self.remote_text_cache.get_or_put(
-            url,
-            default_factory=lambda _url: get_body(
-                url,
+            if (session := self._http_fetch_session) is None:
+                self._http_fetch_session = session = _HTTPFetchSession()
+            timeout = self.http_timeout if self.http_timeout is not None else DEFAULT_HTTP_TIMEOUT
+            return session.get_body(
+                remote_url,
                 self.http_headers,
                 self.http_ignore_tls,
                 self.http_query_parameters,
                 timeout,
                 allow_private_network=self.allow_private_network,
-            ),
+            )
+
+        return self.remote_text_cache.get_or_put(
+            url,
+            default_factory=fetch,
         )
 
     @classmethod
@@ -4532,6 +4540,14 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
             ],
         }
 
+    def _close_http_fetch_session(self) -> None:
+        """Close and discard the parser-scoped HTTP session without masking parser results."""
+        if (session := self._http_fetch_session) is None:
+            return
+        self._http_fetch_session = None
+        with contextlib.suppress(Exception):
+            session.close()
+
     def _dispose(self) -> None:
         """Break reference cycles in the parsed object graph.
 
@@ -4541,6 +4557,7 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         counting reclaim the graph as soon as the parser is dropped, which
         matters for processes that call generate() repeatedly.
         """
+        self._close_http_fetch_session()
         self.generation_store._dispose(self.model_resolver.references.values())  # noqa: SLF001
         self.model_resolver.references.clear()
         self._reset_local_source_cache()
@@ -4564,7 +4581,10 @@ class Parser(ABC, Generic[ParserConfigT, SchemaFeaturesT]):
         self._set_typed_extra_annotation_mode(
             use_deferred_annotations=self._uses_deferred_annotations(with_import, disable_future_imports)
         )
-        self.parse_raw()
+        try:
+            self.parse_raw()
+        finally:
+            self._close_http_fetch_session()
 
         config = self._prepare_parse_config(
             with_import,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1143,12 +1143,25 @@ def mock_httpx_get(mocker: Any) -> HttpxGetMockFactory:
                 timeout=timeout,
             )
 
+        def _response_for_session(
+            _session: Any,
+            httpx_module: Any,
+            url: str,
+            **kwargs: Any,
+        ) -> Any:
+            return _response_for_validated_url(httpx_module, url, **kwargs)
+
         mocker.patch("socket.getaddrinfo", autospec=True, side_effect=_getaddrinfo_for_public_host)
         httpx_get_mock = cast("HttpxGetMock", mocker.patch("httpx.get", autospec=True, side_effect=_response_for_url))
         mocker.patch(
             "datamodel_code_generator.http._get_http_response",
             autospec=True,
             side_effect=_response_for_validated_url,
+        )
+        mocker.patch(
+            "datamodel_code_generator.http._HTTPFetchSession.get_response",
+            autospec=True,
+            side_effect=_response_for_session,
         )
         return httpx_get_mock
 

--- a/tests/parser/test_jsonschema.py
+++ b/tests/parser/test_jsonschema.py
@@ -666,7 +666,7 @@ def test_json_schema_object_ref_url_json(mocker: MockerFixture) -> None:
         "socket.getaddrinfo",
         return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))],
     )
-    mock_fetch = mocker.patch("datamodel_code_generator.http._get_http_response")
+    mock_fetch = mocker.patch("datamodel_code_generator.http._HTTPFetchSession.get_response")
     mock_fetch.return_value.status_code = 200
     mock_fetch.return_value.headers = {}
     mock_fetch.return_value.text = json.dumps(
@@ -714,7 +714,7 @@ def test_json_schema_object_ref_url_yaml(mocker: MockerFixture) -> None:
         "socket.getaddrinfo",
         return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))],
     )
-    mock_fetch = mocker.patch("datamodel_code_generator.http._get_http_response")
+    mock_fetch = mocker.patch("datamodel_code_generator.http._HTTPFetchSession.get_response")
     mock_fetch.return_value.status_code = 200
     mock_fetch.return_value.headers = {}
     mock_fetch.return_value.text = yaml.safe_dump(json.load((DATA_PATH / "user.json").open()))
@@ -761,7 +761,7 @@ def test_json_schema_object_cached_ref_url_yaml(mocker: MockerFixture) -> None:
         "socket.getaddrinfo",
         return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))],
     )
-    mock_fetch = mocker.patch("datamodel_code_generator.http._get_http_response")
+    mock_fetch = mocker.patch("datamodel_code_generator.http._HTTPFetchSession.get_response")
     mock_fetch.return_value.status_code = 200
     mock_fetch.return_value.headers = {}
     mock_fetch.return_value.text = yaml.safe_dump(json.load((DATA_PATH / "user.json").open()))
@@ -801,7 +801,7 @@ def test_json_schema_ref_url_json(mocker: MockerFixture) -> None:
         "socket.getaddrinfo",
         return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))],
     )
-    mock_fetch = mocker.patch("datamodel_code_generator.http._get_http_response")
+    mock_fetch = mocker.patch("datamodel_code_generator.http._HTTPFetchSession.get_response")
     mock_fetch.return_value.status_code = 200
     mock_fetch.return_value.headers = {}
     mock_fetch.return_value.text = json.dumps(json.load((DATA_PATH / "user.json").open()))

--- a/tests/parser/test_openapi.py
+++ b/tests/parser/test_openapi.py
@@ -712,7 +712,10 @@ schemas:
         "socket.getaddrinfo",
         return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))],
     )
-    mock_fetch = mocker.patch("datamodel_code_generator.http._get_http_response", return_value=mock_response)
+    mock_fetch = mocker.patch(
+        "datamodel_code_generator.http._HTTPFetchSession.get_response",
+        return_value=mock_response,
+    )
 
     parser = OpenAPIParser(
         data_model_field_type=DataModelFieldBase,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,7 +6,7 @@ import json
 import socket
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from ipaddress import ip_address
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import Mock
 
@@ -22,11 +22,13 @@ from datamodel_code_generator.http import (
     _get_httpx,
     _get_redirect_headers,
     _get_url_origin,
+    _HTTPFetchSession,
     _is_safe_ip,
     _normalize_dns_host,
     _PinnedNetworkBackend,
     get_body,
 )
+from datamodel_code_generator.parser.jsonschema import JsonSchemaParser
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -41,9 +43,19 @@ def block_dns_by_default(mocker: MockerFixture) -> None:
 
 
 class _SchemaHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    client_connections: ClassVar[set[tuple[str, int]]] = set()
+    connections_closed: ClassVar[threading.Event] = threading.Event()
+    cookie_redirect_target: ClassVar[str | None] = None
+    received_cookies: ClassVar[list[str | None]] = []
     routes: ClassVar[dict[str, tuple[int, dict[str, str], bytes]]] = {
         "/schema.json": (200, {"content-type": "application/json"}, b'{"type":"object"}'),
     }
+
+    def setup(self) -> None:
+        """Record each accepted TCP connection."""
+        super().setup()
+        self.client_connections.add(self.client_address)
 
     def do_GET(self) -> None:
         if self.path.startswith("/echo"):
@@ -51,6 +63,20 @@ class _SchemaHandler(BaseHTTPRequestHandler):
                 "path": self.path,
                 "test_header": self.headers.get("X-Test-Header"),
             }).encode()
+            status, headers = 200, {"content-type": "application/json"}
+        elif self.path == "/cookie-redirect" and self.cookie_redirect_target is not None:
+            status, headers, body = (
+                302,
+                {
+                    "location": self.cookie_redirect_target,
+                    "set-cookie": "session=secret; Path=/",
+                },
+                b"",
+            )
+        elif self.path == "/cookie-target":
+            cookie = self.headers.get("Cookie")
+            self.received_cookies.append(cookie)
+            body = json.dumps({"cookie": cookie}).encode()
             status, headers = 200, {"content-type": "application/json"}
         else:
             status, headers, body = self.routes.get(
@@ -65,6 +91,12 @@ class _SchemaHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def finish(self) -> None:
+        try:
+            super().finish()
+        finally:
+            self.connections_closed.set()
+
     def log_message(self, _format: str, *_args: object) -> None:
         return
 
@@ -72,6 +104,8 @@ class _SchemaHandler(BaseHTTPRequestHandler):
 @pytest.fixture
 def local_http_server() -> Iterator[str]:
     """Run a local HTTP server for transport-level tests."""
+    _SchemaHandler.client_connections.clear()
+    _SchemaHandler.connections_closed.clear()
     server = ThreadingHTTPServer(("127.0.0.1", 0), _SchemaHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -81,6 +115,30 @@ def local_http_server() -> Iterator[str]:
         server.shutdown()
         server.server_close()
         thread.join(timeout=2.0)
+
+
+@pytest.fixture
+def cross_port_cookie_redirect_server() -> Iterator[str]:
+    """Run a real redirect across two local ports."""
+    _SchemaHandler.client_connections.clear()
+    _SchemaHandler.connections_closed.clear()
+    _SchemaHandler.received_cookies.clear()
+    target_server = ThreadingHTTPServer(("127.0.0.1", 0), _SchemaHandler)
+    source_server = ThreadingHTTPServer(("127.0.0.1", 0), _SchemaHandler)
+    _SchemaHandler.cookie_redirect_target = f"http://localhost:{target_server.server_port}/cookie-target"
+    servers = (target_server, source_server)
+    threads = tuple(threading.Thread(target=server.serve_forever, daemon=True) for server in servers)
+    for thread in threads:
+        thread.start()
+    try:
+        yield f"http://localhost:{source_server.server_port}/cookie-redirect"
+    finally:
+        _SchemaHandler.cookie_redirect_target = None
+        for server in servers:
+            server.shutdown()
+            server.server_close()
+        for thread in threads:
+            thread.join(timeout=2.0)
 
 
 def test_get_body_raises_on_http_error(mocker: MockerFixture) -> None:
@@ -426,6 +484,230 @@ def test_get_http_response_uses_pinned_backend_with_real_local_http(
 
     assert schema_response.status_code == 200
     assert schema_response.text == '{"type":"object"}'
+
+
+def test_http_fetch_session_reuses_successful_dns_result(mocker: MockerFixture) -> None:
+    """Reuse successful DNS validation only within one fetch session."""
+    mocker.stopall()
+
+    with _HTTPFetchSession() as session:
+        first_result = session.get_ips_from_host("localhost")
+        second_result = session.get_ips_from_host("localhost")
+
+    assert first_result
+    assert second_result is first_result
+
+
+def test_http_fetch_session_retries_failed_dns_result(mocker: MockerFixture) -> None:
+    """Do not retain failed DNS lookups that may recover during a parser run."""
+    public_ip = ip_address("93.184.216.34")
+    resolver = mocker.patch(
+        "datamodel_code_generator.http._get_ips_from_host",
+        side_effect=[(), (public_ip,)],
+    )
+
+    with _HTTPFetchSession() as session:
+        assert session.get_ips_from_host("schema.example") == ()
+        assert session.get_ips_from_host("schema.example") == (public_ip,)
+
+    assert resolver.call_count == 2
+
+
+def test_http_fetch_session_bounds_successful_dns_cache_with_lru_eviction(mocker: MockerFixture) -> None:
+    """Retain only the most recently used successful DNS results."""
+    public_ip = ip_address("93.184.216.34")
+    mocker.patch("datamodel_code_generator.http._HTTP_FETCH_DNS_CACHE_MAX_SIZE", 2)
+    resolver = mocker.patch("datamodel_code_generator.http._get_ips_from_host", return_value=(public_ip,))
+
+    with _HTTPFetchSession() as session:
+        assert session.get_ips_from_host("one.example") == (public_ip,)
+        assert session.get_ips_from_host("two.example") == (public_ip,)
+        assert session.get_ips_from_host("one.example") == (public_ip,)
+        assert session.get_ips_from_host("three.example") == (public_ip,)
+        assert session.get_ips_from_host("two.example") == (public_ip,)
+
+    assert [call.args[0] for call in resolver.call_args_list] == [
+        "one.example",
+        "two.example",
+        "three.example",
+        "two.example",
+    ]
+
+
+def test_http_fetch_session_closes_evicted_and_remaining_clients_despite_errors(
+    mocker: MockerFixture,
+) -> None:
+    """Bound pooled clients and isolate cleanup failures."""
+    mocker.patch("datamodel_code_generator.http._HTTP_FETCH_CLIENT_CACHE_MAX_SIZE", 2)
+    clients = [Mock() for _ in range(3)]
+    clients[1].close.side_effect = RuntimeError("eviction close failed")
+    clients[2].cookies.clear.side_effect = RuntimeError("cookie cleanup failed")
+    httpx_module = Mock()
+    httpx_module.Client.side_effect = clients
+    session = _HTTPFetchSession()
+
+    for timeout in (1.0, 2.0, 1.0, 3.0):
+        session.get_response(
+            httpx_module,
+            "https://schema.example/schema.json",
+            headers=None,
+            verify=True,
+            follow_redirects=False,
+            query_parameters=None,
+            timeout=timeout,
+            pinned_host=None,
+            pinned_ips=(),
+        )
+
+    assert len(session._clients) == 1
+    clients[0].close.assert_not_called()
+    clients[1].close.assert_called_once_with()
+    clients[2].close.assert_called_once_with()
+    clients[0].close.side_effect = RuntimeError("session close failed")
+
+    session.close()
+
+    for client in clients:
+        client.close.assert_called_once_with()
+    assert [client.cookies.clear.call_count for client in clients] == [2, 1, 1]
+    assert not session._clients
+
+
+@pytest.mark.parametrize(
+    ("pinned_host", "pinned_ips"),
+    [
+        ("localhost", (ip_address("127.0.0.1"),)),
+        (None, ()),
+    ],
+    ids=["pinned", "trusted-private"],
+)
+def test_http_fetch_session_reuses_real_connection(
+    mocker: MockerFixture,
+    local_http_server: str,
+    pinned_host: str | None,
+    pinned_ips: tuple[IPv4Address | IPv6Address, ...],
+) -> None:
+    """Reuse one HTTP connection for distinct URLs on the same host."""
+    mocker.stopall()
+
+    with _HTTPFetchSession() as session:
+        echo_response = session.get_response(
+            _get_httpx(),
+            f"{local_http_server}/echo",
+            headers=None,
+            verify=True,
+            follow_redirects=False,
+            query_parameters=None,
+            timeout=5.0,
+            pinned_host=pinned_host,
+            pinned_ips=pinned_ips,
+        )
+        schema_response = session.get_response(
+            _get_httpx(),
+            f"{local_http_server}/schema.json",
+            headers=None,
+            verify=True,
+            follow_redirects=False,
+            query_parameters=None,
+            timeout=5.0,
+            pinned_host=pinned_host,
+            pinned_ips=pinned_ips,
+        )
+
+    assert echo_response.status_code == 200
+    assert schema_response.text == '{"type":"object"}'
+    assert len(_SchemaHandler.client_connections) == 1
+
+
+def test_http_fetch_session_does_not_replay_response_cookie_across_ports(
+    mocker: MockerFixture,
+    cross_port_cookie_redirect_server: str,
+) -> None:
+    """Do not turn response cookies into implicit headers on another origin."""
+    mocker.stopall()
+
+    with _HTTPFetchSession() as session:
+        result = session.get_body(
+            cross_port_cookie_redirect_server,
+            timeout=5.0,
+            allow_private_network=True,
+        )
+
+    assert json.loads(result) == {"cookie": None}
+    assert _SchemaHandler.received_cookies == [None]
+
+
+def test_parser_parse_closes_real_http_session(
+    mocker: MockerFixture,
+    local_http_server: str,
+) -> None:
+    """Close network resources for direct Parser.parse() users."""
+    mocker.stopall()
+    source = json.dumps({
+        "title": "Root",
+        "type": "object",
+        "properties": {
+            "child": {"$ref": f"{local_http_server}/schema.json"},
+        },
+    })
+    parser = JsonSchemaParser(
+        source,
+        allow_remote_refs=True,
+        allow_private_network=True,
+    )
+
+    result = parser.parse(format_=False)
+
+    assert isinstance(result, str)
+    assert "class Root" in result
+    assert parser._http_fetch_session is None
+    assert _SchemaHandler.connections_closed.wait(timeout=2.0)
+
+
+def test_parser_http_cleanup_errors_do_not_mask_generation_or_skip_disposal() -> None:
+    """Ignore HTTP cleanup errors while still returning output and disposing the graph."""
+    parser = JsonSchemaParser(
+        json.dumps({
+            "title": "Model",
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }),
+    )
+    parse_session = Mock()
+    parse_session.close.side_effect = RuntimeError("parse cleanup failed")
+    parser._http_fetch_session = parse_session
+
+    result = parser.parse(format_=False)
+
+    assert isinstance(result, str)
+    assert "class Model" in result
+    parse_session.close.assert_called_once_with()
+    assert parser._http_fetch_session is None
+    assert parser.model_resolver.references
+
+    dispose_session = Mock()
+    dispose_session.close.side_effect = RuntimeError("dispose cleanup failed")
+    parser._http_fetch_session = dispose_session
+    parser._dispose()
+
+    dispose_session.close.assert_called_once_with()
+    assert parser._http_fetch_session is None
+    assert not parser.model_resolver.references
+
+
+def test_parser_http_cleanup_does_not_mask_parse_error(mocker: MockerFixture) -> None:
+    """Keep the original parsing error when HTTP cleanup also fails."""
+    parser = JsonSchemaParser("")
+    session = Mock()
+    session.close.side_effect = RuntimeError("cleanup failed")
+    parser._http_fetch_session = session
+    mocker.patch.object(parser, "parse_raw", side_effect=ValueError("parse failed"))
+
+    with pytest.raises(ValueError, match="parse failed"):
+        parser.parse(format_=False)
+
+    session.close.assert_called_once_with()
+    assert parser._http_fetch_session is None
 
 
 def test_create_ssl_context_verify_modes() -> None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -573,6 +573,45 @@ def test_http_fetch_session_closes_evicted_and_remaining_clients_despite_errors(
     assert not session._clients
 
 
+def test_http_fetch_session_cookie_cleanup_does_not_remove_replacement_client() -> None:
+    """Keep a replacement pool entry when stale-client cookie cleanup fails."""
+    client = Mock()
+    replacement_client = Mock()
+    response = Mock()
+    httpx_module = Mock()
+    httpx_module.Client.return_value = client
+    session = _HTTPFetchSession()
+
+    def replace_cached_client(*_args: object, **_kwargs: object) -> Mock:
+        key = next(iter(session._clients))
+        session._clients[key] = replacement_client
+        return response
+
+    client.get.side_effect = replace_cached_client
+    client.cookies.clear.side_effect = RuntimeError("cookie cleanup failed")
+
+    assert (
+        session.get_response(
+            httpx_module,
+            "https://schema.example/schema.json",
+            headers=None,
+            verify=True,
+            follow_redirects=False,
+            query_parameters=None,
+            timeout=1.0,
+            pinned_host=None,
+            pinned_ips=(),
+        )
+        is response
+    )
+    assert list(session._clients.values()) == [replacement_client]
+    client.close.assert_called_once_with()
+
+    session.close()
+
+    replacement_client.close.assert_called_once_with()
+
+
 @pytest.mark.parametrize(
     ("pinned_host", "pinned_ips"),
     [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Faster remote schema fetching by reusing validated DNS results and pooled HTTP connections within a parsing run.
  - More reliable URL/redirect handling by validating and repinning each redirect hop.
  - Improved cookie isolation during redirects so cookies aren’t reused across different ports/targets.
  - DNS and connection pooling are now bounded with eviction to avoid unbounded growth.
- **Bug Fixes**
  - Improved HTTP session cleanup to reliably close pooled resources even when parsing/generation errors occur.
- **Tests**
  - Expanded coverage for DNS caching success/failure behavior, connection reuse, cookie redirect scenarios, and cleanup/error resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->