### PR TITLE
Fix vLLM usage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ These public examples are grouped by how each project uses datamodel-code-genera
 ### Development, testing, and evaluation
 
 - [browser-use/browser-use](https://github.com/browser-use/browser-use) - *[Evaluation dependency](https://github.com/browser-use/browser-use/blob/de14b9aa31d167696a7ea7185d71876dbd7e6c94/pyproject.toml#L74-L79)*
-- [vllm-project/vllm](https://github.com/vllm-project/vllm) - *[Test dependency for MiniCPM3 tests](https://github.com/vllm-project/vllm/blob/main/requirements/test/cuda.in#L39)*
+- [vllm-project/vllm](https://github.com/vllm-project/vllm) - *[Test dependency for MiniCPM3 tests](https://github.com/vllm-project/vllm/blob/46f01a50acd6862806ed67b88176c96c2b161142/requirements/test/cuda.in#L40)*
 - [stanfordnlp/dspy](https://github.com/stanfordnlp/dspy) - *[Generate Pydantic models from JSON Schema for reliability tests](https://github.com/stanfordnlp/dspy/blob/main/tests/reliability/generate/utils.py)*
 
 [See all dependents →](https://github.com/koxudaxi/datamodel-code-generator/network/dependents)

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,7 +227,7 @@ These public examples are grouped by how each project uses datamodel-code-genera
 ### Development, testing, and evaluation
 
 - [browser-use/browser-use](https://github.com/browser-use/browser-use) - *[Evaluation dependency](https://github.com/browser-use/browser-use/blob/de14b9aa31d167696a7ea7185d71876dbd7e6c94/pyproject.toml#L74-L79)*
-- [vllm-project/vllm](https://github.com/vllm-project/vllm) - *[Test dependency for MiniCPM3 tests](https://github.com/vllm-project/vllm/blob/main/requirements/test/cuda.in#L39)*
+- [vllm-project/vllm](https://github.com/vllm-project/vllm) - *[Test dependency for MiniCPM3 tests](https://github.com/vllm-project/vllm/blob/46f01a50acd6862806ed67b88176c96c2b161142/requirements/test/cuda.in#L40)*
 - [stanfordnlp/dspy](https://github.com/stanfordnlp/dspy) - *[Generate Pydantic models from JSON Schema for reliability tests](https://github.com/stanfordnlp/dspy/blob/main/tests/reliability/generate/utils.py)*
 
 [See all dependents →](https://github.com/koxudaxi/datamodel-code-generator/network/dependents)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -229,7 +229,7 @@ These public examples are grouped by how each project uses datamodel-code-genera
 ### Development, testing, and evaluation
 
 - [browser-use/browser-use](https://github.com/browser-use/browser-use) - *[Evaluation dependency](https://github.com/browser-use/browser-use/blob/de14b9aa31d167696a7ea7185d71876dbd7e6c94/pyproject.toml#L74-L79)*
-- [vllm-project/vllm](https://github.com/vllm-project/vllm) - *[Test dependency for MiniCPM3 tests](https://github.com/vllm-project/vllm/blob/main/requirements/test/cuda.in#L39)*
+- [vllm-project/vllm](https://github.com/vllm-project/vllm) - *[Test dependency for MiniCPM3 tests](https://github.com/vllm-project/vllm/blob/46f01a50acd6862806ed67b88176c96c2b161142/requirements/test/cuda.in#L40)*
 - [stanfordnlp/dspy](https://github.com/stanfordnlp/dspy) - *[Generate Pydantic models from JSON Schema for reliability tests](https://github.com/stanfordnlp/dspy/blob/main/tests/reliability/generate/utils.py)*
 
 [See all dependents →](https://github.com/koxudaxi/datamodel-code-generator/network/dependents)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated referenced links for the vllm-project/vllm dependency in the development, testing, and evaluation documentation.
  - Links now target a specific commit and the current line location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->