### PR TITLE
Validate generation path conflicts

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -532,14 +532,6 @@ def _normalized_absolute_path(path: Path, *, resolve_aliases: bool = False) -> P
     return Path(os.path.abspath(expanded_path))  # noqa: PTH100
 
 
-def _paths_refer_to_same_file(first: Path, second: Path) -> bool:
-    """Return whether two existing paths refer to the same file."""
-    try:
-        return first.samefile(second)
-    except FileNotFoundError:
-        return False
-
-
 def _validate_generation_path_conflicts(
     input_: Path | str | ParseResult | Mapping[str, Any] | list[Any],
     output: Path | None,
@@ -557,7 +549,7 @@ def _validate_generation_path_conflicts(
             raise Error(msg)
         if _normalized_absolute_path(output, resolve_aliases=True) == _normalized_absolute_path(
             model_metadata, resolve_aliases=True
-        ):
+        ) or (absolute_output.exists() and absolute_metadata.exists() and absolute_output.samefile(absolute_metadata)):
             msg = f"Output and model metadata paths must be different: {absolute_output}"
             raise Error(msg)
 
@@ -570,7 +562,7 @@ def _validate_generation_path_conflicts(
             return
 
     targets = tuple(
-        (label, absolute or _normalized_absolute_path(path))
+        (label, target := absolute or _normalized_absolute_path(path), target.exists())
         for label, path, absolute in (
             ("Output", output, absolute_output),
             ("Model metadata", model_metadata, absolute_metadata),
@@ -579,21 +571,13 @@ def _validate_generation_path_conflicts(
     )
     for input_path in input_paths:
         absolute_input = _normalized_absolute_path(input_path)
-        input_is_directory = input_path.is_dir()
-        resolved_input = (
-            _normalized_absolute_path(input_path, resolve_aliases=True) if input_is_directory else absolute_input
-        )
-        for label, target in targets:
+        if input_path.is_dir():
+            continue
+        for label, target, target_exists in targets:
             if target == absolute_input and input_path.exists():
                 msg = f"{label} path must not overwrite an input path: {target}"
                 raise Error(msg)
-            if input_is_directory and (
-                target.is_relative_to(absolute_input)
-                or _normalized_absolute_path(target, resolve_aliases=True).is_relative_to(resolved_input)
-            ):
-                msg = f"{label} path must not be inside an input directory: {target}"
-                raise Error(msg)
-            if not input_is_directory and _paths_refer_to_same_file(target, input_path):
+            if target_exists and target.samefile(input_path):
                 msg = f"{label} path must not overwrite an input path: {target}"
                 raise Error(msg)
 

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -524,6 +524,54 @@ class Error(Exception):
         return self.message
 
 
+def _normalized_absolute_path(path: Path) -> Path:
+    """Return a normalized absolute path without filesystem access."""
+    return Path(os.path.abspath(path.expanduser()))  # noqa: PTH100
+
+
+def _validate_generation_path_conflicts(
+    input_: Path | str | ParseResult | Mapping[str, Any] | list[Any],
+    output: Path | None,
+    model_metadata: Path | None,
+) -> None:
+    if output is None and model_metadata is None:
+        return
+
+    absolute_output: Path | None = None
+    absolute_metadata: Path | None = None
+    if output is not None and model_metadata is not None:
+        absolute_output = _normalized_absolute_path(output)
+        if absolute_output == (absolute_metadata := _normalized_absolute_path(model_metadata)):
+            msg = f"Output and model metadata paths must be different: {absolute_output}"
+            raise Error(msg)
+
+    match input_:
+        case Path() as input_path:
+            input_paths = (input_path,)
+        case [Path(), *_] as input_paths:
+            pass
+        case _:
+            return
+
+    targets = tuple(
+        (label, absolute or _normalized_absolute_path(path))
+        for label, path, absolute in (
+            ("Output", output, absolute_output),
+            ("Model metadata", model_metadata, absolute_metadata),
+        )
+        if path is not None
+    )
+    for input_path in input_paths:
+        absolute_input = _normalized_absolute_path(input_path)
+        for label, target in targets:
+            if target == absolute_input and input_path.exists():
+                msg = f"{label} path must not overwrite an input path: {target}"
+                raise Error(msg)
+            if target.is_relative_to(absolute_input) and input_path.is_dir():
+                msg = f"{label} path must not be inside an input directory: {target}"
+                raise Error(msg)
+
+
 class DanglingRefWarning(UserWarning):
     """Warn that a local JSON pointer target was not found."""
 
@@ -1454,6 +1502,8 @@ def generate(  # noqa: PLR0912, PLR0914, PLR0915
             "List input is only supported for file path lists or input_file_type=InputFileType.MCPTools."
         )
         raise Error(msg)  # pragma: no cover
+
+    _validate_generation_path_conflicts(input_, config.output, config.emit_model_metadata)
 
     remote_text_cache: DefaultPutDict[str, str] = DefaultPutDict()
     match input_:

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -524,9 +524,20 @@ class Error(Exception):
         return self.message
 
 
-def _normalized_absolute_path(path: Path) -> Path:
-    """Return a normalized absolute path without filesystem access."""
-    return Path(os.path.abspath(path.expanduser()))  # noqa: PTH100
+def _normalized_absolute_path(path: Path, *, resolve_aliases: bool = False) -> Path:
+    """Return a normalized absolute path, resolving aliases only when needed."""
+    expanded_path = path.expanduser()
+    if resolve_aliases:
+        return expanded_path.resolve(strict=False)
+    return Path(os.path.abspath(expanded_path))  # noqa: PTH100
+
+
+def _paths_refer_to_same_file(first: Path, second: Path) -> bool:
+    """Return whether two existing paths refer to the same file."""
+    try:
+        return first.samefile(second)
+    except FileNotFoundError:
+        return False
 
 
 def _validate_generation_path_conflicts(
@@ -542,6 +553,11 @@ def _validate_generation_path_conflicts(
     if output is not None and model_metadata is not None:
         absolute_output = _normalized_absolute_path(output)
         if absolute_output == (absolute_metadata := _normalized_absolute_path(model_metadata)):
+            msg = f"Output and model metadata paths must be different: {absolute_output}"
+            raise Error(msg)
+        if _normalized_absolute_path(output, resolve_aliases=True) == _normalized_absolute_path(
+            model_metadata, resolve_aliases=True
+        ):
             msg = f"Output and model metadata paths must be different: {absolute_output}"
             raise Error(msg)
 
@@ -563,12 +579,22 @@ def _validate_generation_path_conflicts(
     )
     for input_path in input_paths:
         absolute_input = _normalized_absolute_path(input_path)
+        input_is_directory = input_path.is_dir()
+        resolved_input = (
+            _normalized_absolute_path(input_path, resolve_aliases=True) if input_is_directory else absolute_input
+        )
         for label, target in targets:
             if target == absolute_input and input_path.exists():
                 msg = f"{label} path must not overwrite an input path: {target}"
                 raise Error(msg)
-            if target.is_relative_to(absolute_input) and input_path.is_dir():
+            if input_is_directory and (
+                target.is_relative_to(absolute_input)
+                or _normalized_absolute_path(target, resolve_aliases=True).is_relative_to(resolved_input)
+            ):
                 msg = f"{label} path must not be inside an input directory: {target}"
+                raise Error(msg)
+            if not input_is_directory and _paths_refer_to_same_file(target, input_path):
+                msg = f"{label} path must not overwrite an input path: {target}"
                 raise Error(msg)
 
 

--- a/src/datamodel_code_generator/__main__.py
+++ b/src/datamodel_code_generator/__main__.py
@@ -126,6 +126,7 @@ from datamodel_code_generator import (
     OpenAPIScope,
     ReuseScope,
     _validate_alias_generator,
+    _validate_generation_path_conflicts,
     _validate_output_datetime_class,
     enable_debug_message,
     generate,
@@ -1511,6 +1512,9 @@ def main(args: Sequence[str] | None = None) -> Exit:  # noqa: PLR0911, PLR0912, 
                 config.input_file_type = InputFileType.JsonSchema
         else:
             input_ = config.url or config.input or sys.stdin.read()
+
+        if writes_json_output_file:
+            _validate_generation_path_conflicts(input_, config.output, config.emit_model_metadata)
 
         result = run_generate_from_config(
             config=config,

--- a/tests/data/expected/main/malformed/path_conflict_input.txt
+++ b/tests/data/expected/main/malformed/path_conflict_input.txt
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": ["string", "null"],
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "friends": {
+      "type": "array"
+    },
+    "comment": {
+      "type": "null"
+    }
+  }
+}

--- a/tests/main/test_error_messages.py
+++ b/tests/main/test_error_messages.py
@@ -170,6 +170,24 @@ def test_generate_symlinked_output_path_does_not_overwrite_input(tmp_path: Path)
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="hardlink creation requires elevated privileges")
+def test_generate_hardlinked_output_path_does_not_overwrite_input(tmp_path: Path) -> None:
+    """Protect public API inputs when an output is a hardlink."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / source.name
+    shutil.copyfile(source, input_path)
+    output_path = tmp_path / "schema-hardlink.json"
+    output_path.hardlink_to(input_path)
+
+    with pytest.raises(Error, match="Output path must not overwrite an input path"):
+        generate(input_path, input_file_type=InputFileType.JsonSchema, output=output_path)
+
+    assert_output(
+        f"{input_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
 def test_generate_list_input_does_not_overwrite_input(tmp_path: Path) -> None:
     """Protect every file supplied through the public list-input API."""
     source = DATA_PATH / "jsonschema" / "person.json"
@@ -185,50 +203,28 @@ def test_generate_list_input_does_not_overwrite_input(tmp_path: Path) -> None:
     )
 
 
-def test_output_path_does_not_write_inside_input_directory(
+def test_output_path_can_write_inside_input_directory(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Reject generated files that would become inputs on the next run."""
+    """Preserve the existing one-shot layout with output below the input directory."""
     source = DATA_PATH / "jsonschema" / "person.json"
     input_path = tmp_path / "schemas"
     input_path.mkdir()
     shutil.copyfile(source, input_path / source.name)
-    output_path = input_path / "model.py"
+    output_path = input_path / "generated"
 
     run_main_and_assert(
         input_path=input_path,
         output_path=output_path,
         input_file_type="jsonschema",
-        expected_exit=Exit.ERROR,
+        extra_args=["--disable-timestamp", "--formatters", "builtin"],
         capsys=capsys,
-        expected_stderr_contains="Output path must not be inside an input directory",
-        output_should_not_exist=True,
+        assert_no_stderr=True,
     )
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges")
-def test_symlinked_output_path_does_not_write_inside_input_directory(
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Resolve lexical parent segments and directory symlinks before checking containment."""
-    source = DATA_PATH / "jsonschema" / "person.json"
-    input_path = tmp_path / "schemas"
-    input_path.mkdir()
-    shutil.copyfile(source, input_path / source.name)
-    linked_input = tmp_path / "schema-link"
-    linked_input.symlink_to(input_path, target_is_directory=True)
-    output_path = input_path / ".." / linked_input.name / "model.py"
-
-    run_main_and_assert(
-        input_path=input_path,
-        output_path=output_path,
-        input_file_type="jsonschema",
-        expected_exit=Exit.ERROR,
-        capsys=capsys,
-        expected_stderr_contains="Output path must not be inside an input directory",
-        output_should_not_exist=True,
+    assert_output(
+        (output_path / "person.py").read_text(encoding="utf-8"),
+        DATA_PATH / "expected" / "main" / "person.py",
     )
 
 
@@ -274,6 +270,29 @@ def test_generate_output_and_model_metadata_symlinks_must_differ(tmp_path: Path)
     shutil.copyfile(source, output_path)
     metadata_path = tmp_path / "metadata-link.json"
     metadata_path.symlink_to(output_path)
+
+    with pytest.raises(Error, match="Output and model metadata paths must be different"):
+        generate(
+            source,
+            input_file_type=InputFileType.JsonSchema,
+            output=output_path,
+            emit_model_metadata=metadata_path,
+        )
+
+    assert_output(
+        f"{output_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="hardlink creation requires elevated privileges")
+def test_generate_output_and_model_metadata_hardlinks_must_differ(tmp_path: Path) -> None:
+    """Reject public API artifact paths that are hardlinks to the same file."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    output_path = tmp_path / source.name
+    shutil.copyfile(source, output_path)
+    metadata_path = tmp_path / "metadata-hardlink.json"
+    metadata_path.hardlink_to(output_path)
 
     with pytest.raises(Error, match="Output and model metadata paths must be different"):
         generate(

--- a/tests/main/test_error_messages.py
+++ b/tests/main/test_error_messages.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import warnings
 from typing import TYPE_CHECKING
 
@@ -70,6 +71,128 @@ MISSING_INPUT_CASES: tuple[tuple[InputFileTypeLiteral | None, str], ...] = (
     (None, "missing.json"),
     ("jsonschema", "File not found"),
 )
+
+
+def test_output_path_does_not_overwrite_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject destructive output before the input schema is changed."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / source.name
+    shutil.copyfile(source, input_path)
+
+    run_main_and_assert(
+        input_path=input_path,
+        output_path=input_path,
+        input_file_type="jsonschema",
+        extra_args=["--output-format", "json"],
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="Output path must not overwrite an input path",
+        skip_code_validation=True,
+    )
+    assert_output(
+        f"{input_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
+def test_model_metadata_path_does_not_overwrite_input(
+    tmp_path: Path,
+    output_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Apply the input protection to optional generated artifacts."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / source.name
+    shutil.copyfile(source, input_path)
+
+    run_main_and_assert(
+        input_path=input_path,
+        output_path=output_file,
+        input_file_type="jsonschema",
+        extra_args=["--emit-model-metadata", str(input_path)],
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="Model metadata path must not overwrite an input path",
+        output_should_not_exist=True,
+    )
+    assert_output(
+        f"{input_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
+def test_generate_list_input_does_not_overwrite_input(tmp_path: Path) -> None:
+    """Protect every file supplied through the public list-input API."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / source.name
+    shutil.copyfile(source, input_path)
+
+    with pytest.raises(Error, match="Output path must not overwrite an input path"):
+        generate([input_path], input_file_type=InputFileType.JsonSchema, output=input_path)
+
+    assert_output(
+        f"{input_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
+def test_output_path_does_not_write_inside_input_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject generated files that would become inputs on the next run."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / "schemas"
+    input_path.mkdir()
+    shutil.copyfile(source, input_path / source.name)
+    output_path = input_path / "model.py"
+
+    run_main_and_assert(
+        input_path=input_path,
+        output_path=output_path,
+        input_file_type="jsonschema",
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="Output path must not be inside an input directory",
+        output_should_not_exist=True,
+    )
+
+
+def test_missing_input_conflict_preserves_missing_file_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Do not replace the established missing-input diagnostic with a conflict."""
+    missing_path = tmp_path / "missing.json"
+    run_main_and_assert(
+        input_path=missing_path,
+        output_path=missing_path,
+        input_file_type="jsonschema",
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="File not found",
+        output_should_not_exist=True,
+    )
+
+
+def test_output_and_model_metadata_paths_must_differ(
+    output_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject two generated artifacts targeting the same path."""
+    run_main_and_assert(
+        input_path=DATA_PATH / "jsonschema" / "person.json",
+        output_path=output_file,
+        input_file_type="jsonschema",
+        extra_args=["--emit-model-metadata", str(output_file)],
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="Output and model metadata paths must be different",
+        output_should_not_exist=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/main/test_error_messages.py
+++ b/tests/main/test_error_messages.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import sys
 import warnings
 from typing import TYPE_CHECKING
 
@@ -124,6 +125,33 @@ def test_model_metadata_path_does_not_overwrite_input(
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges")
+def test_symlinked_output_path_does_not_overwrite_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Resolve a file symlink before checking for input overwrite."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / source.name
+    shutil.copyfile(source, input_path)
+    output_path = tmp_path / "schema-link.json"
+    output_path.symlink_to(input_path)
+
+    run_main_and_assert(
+        input_path=input_path,
+        output_path=output_path,
+        input_file_type="jsonschema",
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="Output path must not overwrite an input path",
+        skip_code_validation=True,
+    )
+    assert_output(
+        f"{input_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
 def test_generate_list_input_does_not_overwrite_input(tmp_path: Path) -> None:
     """Protect every file supplied through the public list-input API."""
     source = DATA_PATH / "jsonschema" / "person.json"
@@ -149,6 +177,31 @@ def test_output_path_does_not_write_inside_input_directory(
     input_path.mkdir()
     shutil.copyfile(source, input_path / source.name)
     output_path = input_path / "model.py"
+
+    run_main_and_assert(
+        input_path=input_path,
+        output_path=output_path,
+        input_file_type="jsonschema",
+        expected_exit=Exit.ERROR,
+        capsys=capsys,
+        expected_stderr_contains="Output path must not be inside an input directory",
+        output_should_not_exist=True,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges")
+def test_symlinked_output_path_does_not_write_inside_input_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Resolve lexical parent segments and directory symlinks before checking containment."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / "schemas"
+    input_path.mkdir()
+    shutil.copyfile(source, input_path / source.name)
+    linked_input = tmp_path / "schema-link"
+    linked_input.symlink_to(input_path, target_is_directory=True)
+    output_path = input_path / ".." / linked_input.name / "model.py"
 
     run_main_and_assert(
         input_path=input_path,

--- a/tests/main/test_error_messages.py
+++ b/tests/main/test_error_messages.py
@@ -152,6 +152,24 @@ def test_symlinked_output_path_does_not_overwrite_input(
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges")
+def test_generate_symlinked_output_path_does_not_overwrite_input(tmp_path: Path) -> None:
+    """Protect public API inputs when an output keeps its symlink spelling."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    input_path = tmp_path / source.name
+    shutil.copyfile(source, input_path)
+    output_path = tmp_path / "schema-link.json"
+    output_path.symlink_to(input_path)
+
+    with pytest.raises(Error, match="Output path must not overwrite an input path"):
+        generate(input_path, input_file_type=InputFileType.JsonSchema, output=output_path)
+
+    assert_output(
+        f"{input_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
+    )
+
+
 def test_generate_list_input_does_not_overwrite_input(tmp_path: Path) -> None:
     """Protect every file supplied through the public list-input API."""
     source = DATA_PATH / "jsonschema" / "person.json"
@@ -245,6 +263,29 @@ def test_output_and_model_metadata_paths_must_differ(
         capsys=capsys,
         expected_stderr_contains="Output and model metadata paths must be different",
         output_should_not_exist=True,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires elevated privileges")
+def test_generate_output_and_model_metadata_symlinks_must_differ(tmp_path: Path) -> None:
+    """Reject public API artifact paths that alias the same existing file."""
+    source = DATA_PATH / "jsonschema" / "person.json"
+    output_path = tmp_path / source.name
+    shutil.copyfile(source, output_path)
+    metadata_path = tmp_path / "metadata-link.json"
+    metadata_path.symlink_to(output_path)
+
+    with pytest.raises(Error, match="Output and model metadata paths must be different"):
+        generate(
+            source,
+            input_file_type=InputFileType.JsonSchema,
+            output=output_path,
+            emit_model_metadata=metadata_path,
+        )
+
+    assert_output(
+        f"{output_path.read_text(encoding='utf-8')}\n",
+        EXPECTED_MALFORMED_PATH / "path_conflict_input.txt",
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safer path validation to prevent generated output from overwriting existing inputs.
  * Prevented writing generated files inside an input directory (including cases involving symlinks and path traversal).
  * Ensured the model metadata output path cannot target the same location as the generated output.
  * Preserved accurate “File not found” diagnostics when the input is genuinely missing.
* **Tests**
  * Added regression tests covering the above CLI and generation path-safety rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->