### PR TITLE
Simplify XML text loading

### DIFF
--- a/src/datamodel_code_generator/parser/xmlschema.py
+++ b/src/datamodel_code_generator/parser/xmlschema.py
@@ -85,12 +85,6 @@ JsonSchema = dict[str, Any]
 QNameKey = tuple[str | None, str]
 DefinitionKey = tuple[str, str | None, str]
 PYTHON_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_XML_TEXT_CACHE_MAX_SIZE = 128
-_XMLTextCacheKey = tuple[Path, str, str]
-_XMLTextSeenKey = tuple[Path, str]
-_xml_text_cache: OrderedDict[_XMLTextCacheKey, str] = OrderedDict()
-_xml_text_seen_keys: OrderedDict[_XMLTextSeenKey, None] = OrderedDict()
-_xml_text_cache_lock = RLock()
 _XML_SCHEMA_DATA_CACHE_MAX_SIZE = 128
 _XMLSchemaDataCacheKey = tuple[Path, Path, str, str, XMLSchemaVersion | None, VersionMode | None, bool]
 _XMLSchemaDataSeenKey = tuple[Path, Path, str, XMLSchemaVersion | None, VersionMode | None, bool]
@@ -261,33 +255,7 @@ def _has_xmlschema_versioning_attribute(element: ET.Element) -> bool:
 
 
 def _read_xml_text(path: Path, encoding: str) -> str:
-    resolved_path = path.resolve()
-    seen_key = (resolved_path, encoding)
-    with _xml_text_cache_lock:
-        use_cache = seen_key in _xml_text_seen_keys
-        _xml_text_seen_keys[seen_key] = None
-        _xml_text_seen_keys.move_to_end(seen_key)
-        while len(_xml_text_seen_keys) > _XML_TEXT_CACHE_MAX_SIZE:
-            _xml_text_seen_keys.popitem(last=False)
-
-    data = resolved_path.read_bytes()
-    if not use_cache:
-        return _decode_xml_bytes(data, encoding)
-
-    cache_key = (resolved_path, _digest_bytes(data), encoding)
-
-    with _xml_text_cache_lock:
-        if cache_key in _xml_text_cache:
-            _xml_text_cache.move_to_end(cache_key)
-            return _xml_text_cache[cache_key]
-
-    text = _decode_xml_bytes(data, encoding)
-    with _xml_text_cache_lock:
-        _xml_text_cache[cache_key] = text
-        _xml_text_cache.move_to_end(cache_key)
-        while len(_xml_text_cache) > _XML_TEXT_CACHE_MAX_SIZE:
-            _xml_text_cache.popitem(last=False)
-    return text
+    return _decode_xml_bytes(path.read_bytes(), encoding)
 
 
 def _decode_xml_bytes(data: bytes, encoding: str) -> str:
@@ -301,12 +269,6 @@ def _decode_xml_bytes(data: bytes, encoding: str) -> str:
         if data.startswith(bom):
             return data.decode(xml_encoding)
     return data.decode(encoding)
-
-
-def _clear_xml_text_cache() -> None:
-    with _xml_text_cache_lock:
-        _xml_text_cache.clear()
-        _xml_text_seen_keys.clear()
 
 
 def _digest_bytes(data: bytes) -> str:

--- a/tests/data/expected/main/xmlschema/xml_text_initial.txt
+++ b/tests/data/expected/main/xmlschema/xml_text_initial.txt
@@ -1,0 +1,1 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">café</xs:schema>

--- a/tests/data/expected/main/xmlschema/xml_text_updated.txt
+++ b/tests/data/expected/main/xmlschema/xml_text_updated.txt
@@ -1,0 +1,1 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">jalapeño</xs:schema>

--- a/tests/main/xmlschema/test_main_xmlschema.py
+++ b/tests/main/xmlschema/test_main_xmlschema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import codecs
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,7 +12,6 @@ from datamodel_code_generator.__main__ import Exit
 from datamodel_code_generator.parser import xmlschema as xmlschema_parser
 from datamodel_code_generator.parser.xmlschema import (
     _clear_xml_schema_data_cache,
-    _clear_xml_text_cache,
     _load_xml_schema_data_from_path,
     _read_xml_text,
 )
@@ -21,8 +20,6 @@ from tests.main.conftest import (
     BACKEND_GOLDEN_TARGET_ARGS,
     XML_SCHEMA_DATA_PATH,
     assert_path_cache_evicts_lru_entries,
-    assert_path_cache_invalidates_after_write,
-    assert_path_cache_reuses_value,
     run_generate_file_and_assert,
     run_main_and_assert,
 )
@@ -55,53 +52,41 @@ def test_main_xmlschema_with_parsed_source_cache(output_file: Path) -> None:
     )
 
 
-def test_read_xml_text_caches_raw_source(tmp_path: Path) -> None:
-    """Reuse raw XML source text by path and content hash."""
+@pytest.mark.parametrize(
+    ("byte_order_mark", "xml_encoding"),
+    [
+        (codecs.BOM_UTF8, "utf-8"),
+        (codecs.BOM_UTF32_LE, "utf-32-le"),
+        (codecs.BOM_UTF32_BE, "utf-32-be"),
+        (codecs.BOM_UTF16_LE, "utf-16-le"),
+        (codecs.BOM_UTF16_BE, "utf-16-be"),
+    ],
+)
+def test_read_xml_text_detects_byte_order_mark(tmp_path: Path, byte_order_mark: bytes, xml_encoding: str) -> None:
+    """Decode XML source according to its byte order mark."""
     schema_path = tmp_path / "schema.xsd"
-    schema_path.write_text(
-        (XML_SCHEMA_DATA_PATH / "single_root_item.xsd").read_text(encoding="utf-8"), encoding="utf-8"
-    )
-    _clear_xml_text_cache()
+    schema_text = '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">é</xs:schema>'
+    schema_path.write_bytes(byte_order_mark + schema_text.encode(xml_encoding))
 
-    assert_path_cache_reuses_value(_read_xml_text, schema_path, warmups=1)
+    assert _read_xml_text(schema_path, "ascii") == schema_text
 
 
-def test_read_xml_text_invalidates_updated_raw_source(tmp_path: Path) -> None:
-    """Reload raw XML source text when the local file changes."""
+def test_read_xml_text_reads_updated_source(tmp_path: Path) -> None:
+    """Read the current XML source content without retaining stale text."""
     schema_path = tmp_path / "schema.xsd"
-    schema_path.write_text(
-        (XML_SCHEMA_DATA_PATH / "single_root_item.xsd").read_text(encoding="utf-8"), encoding="utf-8"
-    )
-    _clear_xml_text_cache()
-
-    updated_text = (XML_SCHEMA_DATA_PATH / "inline_root.xsd").read_text(encoding="utf-8")
-    assert_path_cache_invalidates_after_write(
-        _read_xml_text,
-        schema_path,
-        updated_text,
-        updated_text.replace("\n", os.linesep),
-    )
-
-
-def test_read_xml_text_evicts_lru_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Evict old raw XML text cache entries after the configured limit."""
-    monkeypatch.setattr(xmlschema_parser, "_XML_TEXT_CACHE_MAX_SIZE", 1)
-    _clear_xml_text_cache()
-    first_path = tmp_path / "first.xsd"
-    second_path = tmp_path / "second.xsd"
     first_text = (XML_SCHEMA_DATA_PATH / "single_root_item.xsd").read_text(encoding="utf-8")
     second_text = (XML_SCHEMA_DATA_PATH / "inline_root.xsd").read_text(encoding="utf-8")
-    first_path.write_text(first_text, encoding="utf-8")
-    second_path.write_text(second_text, encoding="utf-8")
+    schema_path.write_bytes(first_text.encode("latin-1"))
+    assert _read_xml_text(schema_path, "latin-1") == first_text
 
-    assert_path_cache_evicts_lru_entries(_read_xml_text, first_path, second_path)
+    schema_path.write_bytes(second_text.encode("latin-1"))
+    assert _read_xml_text(schema_path, "latin-1") == second_text
 
 
 def test_load_xml_schema_data_from_path_evicts_lru_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Evict old converted XML Schema cache entries after the configured limit."""
     monkeypatch.setattr(xmlschema_parser, "_XML_SCHEMA_DATA_CACHE_MAX_SIZE", 1)
     _clear_xml_schema_data_cache()
-    _clear_xml_text_cache()
     first_path = tmp_path / "first.xsd"
     second_path = tmp_path / "second.xsd"
     first_path.write_text((XML_SCHEMA_DATA_PATH / "single_root_item.xsd").read_text(encoding="utf-8"), encoding="utf-8")

--- a/tests/main/xmlschema/test_main_xmlschema.py
+++ b/tests/main/xmlschema/test_main_xmlschema.py
@@ -15,9 +15,11 @@ from datamodel_code_generator.parser.xmlschema import (
     _load_xml_schema_data_from_path,
     _read_xml_text,
 )
+from tests.conftest import assert_output
 from tests.main.conftest import (
     BACKEND_GOLDEN_CASES,
     BACKEND_GOLDEN_TARGET_ARGS,
+    EXPECTED_XML_SCHEMA_PATH,
     XML_SCHEMA_DATA_PATH,
     assert_path_cache_evicts_lru_entries,
     run_generate_file_and_assert,
@@ -65,22 +67,23 @@ def test_main_xmlschema_with_parsed_source_cache(output_file: Path) -> None:
 def test_read_xml_text_detects_byte_order_mark(tmp_path: Path, byte_order_mark: bytes, xml_encoding: str) -> None:
     """Decode XML source according to its byte order mark."""
     schema_path = tmp_path / "schema.xsd"
-    schema_text = '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">é</xs:schema>'
+    expected_path = EXPECTED_XML_SCHEMA_PATH / "xml_text_initial.txt"
+    schema_text = expected_path.read_text(encoding="utf-8")
     schema_path.write_bytes(byte_order_mark + schema_text.encode(xml_encoding))
 
-    assert _read_xml_text(schema_path, "ascii") == schema_text
+    assert_output(_read_xml_text(schema_path, "ascii"), expected_path)
 
 
 def test_read_xml_text_reads_updated_source(tmp_path: Path) -> None:
     """Read the current XML source content without retaining stale text."""
     schema_path = tmp_path / "schema.xsd"
-    first_text = (XML_SCHEMA_DATA_PATH / "single_root_item.xsd").read_text(encoding="utf-8")
-    second_text = (XML_SCHEMA_DATA_PATH / "inline_root.xsd").read_text(encoding="utf-8")
-    schema_path.write_bytes(first_text.encode("latin-1"))
-    assert _read_xml_text(schema_path, "latin-1") == first_text
+    first_expected_path = EXPECTED_XML_SCHEMA_PATH / "xml_text_initial.txt"
+    second_expected_path = EXPECTED_XML_SCHEMA_PATH / "xml_text_updated.txt"
+    schema_path.write_bytes(first_expected_path.read_text(encoding="utf-8").encode("latin-1"))
+    assert_output(_read_xml_text(schema_path, "latin-1"), first_expected_path)
 
-    schema_path.write_bytes(second_text.encode("latin-1"))
-    assert _read_xml_text(schema_path, "latin-1") == second_text
+    schema_path.write_bytes(second_expected_path.read_text(encoding="utf-8").encode("latin-1"))
+    assert_output(_read_xml_text(schema_path, "latin-1"), second_expected_path)
 
 
 def test_load_xml_schema_data_from_path_evicts_lru_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * XML text is no longer reused from an internal cache, ensuring updated file contents are reflected on subsequent reads.
  * XML decoding now correctly detects and applies byte-order marks across supported UTF encodings.
* **Tests**
  * Added parameterized tests for BOM/encoding-aware XML text decoding.
  * Added tests confirming reads reflect updated file contents without retaining stale decoded XML.
  * Removed tests specifically targeting raw XML text cache reuse, invalidation, and LRU eviction; XML-schema converted-data cache eviction coverage remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->