### PR TITLE
Isolate cached parsed source values

### DIFF
--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -156,7 +156,8 @@ _IGNORED_TEXT_PREFIX_CHARS: frozenset[str] = frozenset({"\ufeff", " ", "\t", "\r
 _PARSER_SOURCE_DATA_CACHE_MAX_SIZE = 128
 _ParserSourceDataCacheKey: TypeAlias = tuple[Path, str, str, str]
 _ParserSourceDataSeenKey: TypeAlias = tuple[Path, str]
-_parser_source_data_cache: OrderedDict[_ParserSourceDataCacheKey, YamlValue] = OrderedDict()
+# Serialized snapshots isolate mutable callers and are faster to restore than reparsing source text.
+_parser_source_data_cache: OrderedDict[_ParserSourceDataCacheKey, bytes] = OrderedDict()
 _parser_source_data_seen_keys: OrderedDict[_ParserSourceDataSeenKey, None] = OrderedDict()
 _parser_source_data_cache_lock = RLock()
 _parsed_source_cache_enable_count = 0
@@ -339,15 +340,32 @@ def _load_parser_source_data_from_path_bytes(resolved_path: Path, data: bytes, e
 
 def _load_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> YamlValue | None:
     with _parser_source_data_cache_lock:
-        if cache_key in _parser_source_data_cache:
-            _parser_source_data_cache.move_to_end(cache_key)
-            return _parser_source_data_cache[cache_key]
-    return None
+        if (cached_data := _parser_source_data_cache.get(cache_key)) is None:
+            return None
+        _parser_source_data_cache.move_to_end(cache_key)
+
+    import pickle  # noqa: PLC0415, S403
+
+    try:
+        return pickle.loads(cached_data)  # noqa: S301
+    except Exception:  # noqa: BLE001
+        # A damaged optimization entry must fall back to the source parser.
+        with _parser_source_data_cache_lock:
+            if _parser_source_data_cache.get(cache_key) is cached_data:
+                del _parser_source_data_cache[cache_key]
+        return None
 
 
 def _store_parser_source_data(cache_key: _ParserSourceDataCacheKey, parsed_data: YamlValue) -> YamlValue:
+    import pickle  # noqa: PLC0415, S403
+
+    try:
+        cached_data = pickle.dumps(parsed_data, protocol=pickle.HIGHEST_PROTOCOL)
+    except Exception:  # noqa: BLE001
+        # Exotic YAML values may not be picklable; they remain valid uncached input.
+        return parsed_data
     with _parser_source_data_cache_lock:
-        _parser_source_data_cache[cache_key] = parsed_data
+        _parser_source_data_cache[cache_key] = cached_data
         _parser_source_data_cache.move_to_end(cache_key)
         while len(_parser_source_data_cache) > _PARSER_SOURCE_DATA_CACHE_MAX_SIZE:
             _parser_source_data_cache.popitem(last=False)

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -154,10 +154,11 @@ def _apply_generate_config_preset(config: GenerateConfig) -> GenerateConfig:
 DEFAULT_BASE_CLASS: str = "pydantic.BaseModel"
 _IGNORED_TEXT_PREFIX_CHARS: frozenset[str] = frozenset({"\ufeff", " ", "\t", "\r", "\n"})
 _PARSER_SOURCE_DATA_CACHE_MAX_SIZE = 128
+_PARSER_SOURCE_DATA_CACHE_MAGIC = b"dcg\x00"
 _ParserSourceDataCacheKey: TypeAlias = tuple[Path, str, str, str]
 _ParserSourceDataSeenKey: TypeAlias = tuple[Path, str]
 # Serialized snapshots isolate mutable callers and are faster to restore than reparsing source text.
-_parser_source_data_cache: OrderedDict[_ParserSourceDataCacheKey, str] = OrderedDict()
+_parser_source_data_cache: OrderedDict[_ParserSourceDataCacheKey, bytes] = OrderedDict()
 _parser_source_data_seen_keys: OrderedDict[_ParserSourceDataSeenKey, None] = OrderedDict()
 _parser_source_data_cache_lock = RLock()
 _parsed_source_cache_enable_count = 0
@@ -338,32 +339,39 @@ def _load_parser_source_data_from_path_bytes(resolved_path: Path, data: bytes, e
     return _load_parser_source_data_from_bytes_with_cache(resolved_path, data, digest, encoding)
 
 
+def _discard_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> None:
+    with _parser_source_data_cache_lock:
+        _parser_source_data_cache.pop(cache_key, None)
+
+
 def _load_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> YamlValue | None:
     with _parser_source_data_cache_lock:
         if (cached_data := _parser_source_data_cache.get(cache_key)) is None:
             return None
         _parser_source_data_cache.move_to_end(cache_key)
 
-    import json  # noqa: PLC0415
+    if not cached_data.startswith(_PARSER_SOURCE_DATA_CACHE_MAGIC):
+        _discard_cached_parser_source_data(cache_key)
+        return None
+
+    import marshal  # noqa: PLC0415
 
     try:
-        return json.loads(cached_data)
+        # Entries are process-local values emitted by marshal.dumps below, never external bytes.
+        return marshal.loads(cached_data[len(_PARSER_SOURCE_DATA_CACHE_MAGIC) :])  # noqa: S302
     except Exception:  # noqa: BLE001
         # A damaged optimization entry must fall back to the source parser.
-        with _parser_source_data_cache_lock:
-            _parser_source_data_cache.pop(cache_key, None)
+        _discard_cached_parser_source_data(cache_key)
         return None
 
 
 def _store_parser_source_data(cache_key: _ParserSourceDataCacheKey, parsed_data: YamlValue) -> YamlValue:
-    import json  # noqa: PLC0415
+    import marshal  # noqa: PLC0415
 
     try:
-        cached_data = json.dumps(parsed_data, ensure_ascii=False, separators=(",", ":"))
-        if json.loads(cached_data) != parsed_data:
-            return parsed_data
+        cached_data = _PARSER_SOURCE_DATA_CACHE_MAGIC + marshal.dumps(parsed_data)
     except Exception:  # noqa: BLE001
-        # Values outside the JSON-compatible YamlValue shape remain valid uncached input.
+        # Values outside the primitive YamlValue shape remain valid uncached input.
         return parsed_data
     with _parser_source_data_cache_lock:
         _parser_source_data_cache[cache_key] = cached_data

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -351,8 +351,7 @@ def _load_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> Yam
     except Exception:  # noqa: BLE001
         # A damaged optimization entry must fall back to the source parser.
         with _parser_source_data_cache_lock:
-            if _parser_source_data_cache.get(cache_key) is cached_data:
-                del _parser_source_data_cache[cache_key]
+            _parser_source_data_cache.pop(cache_key, None)
         return None
 
 

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -157,7 +157,7 @@ _PARSER_SOURCE_DATA_CACHE_MAX_SIZE = 128
 _ParserSourceDataCacheKey: TypeAlias = tuple[Path, str, str, str]
 _ParserSourceDataSeenKey: TypeAlias = tuple[Path, str]
 # Serialized snapshots isolate mutable callers and are faster to restore than reparsing source text.
-_parser_source_data_cache: OrderedDict[_ParserSourceDataCacheKey, bytes] = OrderedDict()
+_parser_source_data_cache: OrderedDict[_ParserSourceDataCacheKey, str] = OrderedDict()
 _parser_source_data_seen_keys: OrderedDict[_ParserSourceDataSeenKey, None] = OrderedDict()
 _parser_source_data_cache_lock = RLock()
 _parsed_source_cache_enable_count = 0
@@ -344,10 +344,10 @@ def _load_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> Yam
             return None
         _parser_source_data_cache.move_to_end(cache_key)
 
-    import pickle  # noqa: PLC0415, S403
+    import json  # noqa: PLC0415
 
     try:
-        return pickle.loads(cached_data)  # noqa: S301
+        return json.loads(cached_data)
     except Exception:  # noqa: BLE001
         # A damaged optimization entry must fall back to the source parser.
         with _parser_source_data_cache_lock:
@@ -356,12 +356,14 @@ def _load_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> Yam
 
 
 def _store_parser_source_data(cache_key: _ParserSourceDataCacheKey, parsed_data: YamlValue) -> YamlValue:
-    import pickle  # noqa: PLC0415, S403
+    import json  # noqa: PLC0415
 
     try:
-        cached_data = pickle.dumps(parsed_data, protocol=pickle.HIGHEST_PROTOCOL)
+        cached_data = json.dumps(parsed_data, ensure_ascii=False, separators=(",", ":"))
+        if json.loads(cached_data) != parsed_data:
+            return parsed_data
     except Exception:  # noqa: BLE001
-        # Exotic YAML values may not be picklable; they remain valid uncached input.
+        # Values outside the JSON-compatible YamlValue shape remain valid uncached input.
         return parsed_data
     with _parser_source_data_cache_lock:
         _parser_source_data_cache[cache_key] = cached_data

--- a/src/datamodel_code_generator/__init__.py
+++ b/src/datamodel_code_generator/__init__.py
@@ -154,7 +154,6 @@ def _apply_generate_config_preset(config: GenerateConfig) -> GenerateConfig:
 DEFAULT_BASE_CLASS: str = "pydantic.BaseModel"
 _IGNORED_TEXT_PREFIX_CHARS: frozenset[str] = frozenset({"\ufeff", " ", "\t", "\r", "\n"})
 _PARSER_SOURCE_DATA_CACHE_MAX_SIZE = 128
-_PARSER_SOURCE_DATA_CACHE_MAGIC = b"dcg\x00"
 _ParserSourceDataCacheKey: TypeAlias = tuple[Path, str, str, str]
 _ParserSourceDataSeenKey: TypeAlias = tuple[Path, str]
 # Serialized snapshots isolate mutable callers and are faster to restore than reparsing source text.
@@ -339,37 +338,23 @@ def _load_parser_source_data_from_path_bytes(resolved_path: Path, data: bytes, e
     return _load_parser_source_data_from_bytes_with_cache(resolved_path, data, digest, encoding)
 
 
-def _discard_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> None:
-    with _parser_source_data_cache_lock:
-        _parser_source_data_cache.pop(cache_key, None)
-
-
 def _load_cached_parser_source_data(cache_key: _ParserSourceDataCacheKey) -> YamlValue | None:
     with _parser_source_data_cache_lock:
         if (cached_data := _parser_source_data_cache.get(cache_key)) is None:
             return None
         _parser_source_data_cache.move_to_end(cache_key)
 
-    if not cached_data.startswith(_PARSER_SOURCE_DATA_CACHE_MAGIC):
-        _discard_cached_parser_source_data(cache_key)
-        return None
-
     import marshal  # noqa: PLC0415
 
-    try:
-        # Entries are process-local values emitted by marshal.dumps below, never external bytes.
-        return marshal.loads(cached_data[len(_PARSER_SOURCE_DATA_CACHE_MAGIC) :])  # noqa: S302
-    except Exception:  # noqa: BLE001
-        # A damaged optimization entry must fall back to the source parser.
-        _discard_cached_parser_source_data(cache_key)
-        return None
+    # Entries are process-local values emitted by marshal.dumps below, never external bytes.
+    return marshal.loads(cached_data)  # noqa: S302
 
 
 def _store_parser_source_data(cache_key: _ParserSourceDataCacheKey, parsed_data: YamlValue) -> YamlValue:
     import marshal  # noqa: PLC0415
 
     try:
-        cached_data = _PARSER_SOURCE_DATA_CACHE_MAGIC + marshal.dumps(parsed_data)
+        cached_data = marshal.dumps(parsed_data)
     except Exception:  # noqa: BLE001
         # Values outside the primitive YamlValue shape remain valid uncached input.
         return parsed_data

--- a/tests/main/conftest.py
+++ b/tests/main/conftest.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Generator, Mapping, Sequence
 from contextlib import contextmanager
 from functools import cache
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import black
 import pytest
@@ -721,74 +721,6 @@ def assert_input_file_type(result: object, expected: InputFileType) -> None:
     __tracebackhide__ = True
     if result != expected:  # pragma: no cover
         pytest.fail(f"Expected input file type {expected!r}, got {result!r}")
-
-
-def _value_at_path(value: object, path: Sequence[str | int]) -> object:
-    __tracebackhide__ = True
-    current = value
-    for key in path:
-        match current, key:
-            case Mapping(), _:
-                current = cast("Mapping[object, object]", current)[key]
-            case Sequence(), int() if not isinstance(current, str | bytes | bytearray):
-                current = cast("Sequence[object]", current)[key]
-            case _:
-                pytest.fail(f"Expected cached value to contain path {path!r}, got {value!r}")
-    return current
-
-
-def assert_path_cache_reuses_value(
-    loader: Callable[[Path, str], object],
-    path: Path,
-    *,
-    encoding: str = "utf-8",
-    warmups: int = 0,
-) -> None:
-    """Assert a path-based cache reuses the parsed or decoded value."""
-    __tracebackhide__ = True
-    for _ in range(warmups):
-        loader(path, encoding)
-
-    first = loader(path, encoding)
-    second = loader(path, encoding)
-
-    if first is second:
-        return
-
-    pytest.fail(f"Expected cached value for {path} to be reused")
-
-
-def assert_path_cache_invalidates_after_write(
-    loader: Callable[[Path, str], object],
-    path: Path,
-    new_text: str,
-    expected_value: object,
-    *,
-    encoding: str = "utf-8",
-    expected_value_path: Sequence[str | int] = (),
-    warmups: int = 0,
-) -> None:
-    """Assert a path-based cache reloads after file content changes."""
-    __tracebackhide__ = True
-    for _ in range(warmups):
-        loader(path, encoding)
-
-    first = loader(path, encoding)
-    path.write_text(new_text, encoding=encoding)
-    second = loader(path, encoding)
-
-    if first is second:
-        pytest.fail(f"Expected cached value for {path} to be invalidated after write")
-
-    actual_value = _value_at_path(second, expected_value_path)
-    if actual_value != expected_value:
-        pytest.fail(f"Expected cached value {expected_value!r}, got {actual_value!r}")
-
-    third = loader(path, encoding)
-    if second is third:
-        return
-
-    pytest.fail(f"Expected updated cached value for {path} to be reused")
 
 
 def assert_path_cache_evicts_lru_entries(

--- a/tests/main/jsonschema/test_main_jsonschema.py
+++ b/tests/main/jsonschema/test_main_jsonschema.py
@@ -33,6 +33,7 @@ from datamodel_code_generator import (
     cached_path_exists,
     chdir,
     generate,
+    load_data,
     load_data_from_path,
 )
 from datamodel_code_generator.__main__ import Exit
@@ -47,6 +48,7 @@ from tests.conftest import (
     MockHttpxResponse,
     assert_directory_content,
     assert_httpx_get_kwargs,
+    assert_mutable_copy_is_isolated,
     assert_output,
     assert_warnings_contain,
     assert_warnings_do_not_contain,
@@ -69,8 +71,6 @@ from tests.main.conftest import (
     _uses_external_test_default_formatter,
     assert_generated_model_json_invalid,
     assert_generated_model_json_validation,
-    assert_path_cache_invalidates_after_write,
-    assert_path_cache_reuses_value,
     run_generate_and_assert,
     run_generate_file_and_assert,
     run_main_and_assert,
@@ -2801,13 +2801,26 @@ def test_main_generate_with_parsed_source_cache(output_file: Path) -> None:
     )
 
 
-def test_load_data_from_path_caches_json_source(tmp_path: Path) -> None:
-    """Reuse parsed JSON file data by path and content hash for local reference loading."""
+def test_load_data_from_path_isolates_cached_json_source(tmp_path: Path) -> None:
+    """Return independent parsed JSON values from the process-local cache."""
     schema_path = tmp_path / "schema.json"
     schema_path.write_text((JSON_SCHEMA_DATA_PATH / "person.json").read_text(encoding="utf-8"), encoding="utf-8")
     _clear_parser_source_data_cache()
 
-    assert_path_cache_reuses_value(load_data_from_path, schema_path, warmups=1)
+    original = load_data_from_path(schema_path, "utf-8")
+    cached = load_data_from_path(schema_path, "utf-8")
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=cached,
+        mutate_copied=lambda value: value["properties"]["firstName"].update(type="integer"),
+        label="cached JSON source",
+    )
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=load_data_from_path(schema_path, "utf-8"),
+        mutate_copied=lambda value: value["properties"]["lastName"].update(type="integer"),
+        label="reloaded JSON source",
+    )
 
 
 def test_load_data_from_path_invalidates_updated_json_source(tmp_path: Path) -> None:
@@ -2815,13 +2828,16 @@ def test_load_data_from_path_invalidates_updated_json_source(tmp_path: Path) -> 
     schema_path = tmp_path / "schema.json"
     schema_path.write_text((JSON_SCHEMA_DATA_PATH / "person.json").read_text(encoding="utf-8"), encoding="utf-8")
     _clear_parser_source_data_cache()
+    load_data_from_path(schema_path, "utf-8")
+    load_data_from_path(schema_path, "utf-8")
+    updated_text = (JSON_SCHEMA_DATA_PATH / "simple_string.json").read_text(encoding="utf-8")
+    schema_path.write_text(updated_text, encoding="utf-8")
 
-    assert_path_cache_invalidates_after_write(
-        load_data_from_path,
-        schema_path,
-        (JSON_SCHEMA_DATA_PATH / "simple_string.json").read_text(encoding="utf-8"),
-        ["s"],
-        expected_value_path=("required",),
+    assert_mutable_copy_is_isolated(
+        original=load_data(updated_text),
+        copied=load_data_from_path(schema_path, "utf-8"),
+        mutate_copied=lambda value: value["required"].append("mutated"),
+        label="updated cached JSON source",
     )
 
 

--- a/tests/main/test_parsed_source_cache_parity.py
+++ b/tests/main/test_parsed_source_cache_parity.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pickle
+import json
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier, Event
 from typing import TYPE_CHECKING
@@ -162,10 +162,10 @@ def test_parser_source_cache_skips_unserializable_values(
     _clear_parser_source_data_cache()
     original = load_data_from_path(schema_path, "utf-8")
 
-    def raise_pickling_error(*_args: object, **_kwargs: object) -> bytes:
-        raise pickle.PicklingError
+    def raise_serialization_error(*_args: object, **_kwargs: object) -> str:
+        raise ValueError
 
-    monkeypatch.setattr(pickle, "dumps", raise_pickling_error)
+    monkeypatch.setattr(json, "dumps", raise_serialization_error)
     assert_mutable_copy_is_isolated(
         original=original,
         copied=load_data_from_path(schema_path, "utf-8"),
@@ -173,6 +173,23 @@ def test_parser_source_cache_skips_unserializable_values(
         label="uncached unserializable JSON source",
     )
 
+    assert not _parser_source_data_cache
+
+
+@pytest.mark.allow_direct_assert
+def test_parser_source_cache_skips_lossy_yaml_values(tmp_path: Path) -> None:
+    """Keep values uncached when JSON serialization would change their shape."""
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text("1:\n  nested: true\n", encoding="utf-8")
+    _clear_parser_source_data_cache()
+    original = load_data_from_path(schema_path, "utf-8")
+
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=load_data_from_path(schema_path, "utf-8"),
+        mutate_copied=lambda value: value[1].update(nested=False),
+        label="uncached lossy YAML source",
+    )
     assert not _parser_source_data_cache
 
 
@@ -184,7 +201,7 @@ def test_parser_source_cache_recovers_from_invalid_serialized_value(tmp_path: Pa
     original = load_data_from_path(schema_path, "utf-8")
     load_data_from_path(schema_path, "utf-8")
     cache_key = next(iter(_parser_source_data_cache))
-    _parser_source_data_cache[cache_key] = b"invalid pickle"
+    _parser_source_data_cache[cache_key] = "invalid JSON"
 
     assert_mutable_copy_is_isolated(
         original=original,

--- a/tests/main/test_parsed_source_cache_parity.py
+++ b/tests/main/test_parsed_source_cache_parity.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from datamodel_code_generator import (
-    _PARSER_SOURCE_DATA_CACHE_MAGIC,
     InputFileType,
     _clear_parser_source_data_cache,
     _is_parsed_source_cache_enabled,
@@ -213,40 +212,6 @@ def test_parser_source_cache_preserves_yaml_graph_sharing(tmp_path: Path) -> Non
         copied=cached,
         mutate_copied=lambda value: value["first"].update(type="integer"),
         label="cached YAML aliases",
-    )
-
-
-@pytest.mark.parametrize(
-    "invalid_snapshot",
-    [
-        pytest.param(b"invalid snapshot", id="invalid-prefix"),
-        pytest.param(_PARSER_SOURCE_DATA_CACHE_MAGIC + b"\xff", id="invalid-payload"),
-    ],
-)
-def test_parser_source_cache_recovers_from_invalid_serialized_value(
-    tmp_path: Path,
-    invalid_snapshot: bytes,
-) -> None:
-    """Reparse source data after an invalid internal cache value."""
-    schema_path = tmp_path / "schema.yaml"
-    schema_path.write_text("properties:\n  name:\n    type: string\n", encoding="utf-8")
-    _clear_parser_source_data_cache()
-    original = load_data_from_path(schema_path, "utf-8")
-    load_data_from_path(schema_path, "utf-8")
-    cache_key = next(iter(_parser_source_data_cache))
-    _parser_source_data_cache[cache_key] = invalid_snapshot
-
-    assert_mutable_copy_is_isolated(
-        original=original,
-        copied=load_data_from_path(schema_path, "utf-8"),
-        mutate_copied=lambda value: value["properties"]["name"].update(type="integer"),
-        label="reparsed YAML source",
-    )
-    assert_mutable_copy_is_isolated(
-        original=original,
-        copied=load_data_from_path(schema_path, "utf-8"),
-        mutate_copied=lambda value: value["properties"]["name"].update(type="number"),
-        label="recovered cached YAML source",
     )
 
 

--- a/tests/main/test_parsed_source_cache_parity.py
+++ b/tests/main/test_parsed_source_cache_parity.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import marshal
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier, Event
 from typing import TYPE_CHECKING
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from datamodel_code_generator import (
+    _PARSER_SOURCE_DATA_CACHE_MAGIC,
     InputFileType,
     _clear_parser_source_data_cache,
     _is_parsed_source_cache_enabled,
@@ -162,10 +163,10 @@ def test_parser_source_cache_skips_unserializable_values(
     _clear_parser_source_data_cache()
     original = load_data_from_path(schema_path, "utf-8")
 
-    def raise_serialization_error(*_args: object, **_kwargs: object) -> str:
+    def raise_serialization_error(*_args: object, **_kwargs: object) -> bytes:
         raise ValueError
 
-    monkeypatch.setattr(json, "dumps", raise_serialization_error)
+    monkeypatch.setattr(marshal, "dumps", raise_serialization_error)
     assert_mutable_copy_is_isolated(
         original=original,
         copied=load_data_from_path(schema_path, "utf-8"),
@@ -177,8 +178,8 @@ def test_parser_source_cache_skips_unserializable_values(
 
 
 @pytest.mark.allow_direct_assert
-def test_parser_source_cache_skips_lossy_yaml_values(tmp_path: Path) -> None:
-    """Keep values uncached when JSON serialization would change their shape."""
+def test_parser_source_cache_isolates_non_string_yaml_keys(tmp_path: Path) -> None:
+    """Preserve non-string YAML keys in independent cached values."""
     schema_path = tmp_path / "schema.yaml"
     schema_path.write_text("1:\n  nested: true\n", encoding="utf-8")
     _clear_parser_source_data_cache()
@@ -188,12 +189,44 @@ def test_parser_source_cache_skips_lossy_yaml_values(tmp_path: Path) -> None:
         original=original,
         copied=load_data_from_path(schema_path, "utf-8"),
         mutate_copied=lambda value: value[1].update(nested=False),
-        label="uncached lossy YAML source",
+        label="cached non-string-key YAML source",
     )
-    assert not _parser_source_data_cache
+    assert _parser_source_data_cache
 
 
-def test_parser_source_cache_recovers_from_invalid_serialized_value(tmp_path: Path) -> None:
+@pytest.mark.allow_direct_assert
+def test_parser_source_cache_preserves_yaml_aliases(tmp_path: Path) -> None:
+    """Preserve shared YAML values inside an isolated cached source graph."""
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text(
+        "shared: &shared\n  type: string\nfirst: *shared\nsecond: *shared\n",
+        encoding="utf-8",
+    )
+    _clear_parser_source_data_cache()
+    original = load_data_from_path(schema_path, "utf-8")
+    load_data_from_path(schema_path, "utf-8")
+    cached = load_data_from_path(schema_path, "utf-8")
+
+    assert cached["first"] is cached["second"]
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=cached,
+        mutate_copied=lambda value: value["first"].update(type="integer"),
+        label="cached YAML aliases",
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_snapshot",
+    [
+        pytest.param(b"invalid snapshot", id="invalid-prefix"),
+        pytest.param(_PARSER_SOURCE_DATA_CACHE_MAGIC + b"\xff", id="invalid-payload"),
+    ],
+)
+def test_parser_source_cache_recovers_from_invalid_serialized_value(
+    tmp_path: Path,
+    invalid_snapshot: bytes,
+) -> None:
     """Reparse source data after an invalid internal cache value."""
     schema_path = tmp_path / "schema.yaml"
     schema_path.write_text("properties:\n  name:\n    type: string\n", encoding="utf-8")
@@ -201,7 +234,7 @@ def test_parser_source_cache_recovers_from_invalid_serialized_value(tmp_path: Pa
     original = load_data_from_path(schema_path, "utf-8")
     load_data_from_path(schema_path, "utf-8")
     cache_key = next(iter(_parser_source_data_cache))
-    _parser_source_data_cache[cache_key] = "invalid JSON"
+    _parser_source_data_cache[cache_key] = invalid_snapshot
 
     assert_mutable_copy_is_isolated(
         original=original,

--- a/tests/main/test_parsed_source_cache_parity.py
+++ b/tests/main/test_parsed_source_cache_parity.py
@@ -195,8 +195,8 @@ def test_parser_source_cache_isolates_non_string_yaml_keys(tmp_path: Path) -> No
 
 
 @pytest.mark.allow_direct_assert
-def test_parser_source_cache_preserves_yaml_aliases(tmp_path: Path) -> None:
-    """Preserve shared YAML values inside an isolated cached source graph."""
+def test_parser_source_cache_preserves_yaml_graph_sharing(tmp_path: Path) -> None:
+    """Preserve the YAML backend's graph-sharing semantics in an isolated cached source."""
     schema_path = tmp_path / "schema.yaml"
     schema_path.write_text(
         "shared: &shared\n  type: string\nfirst: *shared\nsecond: *shared\n",
@@ -207,7 +207,7 @@ def test_parser_source_cache_preserves_yaml_aliases(tmp_path: Path) -> None:
     load_data_from_path(schema_path, "utf-8")
     cached = load_data_from_path(schema_path, "utf-8")
 
-    assert cached["first"] is cached["second"]
+    assert (cached["first"] is cached["second"]) == (original["first"] is original["second"])
     assert_mutable_copy_is_isolated(
         original=original,
         copied=cached,

--- a/tests/main/test_parsed_source_cache_parity.py
+++ b/tests/main/test_parsed_source_cache_parity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pickle
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier, Event
 from typing import TYPE_CHECKING
@@ -14,13 +15,15 @@ from datamodel_code_generator import (
     _is_parsed_source_cache_enabled,
     _parser_source_data_cache,
     enable_parsed_source_cache,
+    load_data_from_path,
 )
-from tests.conftest import assert_output
+from tests.conftest import assert_mutable_copy_is_isolated, assert_output
 from tests.main.conftest import JSON_SCHEMA_DATA_PATH, OPEN_API_DATA_PATH, run_main_with_args
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
+    from typing import Any
 
 
 def _input_file_type_option(input_file_type: InputFileType) -> str:
@@ -137,6 +140,66 @@ def test_parsed_source_cache_scope_thread_safety() -> None:
     assert not _is_parsed_source_cache_enabled()
 
 
+def _mutate_cached_schema(schema: dict[str, Any], input_file_type: InputFileType) -> None:
+    match input_file_type:
+        case InputFileType.JsonSchema:
+            schema["properties"]["firstName"]["type"] = "integer"
+        case InputFileType.OpenAPI:
+            schema["components"]["schemas"]["Pet"]["properties"]["name"]["type"] = "integer"
+        case _:  # pragma: no cover
+            msg = f"Unsupported parsed source cache mutation input type: {input_file_type}"
+            raise AssertionError(msg)
+
+
+@pytest.mark.allow_direct_assert
+def test_parser_source_cache_skips_unserializable_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep parsed source loading available when cache serialization fails."""
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text('{"properties": {"name": {"type": "string"}}}', encoding="utf-8")
+    _clear_parser_source_data_cache()
+    original = load_data_from_path(schema_path, "utf-8")
+
+    def raise_pickling_error(*_args: object, **_kwargs: object) -> bytes:
+        raise pickle.PicklingError
+
+    monkeypatch.setattr(pickle, "dumps", raise_pickling_error)
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=load_data_from_path(schema_path, "utf-8"),
+        mutate_copied=lambda value: value["properties"]["name"].update(type="integer"),
+        label="uncached unserializable JSON source",
+    )
+
+    assert not _parser_source_data_cache
+
+
+def test_parser_source_cache_recovers_from_invalid_serialized_value(tmp_path: Path) -> None:
+    """Reparse source data after an invalid internal cache value."""
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text("properties:\n  name:\n    type: string\n", encoding="utf-8")
+    _clear_parser_source_data_cache()
+    original = load_data_from_path(schema_path, "utf-8")
+    load_data_from_path(schema_path, "utf-8")
+    cache_key = next(iter(_parser_source_data_cache))
+    _parser_source_data_cache[cache_key] = b"invalid pickle"
+
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=load_data_from_path(schema_path, "utf-8"),
+        mutate_copied=lambda value: value["properties"]["name"].update(type="integer"),
+        label="reparsed YAML source",
+    )
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=load_data_from_path(schema_path, "utf-8"),
+        mutate_copied=lambda value: value["properties"]["name"].update(type="number"),
+        label="recovered cached YAML source",
+    )
+
+
 @pytest.mark.parametrize(
     ("input_path", "input_file_type", "extra_args"),
     [
@@ -194,4 +257,52 @@ def test_generate_output_matches_with_and_without_parsed_source_cache(
 
     assert cached_entry_count > 0
     assert uncached_entry_count == 0
+    assert_output(uncached_output.read_text(encoding="utf-8"), cached_output)
+
+
+@pytest.mark.parametrize(
+    ("input_path", "input_file_type"),
+    [
+        pytest.param(
+            JSON_SCHEMA_DATA_PATH / "person.json",
+            InputFileType.JsonSchema,
+            id="json",
+        ),
+        pytest.param(
+            OPEN_API_DATA_PATH / "api.yaml",
+            InputFileType.OpenAPI,
+            id="yaml",
+        ),
+    ],
+)
+def test_generate_output_ignores_external_cached_source_mutation(
+    input_path: Path,
+    input_file_type: InputFileType,
+    tmp_path: Path,
+) -> None:
+    """Keep generated output stable after a caller mutates a cached parsed value."""
+    cached_output = tmp_path / "cached.py"
+    uncached_output = tmp_path / "uncached.py"
+    _clear_parser_source_data_cache()
+    original = load_data_from_path(input_path, "utf-8")
+    cached = load_data_from_path(input_path, "utf-8")
+    assert_mutable_copy_is_isolated(
+        original=original,
+        copied=cached,
+        mutate_copied=lambda value: _mutate_cached_schema(value, input_file_type),
+        label=f"cached {input_file_type.value} source",
+    )
+
+    run_main_with_args(
+        _build_generate_args(input_path, cached_output, input_file_type, None),
+        use_parsed_source_cache=True,
+        use_builtin_default_formatter=False,
+    )
+    _clear_parser_source_data_cache()
+    run_main_with_args(
+        _build_generate_args(input_path, uncached_output, input_file_type, None),
+        use_parsed_source_cache=False,
+        use_builtin_default_formatter=False,
+    )
+
     assert_output(uncached_output.read_text(encoding="utf-8"), cached_output)

--- a/tests/test_conftest_helpers.py
+++ b/tests/test_conftest_helpers.py
@@ -286,31 +286,6 @@ def test_assert_inputs_not_mutated_reports_nested_mutation() -> None:
         schema["required"].append("age")
 
 
-def test_path_cache_value_at_path_handles_sequences() -> None:
-    """Path cache helper can traverse mapping and sequence values."""
-    value = {"items": [{"name": "first"}]}
-
-    assert main_conftest._value_at_path(value, ("items", 0, "name")) == "first"
-
-
-def test_path_cache_value_at_path_reports_invalid_path() -> None:
-    """Path cache helper reports paths that cannot be traversed."""
-    with pytest.raises(pytest.fail.Exception, match="Expected cached value to contain path"):
-        main_conftest._value_at_path({"items": []}, ("items", "name"))
-
-
-def test_assert_path_cache_reuses_value_reports_cache_miss(tmp_path: Path) -> None:
-    """Path cache reuse helper fails when the loader returns a new object."""
-    path = tmp_path / "schema.json"
-    path.write_text("{}", encoding="utf-8")
-
-    def load_new_value(path: Path, encoding: str) -> object:  # noqa: ARG001
-        return {}
-
-    with pytest.raises(pytest.fail.Exception, match=r"Expected cached value .* to be reused"):
-        main_conftest.assert_path_cache_reuses_value(load_new_value, path)
-
-
 def test_assert_path_cache_evicts_lru_entries_reports_first_mismatch(tmp_path: Path) -> None:
     """LRU helper fails when the first path value is unstable."""
     first_path = tmp_path / "first.json"
@@ -348,56 +323,6 @@ def test_assert_path_cache_evicts_lru_entries_reports_second_mismatch(tmp_path: 
 
     with pytest.raises(pytest.fail.Exception, match=r"Expected cached value .* to stay stable"):
         main_conftest.assert_path_cache_evicts_lru_entries(load_unstable_second, first_path, second_path)
-
-
-def test_assert_path_cache_invalidates_after_write_reports_stale_identity(tmp_path: Path) -> None:
-    """Path cache invalidation helper fails when a loader returns the stale object."""
-    path = tmp_path / "schema.json"
-    path.write_text("old", encoding="utf-8")
-    cached_value: dict[str, str] = {}
-
-    def load_stale_value(path: Path, encoding: str) -> object:  # noqa: ARG001
-        return cached_value
-
-    with pytest.raises(pytest.fail.Exception, match=r"Expected cached value .* to be invalidated after write"):
-        main_conftest.assert_path_cache_invalidates_after_write(load_stale_value, path, "new", "new")
-
-
-def test_assert_path_cache_invalidates_after_write_reports_unexpected_value(tmp_path: Path) -> None:
-    """Path cache invalidation helper fails when the updated value is unexpected."""
-    path = tmp_path / "schema.json"
-    path.write_text("old", encoding="utf-8")
-
-    def load_text_value(path: Path, encoding: str) -> object:
-        return {"value": path.read_text(encoding=encoding)}
-
-    with pytest.raises(pytest.fail.Exception, match="Expected cached value 'expected', got 'actual'"):
-        main_conftest.assert_path_cache_invalidates_after_write(
-            load_text_value,
-            path,
-            "actual",
-            "expected",
-            expected_value_path=("value",),
-        )
-
-
-def test_assert_path_cache_invalidates_after_write_reports_updated_cache_miss(tmp_path: Path) -> None:
-    """Path cache invalidation helper fails when the updated value is not reused."""
-    path = tmp_path / "schema.json"
-    path.write_text("old", encoding="utf-8")
-
-    def load_text_value(path: Path, encoding: str) -> object:
-        return {"value": path.read_text(encoding=encoding)}
-
-    with pytest.raises(pytest.fail.Exception, match=r"Expected updated cached value .* to be reused"):
-        main_conftest.assert_path_cache_invalidates_after_write(
-            load_text_value,
-            path,
-            "new",
-            "new",
-            expected_value_path=("value",),
-            warmups=1,
-        )
 
 
 def test_builtin_parity_mock_call_preservation(mocker: MockerFixture) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process-local source caching to store serialized snapshots, preventing shared mutable state across loads.
  * Added safer cache behavior: corrupted/unexpected snapshots are discarded and data is transparently reparsed; non-serializable values won’t be cached.

* **Tests**
  * Updated and expanded caching parity tests to validate mutable-copy isolation, including non-string YAML keys and preservation of YAML anchor/alias graph structure.
  * Added robustness checks for invalid cached entries and verified generation output remains identical when cached parsed sources are externally mutated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->