### PR TITLE
Invalidate semantic model caches

### DIFF
--- a/src/datamodel_code_generator/model/base.py
+++ b/src/datamodel_code_generator/model/base.py
@@ -327,11 +327,15 @@ class ConstraintsBase(_BaseModel):
         )
 
 
-class DataModelFieldBase(_BaseModel):
+class DataModelFieldBase(_BaseModel):  # noqa: PLR0904
     """Base class for model field representation and rendering."""
 
     _FIELD_IMPORTS_CACHE_MAX_SIZE: ClassVar[int] = 4096
     _field_imports_cache: ClassVar[dict[tuple[Any, ...], tuple[Import, ...]]] = {}
+    _SEMANTIC_CACHE_KEYS: ClassVar[tuple[str, ...]] = (
+        "_computed_default_factory",
+        "_self_reference_cache",
+    )
     SUPPORTS_FIELD_CONSTRAINTS: ClassVar[bool] = False
     SUPPORTS_ANNOTATED_CONSTRAINTS: ClassVar[bool] = False
     ANNOTATED_CONSTRAINTS_CONTEXT: ClassVar[object | None] = None
@@ -427,7 +431,7 @@ class DataModelFieldBase(_BaseModel):
     def self_reference(self) -> bool:
         """Check if field references its parent model.
 
-        Result is cached after first call since parent is stable at render time.
+        Result is cached until a GenerationStore-managed semantic mutation.
         Uses __dict__ for caching to avoid Pydantic-managed field assignment.
         """
         if "_self_reference_cache" in self.__dict__:
@@ -918,7 +922,19 @@ class DataModelFieldBase(_BaseModel):
 
     def force_field_assignment(self) -> None:
         """Render an explicit required-field assignment without changing its semantics."""
+        if self.__dict__.get("_forced_field_assignment") is True:
+            return
         self.__dict__["_forced_field_assignment"] = True
+        self._invalidate_parent_render_caches()
+
+    def _invalidate_parent_render_caches(self) -> None:
+        """Clear parent render caches through current or legacy model hooks."""
+        if (parent := self.parent) is None:
+            return
+        if invalidate_render_caches := getattr(parent, "invalidate_render_caches", None):
+            invalidate_render_caches()
+            return
+        parent.clear_imports_cache()
 
     def _get_constructor_default_info(self) -> tuple[bool, bool]:
         """Return neutral constructor-default semantics for this field."""
@@ -974,7 +990,17 @@ class DataModelFieldBase(_BaseModel):
             copied.data_type.data_types = [dt.model_copy() for dt in self.data_type.data_types]
         if self.data_type.dict_key:
             copied.data_type.dict_key = self.data_type.dict_key.model_copy()
+        copied.invalidate_semantic_caches()
         return copied
+
+    def invalidate_semantic_caches(self, *, invalidate_parent: bool = True) -> None:
+        """Clear field caches derived from mutable type and parent semantics."""
+        field_values = self.__dict__
+        for key in self._SEMANTIC_CACHE_KEYS:
+            field_values.pop(key, None)
+        if not invalidate_parent:
+            return
+        self._invalidate_parent_render_caches()
 
     def replace_data_type(self, new_data_type: DataType, *, clear_old_parent: bool = True) -> None:
         """Replace data_type and update parent relationships.
@@ -989,8 +1015,7 @@ class DataModelFieldBase(_BaseModel):
         else:
             self.data_type = new_data_type
             new_data_type.parent = self
-        if self.parent is not None:
-            self.parent.clear_imports_cache()
+        self.invalidate_semantic_caches()
 
 
 def _nested_model_default_factory(field: DataModelFieldBase, model_cls: type[DataModel]) -> str | None:
@@ -1459,6 +1484,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         self.description = description
         for field in self.fields:
             field.parent = self
+            field.invalidate_semantic_caches(invalidate_parent=False)
 
         self._additional_imports.extend(self.DEFAULT_IMPORTS)
         self.default: Any = default
@@ -1535,8 +1561,27 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
     def replace_children_in_models(self, models: list[DataModel], new_ref: Reference) -> None:
         """Replace reference children if their parent model is in models list."""
         for child in self.reference.children[:]:
-            if isinstance(child, DataType) and get_most_of_parent(child) in models:
-                child.replace_reference(new_ref)
+            if not isinstance(child, DataType):
+                continue
+            owner_model = get_most_of_parent(child, DataModel)
+            if isinstance(owner_model, DataModel):
+                if owner_model not in models:
+                    continue
+                owner_models = (owner_model,)
+            else:
+                owner_models = tuple(
+                    model for model in models if any(base_class is child for base_class in model.base_classes)
+                )
+            if not owner_models:
+                continue
+            child.replace_reference(new_ref)
+            current: DataType | DataModelFieldBase = child
+            while isinstance(parent := current.parent, DataType):
+                current = parent
+            if isinstance(parent, DataModelFieldBase):
+                parent.invalidate_semantic_caches(invalidate_parent=False)
+            for owner_model in owner_models:
+                owner_model.invalidate_render_caches()
 
     def set_base_class(self) -> None:
         """Set up the base class(es) for this model."""
@@ -1549,7 +1594,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
 
         if not base_class_list:
             self.base_classes = []
-            self.clear_imports_cache()
+            self.invalidate_render_caches()
             return
 
         result = []
@@ -1558,7 +1603,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
             self._additional_imports.append(base_class_import)
             result.append(BaseClassDataType.from_import(base_class_import))
         self.base_classes = result
-        self.clear_imports_cache()
+        self.invalidate_render_caches()
 
     @cached_property
     def template_file_path(self) -> Path:
@@ -1610,6 +1655,12 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         """Clear cached imports after import-affecting model, field, or data type mutations."""
         self.__dict__.pop(self._IMPORTS_CACHE_KEY, None)
 
+    def invalidate_render_caches(self) -> None:
+        """Clear cached imports and render-derived model identity."""
+        self.clear_imports_cache()
+        if dedup_key_cache := getattr(self, "_dedup_key_cache", None):
+            dedup_key_cache.clear()
+
     @property
     def reference_classes(self) -> frozenset[str]:
         """Get all referenced class paths used by this model."""
@@ -1650,7 +1701,7 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
             self.reference.name = f"{self.reference.name.rsplit('.', 1)[0]}.{class_name}"
         else:
             self.reference.name = class_name
-        self.clear_imports_cache()
+        self.invalidate_render_caches()
 
     @property
     def duplicate_class_name(self) -> str:
@@ -1720,7 +1771,9 @@ class DataModel(TemplateBase, Nullable, ABC):  # noqa: PLR0904
         self.reference.path = new_path
         if "path" in self.__dict__:  # pragma: no branch
             del self.__dict__["path"]
-        self.clear_imports_cache()
+        for field in self.fields:
+            field.invalidate_semantic_caches(invalidate_parent=False)
+        self.invalidate_render_caches()
 
     def render(self, *, class_name: str | None = None) -> str:
         """Render the model to a string using the template."""

--- a/src/datamodel_code_generator/parser/generation.py
+++ b/src/datamodel_code_generator/parser/generation.py
@@ -49,11 +49,16 @@ if TYPE_CHECKING:
     from datamodel_code_generator.model.base import BaseClassDataType, DataModel, DataModelFieldBase
     from datamodel_code_generator.types import DataType
 
+    OwnerModels: TypeAlias = DataModel | tuple[DataModel, ...] | None
+    CacheOwners: TypeAlias = tuple[DataModelFieldBase | None, OwnerModels]
+
 else:
     BaseClassDataType: TypeAlias = Any
     DataModel: TypeAlias = Any
     DataModelFieldBase: TypeAlias = Any
     DataType: TypeAlias = Any
+    OwnerModels: TypeAlias = Any
+    CacheOwners: TypeAlias = Any
 
 Reference: TypeAlias = Any
 ModelId: TypeAlias = int
@@ -99,13 +104,6 @@ def set_model_base_classes(
         generation_store.set_base_classes(model, base_classes)
 
 
-def _outermost_parent(value: object) -> object:
-    current = value
-    while (parent := getattr(current, "parent", None)) is not None:
-        current = parent
-    return current
-
-
 @dataclass(frozen=True, slots=True)
 class ModelFact:
     """A parsed model and the stable facts derived from its reference."""
@@ -139,6 +137,7 @@ class GenerationFacts:
     model_facts: dict[ModelId, ModelFact] = field(default_factory=dict)
     data_type_facts: dict[DataTypeId, DataTypeFact] = field(default_factory=dict)
     data_type_fact_by_object: dict[int, DataTypeFact] = field(default_factory=dict)
+    base_owner_model_ids_by_object: dict[int, ModelId | list[ModelId]] = field(default_factory=dict)
     model_by_path: dict[str, ModelId] = field(default_factory=dict)
     model_by_ref_id: dict[int, ModelId] = field(default_factory=dict)
     data_types_by_model: dict[ModelId, tuple[DataTypeId, ...]] = field(default_factory=dict)
@@ -325,6 +324,14 @@ class GenerationIndexBuilder:
                 )
 
             for base_class in model_fact.model.base_classes:
+                base_class_id = id(base_class)
+                match self._facts.base_owner_model_ids_by_object.get(base_class_id):
+                    case None:
+                        self._facts.base_owner_model_ids_by_object[base_class_id] = model_id
+                    case int() as existing_model_id if existing_model_id != model_id:
+                        self._facts.base_owner_model_ids_by_object[base_class_id] = [existing_model_id, model_id]
+                    case list() as existing_model_ids if model_id not in existing_model_ids:
+                        existing_model_ids.append(model_id)
                 self._record_data_type_tree(
                     base_class,
                     owner_model=model_id,
@@ -698,9 +705,9 @@ class GenerationStore:  # noqa: PLR0904
 
     def replace_data_type_ref(self, data_type: DataType, new_reference: Reference | None) -> None:
         """Set ``data_type.reference`` while preserving reverse reference links."""
-        owner_model = self._owner_model_for_data_type(data_type)
+        cache_owners = self._cache_owners_for_data_type(data_type)
         self._replace_data_type_reference(data_type, new_reference)
-        self._clear_imports_cache_for_model(owner_model)
+        self._invalidate_owner_caches(*cache_owners)
         self._invalidate_after_mutation()
 
     def detach_data_type_ref(self, data_type: DataType) -> None:
@@ -725,7 +732,7 @@ class GenerationStore:  # noqa: PLR0904
             model.set_reference_path(new_path)
         if new_file_path is not None:
             model.file_path = new_file_path
-        self._clear_imports_cache_for_model(model)
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def rename_model(
@@ -747,9 +754,7 @@ class GenerationStore:  # noqa: PLR0904
 
     def replace_field_type(self, field_: DataModelFieldBase, new_data_type: DataType) -> None:
         """Replace a field's data type and invalidate derived facts."""
-        owner_model = self._owner_model_for_field(field_)
         field_.replace_data_type(new_data_type)
-        self._clear_imports_cache_for_model(owner_model)
         self._invalidate_after_mutation()
 
     def replace_nested_data_type(
@@ -767,27 +772,29 @@ class GenerationStore:  # noqa: PLR0904
 
     def set_nested_data_types(self, data_type: DataType, nested_data_types: Iterable[DataType]) -> None:
         """Replace nested data types and invalidate derived facts."""
-        owner_model = self._owner_model_for_data_type(data_type)
+        cache_owners = self._cache_owners_for_data_type(data_type)
         for nested_data_type in data_type.data_types:
             nested_data_type.parent = None
         data_type.data_types = list(nested_data_types)
         for nested_data_type in data_type.data_types:
             nested_data_type.parent = data_type
-        self._clear_imports_cache_for_model(owner_model)
+        self._invalidate_owner_caches(*cache_owners)
         self._invalidate_after_mutation()
 
     def append_field(self, model: DataModel, field_: DataModelFieldBase) -> None:
         """Append a field to ``model`` and invalidate derived facts."""
         field_.parent = model
+        field_.invalidate_semantic_caches(invalidate_parent=False)
         model.fields.append(field_)
-        self._clear_imports_cache_for_model(model)
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def insert_field(self, model: DataModel, index: int, field_: DataModelFieldBase) -> None:
         """Insert a field into ``model`` and invalidate derived facts."""
         field_.parent = model
+        field_.invalidate_semantic_caches(invalidate_parent=False)
         model.fields.insert(index, field_)
-        self._clear_imports_cache_for_model(model)
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def remove_field(self, model: DataModel, field_: DataModelFieldBase) -> None:
@@ -795,7 +802,8 @@ class GenerationStore:  # noqa: PLR0904
         model.fields.remove(field_)
         if field_.parent is model:
             field_.parent = None
-        self._clear_imports_cache_for_model(model)
+            field_.invalidate_semantic_caches(invalidate_parent=False)
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def set_fields(self, model: DataModel, fields: Iterable[DataModelFieldBase]) -> None:
@@ -806,31 +814,31 @@ class GenerationStore:  # noqa: PLR0904
         for field_ in old_fields:
             if field_.parent is model and id(field_) not in new_field_ids:
                 field_.parent = None
+                field_.invalidate_semantic_caches(invalidate_parent=False)
         for field_ in model.fields:
             field_.parent = model
-        self._clear_imports_cache_for_model(model)
+            field_.invalidate_semantic_caches(invalidate_parent=False)
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def set_base_classes(self, model: DataModel, base_classes: Iterable[BaseClassDataType]) -> None:
         """Replace ``model`` base classes and invalidate derived facts."""
         model.base_classes = list(base_classes)
-        self._clear_imports_cache_for_model(model)
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def reset_base_classes(self, model: DataModel) -> None:
         """Reset ``model`` to its default base classes and invalidate derived facts."""
         model.set_base_class()
+        self._invalidate_render_caches_for_model(model)
         self._invalidate_after_mutation()
 
     def redirect_reference_users(self, old_reference: Reference, new_reference: Reference) -> None:
         """Redirect every user of ``old_reference`` to ``new_reference``."""
-        owner_models = [
-            self._owner_model_for_data_type(child)
-            for child in old_reference.children[:]
-            if hasattr(child, "replace_reference")
-        ]
+        children = [child for child in old_reference.children[:] if hasattr(child, "replace_reference")]
+        cache_owners = [self._cache_owners_for_data_type(child) for child in children]
         self._replace_reference_children(old_reference, new_reference)
-        self._clear_imports_cache_for_models(owner_models)
+        self._invalidate_owner_caches_many(cache_owners)
         self._invalidate_after_mutation()
 
     def redirect_model_reference_users(
@@ -841,12 +849,21 @@ class GenerationStore:  # noqa: PLR0904
     ) -> None:
         """Redirect ``model`` reference users owned by ``models`` to ``new_reference``."""
         model_ids = {id(candidate) for candidate in models}
-        owner_models = []
+        cache_owners = []
         for child in model.reference.children[:]:
-            if id(_outermost_parent(child)) in model_ids and hasattr(child, "replace_reference"):
-                owner_models.append(self._owner_model_for_data_type(child))
-                child.replace_reference(new_reference)  # ty: ignore[call-non-callable]
-        self._clear_imports_cache_for_models(owner_models)
+            if not hasattr(child, "replace_reference"):
+                continue
+            cache_owners_for_child = self._cache_owners_for_data_type(child)
+            owner_models = cache_owners_for_child[1]
+            if isinstance(owner_models, tuple):
+                matches_owner = any(id(owner_model) in model_ids for owner_model in owner_models)
+            else:
+                matches_owner = owner_models is not None and id(owner_models) in model_ids
+            if not matches_owner:
+                continue
+            cache_owners.append(cache_owners_for_child)
+            child.replace_reference(new_reference)  # ty: ignore[call-non-callable]
+        self._invalidate_owner_caches_many(cache_owners)
         self._invalidate_after_mutation()
 
     def collapse_root_data_type(self, data_type: DataType, inner_reference: Reference) -> None:
@@ -907,28 +924,72 @@ class GenerationStore:  # noqa: PLR0904
     def _invalidate_after_mutation(self) -> None:
         self._invalidate()
 
-    @staticmethod
-    def _owner_model_for_field(field_: DataModelFieldBase) -> DataModel | None:
-        owner_model = getattr(field_, "parent", None)
-        return owner_model if hasattr(owner_model, "clear_imports_cache") else None
+    def _cache_owners_for_data_type(self, data_type: object) -> CacheOwners:
+        current: Any = data_type
+        owner_field: DataModelFieldBase | None = None
+        while (parent := getattr(current, "parent", None)) is not None:
+            current = parent
+            if owner_field is None and hasattr(current, "invalidate_semantic_caches"):
+                owner_field = current
+        owner_model = current if hasattr(current, "clear_imports_cache") else None
+        if owner_model is not None:
+            return owner_field, owner_model  # ty: ignore[invalid-return-type]  # dynamic external model hooks
+        if not self.models:
+            return owner_field, None
+        if self._dirty and self._defer_refresh_depth:
+            return owner_field, tuple(
+                model for model in self.models if any(base_class is current for base_class in model.base_classes)
+            )
+        facts = self.current_facts()
+        match facts.base_owner_model_ids_by_object.get(id(current)):
+            case None:
+                owner_models = None
+            case int() as model_id:
+                owner_models = facts.model_facts[model_id].model
+            case model_ids:
+                owner_models = tuple(facts.model_facts[model_id].model for model_id in model_ids)
+        return owner_field, owner_models
+
+    def _invalidate_owner_caches(
+        self,
+        field_: DataModelFieldBase | None,
+        owner_models: OwnerModels,
+    ) -> None:
+        if field_ is not None:
+            field_.invalidate_semantic_caches(invalidate_parent=False)
+        if isinstance(owner_models, tuple):
+            for model in owner_models:
+                self._invalidate_render_caches_for_model(model)  # ty: ignore[invalid-argument-type]
+            return
+        self._invalidate_render_caches_for_model(owner_models)
+
+    def _invalidate_owner_caches_many(
+        self,
+        cache_owners: Iterable[CacheOwners],
+    ) -> None:
+        fields: dict[int, DataModelFieldBase] = {}
+        models: dict[int, DataModel] = {}
+        for field_, owner_models in cache_owners:
+            if field_ is not None:
+                fields[id(field_)] = field_
+            if isinstance(owner_models, tuple):
+                for model in owner_models:
+                    models[id(model)] = model  # ty: ignore[invalid-assignment]
+            elif owner_models is not None:
+                models[id(owner_models)] = owner_models
+        for field_ in fields.values():
+            field_.invalidate_semantic_caches(invalidate_parent=False)
+        for model in models.values():
+            self._invalidate_render_caches_for_model(model)
 
     @staticmethod
-    def _owner_model_for_data_type(data_type: object) -> Any:
-        owner_model: Any = _outermost_parent(data_type)
-        return owner_model if hasattr(owner_model, "clear_imports_cache") else None
-
-    @staticmethod
-    def _clear_imports_cache_for_model(model: DataModel | None) -> None:
-        if model is not None:
-            model.clear_imports_cache()
-
-    def _clear_imports_cache_for_models(self, models: Iterable[DataModel | None]) -> None:
-        seen: set[int] = set()
-        for model in models:
-            if model is None or id(model) in seen:
-                continue
-            seen.add(id(model))
-            self._clear_imports_cache_for_model(model)
+    def _invalidate_render_caches_for_model(model: DataModel | None) -> None:
+        if model is None:
+            return
+        if invalidate_render_caches := getattr(model, "invalidate_render_caches", None):
+            invalidate_render_caches()
+            return
+        model.clear_imports_cache()
 
     def __iter__(self) -> Iterator[DataModel]:
         return iter(self.models)

--- a/src/datamodel_code_generator/types.py
+++ b/src/datamodel_code_generator/types.py
@@ -107,7 +107,14 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
 
     from datamodel_code_generator.enums import StrictTypes
-    from datamodel_code_generator.model.base import DataModelFieldBase
+
+    class DataModelFieldBase(Protocol):
+        """Type-checking contract for a field that owns a DataType."""
+
+        data_type: DataType
+
+else:
+    DataModelFieldBase = Any
 
 
 class UnionIntFloat:
@@ -469,10 +476,8 @@ def get_optional_type(type_: str, use_union_operator: bool) -> str:  # noqa: FBT
 
 
 def is_data_model_field(obj: object) -> TypeIs[DataModelFieldBase]:
-    """Check if an object is a DataModelFieldBase instance."""
-    from datamodel_code_generator.model.base import DataModelFieldBase  # noqa: PLC0415
-
-    return isinstance(obj, DataModelFieldBase)
+    """Check if an object structurally owns a DataType."""
+    return isinstance(getattr(obj, "data_type", None), DataType)
 
 
 @runtime_checkable

--- a/tests/data/expected/main/custom_import_cache_unique_items.py
+++ b/tests/data/expected/main/custom_import_cache_unique_items.py
@@ -19,6 +19,6 @@ class Item(BaseModel):
 
 
 class Container(BaseModel):
-    cache_clear_history = ['empty', 'cached', 'empty', 'empty', 'empty', 'empty', 'cached']
+    cache_clear_history = ['empty', 'cached', 'empty', 'empty', 'cached']
     statuses: Optional[Set[Status]] = None
     items: Optional[Set[Item]] = None

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -224,6 +224,21 @@ def test_data_model() -> None:
     assert data_model.render() == "@validate\n@dataclass\nclass test_model:\n    a: str"
 
 
+def test_data_model_custom_base_class_list() -> None:
+    """Preserve every explicitly configured custom base class."""
+    model = BaseModel(
+        fields=[],
+        reference=Reference(path="Model", original_name="Model", name="Model"),
+        custom_base_class=["package.First", "package.Second"],
+    )
+
+    assert model.base_class == "First, Second"
+    assert [(base.type, base.import_) for base in model.base_classes] == [
+        ("First", Import(from_="package", import_="First")),
+        ("Second", Import(from_="package", import_="Second")),
+    ]
+
+
 def test_data_model_relative_custom_template_without_adapter() -> None:
     """Load a relative custom template unchanged when the model has no adapter."""
 
@@ -357,6 +372,94 @@ def test_data_model_imports_cache_clears_after_field_type_replacement() -> None:
     field.replace_data_type(DataType.from_import(IMPORT_DECIMAL))
 
     assert IMPORT_DECIMAL in model.imports
+
+
+def test_data_model_render_identity_cache_clears_after_field_mutations() -> None:
+    """Field mutations must not retain a render-derived deduplication key."""
+    field = PydanticDataclassField(name="value", data_type=DataType(type="str"), required=True)
+    model = PydanticDataclassModel(
+        fields=[field],
+        reference=Reference(path="Model", original_name="Model", name="Model"),
+    )
+    original_key = model.get_dedup_key()
+
+    field.force_field_assignment()
+    field.force_field_assignment()
+
+    assert model.get_dedup_key() != original_key
+
+
+@pytest.mark.parametrize("reference_name", ["Before", "package.Before"])
+def test_data_model_render_identity_cache_clears_after_model_rename(reference_name: str) -> None:
+    """Model identity must be recomputed after a generated class name changes."""
+    model = BaseModel(
+        fields=[],
+        reference=Reference(path=reference_name, original_name=reference_name, name=reference_name),
+    )
+    original_key = model.get_dedup_key(None, use_default=False)
+
+    model.class_name = "After"
+
+    assert model.reference.name == ("package.After" if "." in reference_name else "After")
+    assert model.get_dedup_key(None, use_default=False) != original_key
+
+
+def test_data_model_parent_and_reference_path_changes_invalidate_field_semantics() -> None:
+    """Direct model ownership and path changes must refresh self-reference state."""
+    model_reference = Reference(path="Before", original_name="Before", name="Before")
+    other_reference = Reference(path="After", original_name="After", name="After")
+    field = PydanticV2DataModelField(name="value", data_type=DataType(reference=other_reference))
+    model = BaseModel(fields=[field], reference=model_reference)
+
+    assert not field.self_reference()
+
+    model.set_reference_path("After")
+
+    assert field.self_reference()
+
+    replacement_model = BaseModel(
+        fields=[field],
+        reference=Reference(path="Replacement", original_name="Replacement", name="Replacement"),
+    )
+
+    assert field.parent is replacement_model
+    assert not field.self_reference()
+
+
+def test_field_deep_copy_drops_transient_semantic_caches() -> None:
+    """Copied fields must recompute transient renderer and self-reference state."""
+    field = PydanticV2DataModelField(name="value", data_type=DataType(type="str"))
+    field.__dict__["_computed_default_factory"] = "list"
+    field.__dict__["_self_reference_cache"] = True
+
+    copied = field.copy_deep()
+
+    assert "_computed_default_factory" not in copied.__dict__
+    assert "_self_reference_cache" not in copied.__dict__
+
+
+def test_field_semantic_cache_invalidation_supports_legacy_parent_hook() -> None:
+    """External parent implementations with only the legacy import hook remain compatible."""
+
+    class ImportsOnlyParent:
+        def __init__(self) -> None:
+            self.cache_cleared = False
+
+        def clear_imports_cache(self) -> None:
+            self.cache_cleared = True
+
+    parent = ImportsOnlyParent()
+    field = DataModelFieldBase(name="value", data_type=DataType(type="str"))
+    field.parent = parent  # ty: ignore[invalid-assignment]
+
+    field.invalidate_semantic_caches()
+
+    assert parent.cache_cleared
+
+    parent.cache_cleared = False
+    field.force_field_assignment()
+
+    assert parent.cache_cleared
 
 
 def test_pydantic_v2_extra_type_hint_keeps_non_dict_hint() -> None:
@@ -1004,11 +1107,14 @@ def test_data_model_exception() -> None:
 def test_replace_children_in_models_updates_matching_owner_references() -> None:
     """Test replacing reference children for only the selected owner models."""
     old_reference = Reference(path="Old", original_name="Old", name="Old")
-    new_reference = Reference(path="New", original_name="New", name="New")
+    new_reference = Reference(path="Selected", original_name="Selected", name="Selected")
     target_model = BaseModel(fields=[], reference=old_reference)
-    selected_type = DataType(reference=old_reference)
+    selected_type = DataType(data_types=[DataType(reference=old_reference)])
+    selected_reference_type = selected_type.data_types[0]
+    selected_reference_type.parent = selected_type
+    selected_field = DataModelFieldBase(data_type=selected_type)
     selected_model = BaseModel(
-        fields=[DataModelFieldBase(data_type=selected_type)],
+        fields=[selected_field],
         reference=Reference(path="Selected", original_name="Selected", name="Selected"),
     )
     other_type = DataType(reference=old_reference)
@@ -1017,12 +1123,50 @@ def test_replace_children_in_models_updates_matching_owner_references() -> None:
         reference=Reference(path="Other", original_name="Other", name="Other"),
     )
 
+    assert not selected_field.self_reference()
+
     target_model.replace_children_in_models([selected_model], new_reference)
 
-    assert selected_type.reference is new_reference
+    assert selected_field.self_reference()
+    assert selected_reference_type.reference is new_reference
     assert other_type.reference is old_reference
-    assert [child is selected_type for child in old_reference.children] == [False]
-    assert [child is selected_type for child in new_reference.children] == [True]
+    assert [child is selected_reference_type for child in old_reference.children] == [False]
+    assert [child is selected_reference_type for child in new_reference.children] == [True]
+
+
+def test_replace_children_in_models_invalidates_direct_model_owner() -> None:
+    """A redirected base-class reference refreshes its owning model's render identity."""
+    old_reference = Reference(path="Old", original_name="Old", name="Old")
+    new_reference = Reference(path="New", original_name="New", name="New")
+    target_model = BaseModel(fields=[], reference=old_reference)
+    selected_model = BaseModel(
+        fields=[],
+        base_classes=[old_reference],
+        reference=Reference(path="Selected", original_name="Selected", name="Selected"),
+    )
+    base_class = selected_model.base_classes[0]
+    shared_owner_model = BaseModel(
+        fields=[],
+        reference=Reference(path="SharedOwner", original_name="SharedOwner", name="SharedOwner"),
+    )
+    shared_owner_model.base_classes = [base_class]
+    ignored_owner_model = BaseModel(
+        fields=[],
+        base_classes=[old_reference],
+        reference=Reference(path="IgnoredOwner", original_name="IgnoredOwner", name="IgnoredOwner"),
+    )
+    ignored_base_class = ignored_owner_model.base_classes[0]
+    original_key = selected_model.get_dedup_key()
+    shared_owner_key = shared_owner_model.get_dedup_key()
+    ignored_owner_key = ignored_owner_model.get_dedup_key()
+
+    target_model.replace_children_in_models([selected_model, shared_owner_model], new_reference)
+
+    assert base_class.reference is new_reference
+    assert ignored_base_class.reference is old_reference
+    assert selected_model.get_dedup_key() != original_key
+    assert shared_owner_model.get_dedup_key() != shared_owner_key
+    assert ignored_owner_model.get_dedup_key() == ignored_owner_key
 
 
 def test_data_field() -> None:

--- a/tests/parser/test_generation.py
+++ b/tests/parser/test_generation.py
@@ -14,7 +14,11 @@ from inline_snapshot import snapshot
 from datamodel_code_generator.imports import IMPORT_DECIMAL, IMPORT_LIST, IMPORT_SET
 from datamodel_code_generator.model.base import BaseClassDataType, DataModel, DataModelFieldBase
 from datamodel_code_generator.model.dataclass import DataClass as StandardDataClass
+from datamodel_code_generator.model.msgspec import Constraints as MsgspecConstraints
+from datamodel_code_generator.model.msgspec import DataModelField as MsgspecDataModelField
+from datamodel_code_generator.model.msgspec import Struct as MsgspecStruct
 from datamodel_code_generator.model.pydantic_v2 import BaseModel, DataModelField, RootModel, RootModelTypeAlias
+from datamodel_code_generator.model.pydantic_v2.base_model import Constraints as PydanticConstraints
 from datamodel_code_generator.model.pydantic_v2.dataclass import DataClass as PydanticDataClass
 from datamodel_code_generator.model.pydantic_v2.version import (
     PYDANTIC_V2_ROOT_MODEL_DICT_KEY_FORWARD_REF_NEEDS_SORTING,
@@ -1211,6 +1215,193 @@ def test_generation_store_reference_redirects_clear_each_owner_imports_cache_onc
     })
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        pytest.param("replace_field_type", id="field-type"),
+        pytest.param("replace_data_type_ref", id="reference"),
+        pytest.param("replace_nested_reference", id="nested-reference"),
+        pytest.param("set_nested_data_types", id="nested-types"),
+        pytest.param("redirect_reference_users", id="redirect"),
+    ],
+)
+@pytest.mark.parametrize("starts_self_referencing", [False, True])
+def test_generation_store_type_mutations_invalidate_semantic_and_render_caches(
+    mutation: str,
+    *,
+    starts_self_referencing: bool,
+) -> None:
+    """Every store type mutation must invalidate field semantics and model identity."""
+    model_reference = Reference(path="Node", original_name="Node", name="Node")
+    other_reference = Reference(path="Other", original_name="Other", name="Other")
+    old_reference, new_reference = (
+        (model_reference, other_reference) if starts_self_referencing else (other_reference, model_reference)
+    )
+    nested_data_type = DataType(reference=old_reference)
+    data_type = (
+        DataType(data_types=[nested_data_type])
+        if mutation in {"replace_nested_reference", "set_nested_data_types"}
+        else nested_data_type
+    )
+    if data_type is not nested_data_type:
+        nested_data_type.parent = data_type
+    field = DataModelField(name="value", data_type=data_type)
+    if mutation in {"replace_nested_reference", "set_nested_data_types"}:
+        nested_data_type.parent = field.data_type
+    model = BaseModel(fields=[field], reference=model_reference)
+    store = GenerationStore()
+    store.register_model(model)
+
+    assert field.self_reference() is starts_self_referencing
+    assert model.get_dedup_key()
+
+    match mutation:
+        case "replace_field_type":
+            store.replace_field_type(field, DataType(reference=new_reference))
+        case "replace_data_type_ref" | "replace_nested_reference":
+            store.replace_data_type_ref(nested_data_type, new_reference)
+        case "set_nested_data_types":
+            store.set_nested_data_types(data_type, [DataType(reference=new_reference)])
+        case "redirect_reference_users":
+            store.redirect_reference_users(old_reference, new_reference)
+        case _:  # pragma: no cover
+            pytest.fail(f"Unsupported mutation: {mutation}")
+
+    assert field.self_reference() is not starts_self_referencing
+    assert model._dedup_key_cache == {}
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        pytest.param("append_field", id="append"),
+        pytest.param("insert_field", id="insert"),
+        pytest.param("set_fields", id="set"),
+    ],
+)
+def test_generation_store_field_ownership_mutations_invalidate_self_reference_cache(mutation: str) -> None:
+    """Moving a cached field to another model must refresh its parent semantics."""
+    original_model = _base_model("Original")
+    field = DataModelField(name="value", data_type=DataType(reference=original_model.reference))
+    original_model.fields.append(field)
+    field.parent = original_model
+    destination_model = _base_model("Destination")
+    store = GenerationStore()
+    store.register_model(original_model)
+    store.register_model(destination_model)
+
+    assert field.self_reference()
+
+    match mutation:
+        case "append_field":
+            store.append_field(destination_model, field)
+        case "insert_field":
+            store.insert_field(destination_model, 0, field)
+        case "set_fields":
+            store.set_fields(destination_model, [field])
+        case _:  # pragma: no cover
+            pytest.fail(f"Unsupported mutation: {mutation}")
+
+    assert field.parent is destination_model
+    assert not field.self_reference()
+
+
+def test_generation_store_field_removal_invalidates_self_reference_cache() -> None:
+    """Detaching a cached field must clear parent-dependent semantics."""
+    model = _base_model("Model")
+    field = DataModelField(name="value", data_type=DataType(reference=model.reference))
+    model.fields.append(field)
+    field.parent = model
+    store = GenerationStore()
+    store.register_model(model)
+
+    assert field.self_reference()
+
+    store.remove_field(model, field)
+
+    assert field.parent is None
+    assert not field.self_reference()
+
+
+def test_generation_store_self_reference_invalidation_updates_pydantic_constraints() -> None:
+    """Pydantic constraints must follow the current, not cached, self-reference state."""
+    model_reference = Reference(path="Node", original_name="Node", name="Node")
+    other_reference = Reference(path="Other", original_name="Other", name="Other")
+    data_type = DataType(reference=other_reference)
+    field = DataModelField(
+        name="value",
+        data_type=data_type,
+        constraints=PydanticConstraints(pattern="x"),
+    )
+    model = BaseModel(fields=[field], reference=model_reference)
+    store = GenerationStore()
+    store.register_model(model)
+
+    assert str(field) == "Field(None, pattern='x')"
+
+    store.replace_data_type_ref(data_type, model_reference)
+
+    assert not str(field)
+
+
+def test_generation_store_self_reference_invalidation_updates_msgspec_metadata() -> None:
+    """Msgspec metadata and imports must follow the current self-reference state."""
+    model_reference = Reference(path="Node", original_name="Node", name="Node")
+    other_reference = Reference(path="Other", original_name="Other", name="Other")
+    data_type = DataType(reference=other_reference)
+    field = MsgspecDataModelField(
+        name="value",
+        data_type=data_type,
+        constraints=MsgspecConstraints(pattern="x"),
+        required=True,
+        use_annotated=True,
+    )
+    model = MsgspecStruct(fields=[field], reference=model_reference)
+    store = GenerationStore()
+    store.register_model(model)
+
+    assert field.annotated == "Annotated[Other, Meta(pattern='x')]"
+    assert field.imports
+
+    store.replace_data_type_ref(data_type, model_reference)
+
+    assert field.annotated is None
+    assert field.imports == ()
+
+
+def test_generation_store_redirects_unattached_reference_users() -> None:
+    """Unattached data types remain supported without a field or model cache owner."""
+    old_reference = Reference(path="Old", original_name="Old", name="Old")
+    new_reference = Reference(path="New", original_name="New", name="New")
+    data_type = DataType(reference=old_reference)
+    store = GenerationStore()
+
+    store.redirect_reference_users(old_reference, new_reference)
+
+    assert data_type.reference is new_reference
+
+
+def test_generation_store_render_cache_invalidation_supports_legacy_model_hook() -> None:
+    """External model implementations with only the legacy import hook remain compatible."""
+
+    class ImportsOnlyModel:
+        def __init__(self) -> None:
+            self.reference = Reference(path="Before", original_name="Before", name="Before")
+            self.class_name = "Before"
+            self.cache_cleared = False
+
+        def clear_imports_cache(self) -> None:
+            self.cache_cleared = True
+
+    model = ImportsOnlyModel()
+    store = GenerationStore()
+
+    store.update_model_reference(model, class_name="After")  # ty: ignore[invalid-argument-type]
+
+    assert model.class_name == "After"
+    assert model.cache_cleared
+
+
 def test_generation_store_model_reference_redirect_clears_only_affected_owner_imports_cache() -> None:
     """Scoped model reference redirects should invalidate only matching owner models."""
     target_model = _base_model("Target")
@@ -1252,6 +1443,121 @@ def test_generation_store_model_reference_redirect_clears_only_affected_owner_im
         "owner_references": ["NewTarget", "NewTarget"],
         "other_references": ["Target"],
     })
+
+
+def test_generation_store_reference_redirect_invalidates_base_class_owner_render_cache() -> None:
+    """Unscoped redirects must invalidate models that own parentless base class types."""
+    target_model = _base_model("Target")
+    owner_model = BaseModel(
+        fields=[],
+        base_classes=[target_model.reference],
+        reference=Reference(path="Owner", original_name="Owner", name="Owner"),
+    )
+    new_reference = Reference(path="NewTarget", original_name="NewTarget", name="NewTarget")
+    store = GenerationStore()
+    store.register_model(target_model)
+    store.register_model(owner_model)
+    original_key = owner_model.get_dedup_key()
+
+    store.redirect_reference_users(target_model.reference, new_reference)
+
+    assert owner_model.base_classes[0].reference is new_reference
+    assert owner_model._dedup_key_cache == {}
+    assert owner_model.get_dedup_key() != original_key
+
+
+def test_generation_store_model_reference_redirect_resolves_base_class_owner() -> None:
+    """Scoped redirects must resolve base class ownership from generation facts."""
+    target_model = _base_model("Target")
+    owner_model = BaseModel(
+        fields=[],
+        base_classes=[target_model.reference],
+        reference=Reference(path="Owner", original_name="Owner", name="Owner"),
+    )
+    other_model = BaseModel(
+        fields=[],
+        base_classes=[target_model.reference],
+        reference=Reference(path="Other", original_name="Other", name="Other"),
+    )
+    new_reference = Reference(path="NewTarget", original_name="NewTarget", name="NewTarget")
+    store = GenerationStore()
+    store.register_model(target_model)
+    store.register_model(owner_model)
+    store.register_model(other_model)
+    assert owner_model.get_dedup_key()
+    assert other_model.get_dedup_key()
+
+    store.redirect_model_reference_users(target_model, [owner_model], new_reference)
+
+    assert owner_model.base_classes[0].reference is new_reference
+    assert owner_model._dedup_key_cache == {}
+    assert other_model.base_classes[0].reference is target_model.reference
+    assert other_model._dedup_key_cache
+
+
+def test_generation_store_model_reference_redirect_invalidates_shared_base_class_owners() -> None:
+    """A shared base class occurrence must invalidate every owning model."""
+    target_model = _base_model("Target")
+    first_model = _base_model("First")
+    second_model = _base_model("Second")
+    third_model = _base_model("Third")
+    shared_base_class = BaseClassDataType(reference=target_model.reference)
+    new_reference = Reference(path="NewTarget", original_name="NewTarget", name="NewTarget")
+    store = GenerationStore()
+    store.register_model(target_model)
+    store.register_model(first_model)
+    store.register_model(second_model)
+    store.register_model(third_model)
+    store.set_base_classes(first_model, [shared_base_class])
+    store.set_base_classes(second_model, [shared_base_class])
+    store.set_base_classes(third_model, [shared_base_class])
+    assert first_model.get_dedup_key()
+    assert second_model.get_dedup_key()
+    assert third_model.get_dedup_key()
+
+    store.redirect_model_reference_users(target_model, [first_model], new_reference)
+
+    assert shared_base_class.reference is new_reference
+    assert first_model._dedup_key_cache == {}
+    assert second_model._dedup_key_cache == {}
+    assert third_model._dedup_key_cache == {}
+
+
+def test_generation_store_indexes_each_shared_base_class_owner_once() -> None:
+    """Repeated shared base occurrences must not duplicate the owning model id."""
+    first_model = _base_model("First")
+    second_model = _base_model("Second")
+    shared_base_class = BaseClassDataType(type="object")
+    store = GenerationStore()
+    store.register_model(first_model)
+    store.register_model(second_model)
+    store.set_base_classes(first_model, [shared_base_class])
+    store.set_base_classes(second_model, [shared_base_class, shared_base_class])
+
+    facts = store.current_facts()
+    owner_ids = facts.base_owner_model_ids_by_object[id(shared_base_class)]
+
+    assert isinstance(owner_ids, list)
+    assert [facts.model_facts[model_id].model for model_id in owner_ids] == [first_model, second_model]
+
+
+def test_generation_store_detach_model_refs_resolves_deferred_base_class_owner() -> None:
+    """Deferred mutations must resolve live base class ownership before facts exist."""
+    target_model = _base_model("Target")
+    owner_model = BaseModel(
+        fields=[],
+        base_classes=[target_model.reference],
+        reference=Reference(path="Owner", original_name="Owner", name="Owner"),
+    )
+    store = GenerationStore()
+    store.register_model(target_model)
+    store.register_model(owner_model)
+    assert owner_model.get_dedup_key()
+
+    store.detach_model_data_type_refs(owner_model)
+
+    assert owner_model.base_classes[0].reference is None
+    assert owner_model._dedup_key_cache == {}
 
 
 def test_generation_store_redirects_model_reference_users_by_owner() -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,6 +19,7 @@ from datamodel_code_generator.types import (
     get_optional_type,
     get_subscript_args,
     get_type_base_name,
+    is_data_model_field,
     normalize_integer_constraint,
 )
 
@@ -77,6 +78,23 @@ def test_get_optional_type_cache_clear_preserves_value() -> None:
 def test_chain_as_tuple_chains_multiple_iterables() -> None:
     """Test chain_as_tuple handles the general path for more than two iterables."""
     assert chain_as_tuple((1,), (2,), (3,)) == (1, 2, 3)
+
+
+def test_is_data_model_field_matches_structural_type_contract() -> None:
+    """The runtime predicate must accept exactly field-like DataType owners."""
+
+    class FieldLike:
+        data_type = DataType(type="str")
+
+    class InvalidFieldLike:
+        data_type = object()
+
+    candidate: object = FieldLike()
+
+    assert is_data_model_field(candidate)
+    assert candidate.data_type.type == "str"
+    assert not is_data_model_field(InvalidFieldLike())
+    assert not is_data_model_field(object())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale field self-references and model deduplication keys after type/reference changes, field reparenting, deep copies, and model renames.
  * Improved semantic and render-cache invalidation when updating reference paths or redirecting reference users, including correct base-class owner handling.
  * Kept compatibility with legacy render-cache hooks when available.
* **Tests**
  * Expanded coverage for cache invalidation across nested and redirected mutations, including pydantic v2 and msgspec output/metadata changes and updated expected cache-clear history.
* **Refactor**
  * Updated field detection to use a structural contract for `is_data_model_field`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->