### PR TITLE
Suggest similar CLI options

### DIFF
--- a/src/datamodel_code_generator/arguments.py
+++ b/src/datamodel_code_generator/arguments.py
@@ -47,7 +47,7 @@ from datamodel_code_generator.preset_names import PRESET_NAMES
 
 if TYPE_CHECKING:
     from argparse import Action
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
 
 DEFAULT_ENCODING = "utf-8"
 
@@ -119,7 +119,41 @@ class SortingHelpFormatter(RawDescriptionHelpFormatter):
         return super().start_section(heading if namespace.no_color or not heading else self._bold_cyan(heading))
 
 
-arg_parser = ArgumentParser(
+class SuggestingArgumentParser(ArgumentParser):
+    """Argument parser that suggests close matches for unknown option names."""
+
+    def parse_args(self, args: Sequence[str] | None = None, namespace: Namespace | None = None) -> Namespace:
+        """Parse arguments and suggest close matches for unknown option names."""
+        parsed_args, unknown_arguments = self.parse_known_args(args, namespace)
+        if not unknown_arguments:
+            return cast("Namespace", parsed_args)
+        return self.error(self._unrecognized_arguments_message(unknown_arguments))
+
+    def _unrecognized_arguments_message(self, unknown_arguments: Sequence[str]) -> str:
+        """Format an unknown-argument message with close option-name matches."""
+        message = f"unrecognized arguments: {' '.join(unknown_arguments)}"
+        suggestions: list[str] = []
+        for unknown_argument in unknown_arguments:
+            match unknown_argument:
+                case "--":
+                    break
+                case option_name if option_name.startswith("-"):
+                    option_name = option_name.partition("=")[0]
+                case _:
+                    continue
+
+            from difflib import get_close_matches  # noqa: PLC0415
+
+            if (matches := get_close_matches(option_name, self._option_string_actions, n=1, cutoff=0.7)) and (
+                suggestion := matches[0]
+            ) not in suggestions:
+                suggestions.append(suggestion)
+        if not suggestions:
+            return message
+        return f"{message}\nDid you mean: {', '.join(suggestions)}?"
+
+
+arg_parser = SuggestingArgumentParser(
     usage="\n  datamodel-codegen [options]",
     description="Generate Python data models from schema definitions or structured data\n\n"
     "For detailed usage, see: https://datamodel-code-generator.koxudaxi.dev",

--- a/tests/data/expected/main/cli_fast_paths/generate_prompt_invalid_option.txt
+++ b/tests/data/expected/main/cli_fast_paths/generate_prompt_invalid_option.txt
@@ -1,0 +1,6 @@
+{
+  "code": 2,
+  "imported_difflib": true,
+  "imported_pydantic": false,
+  "stderr": "usage: \n  datamodel-codegen [options]\ndatamodel-codegen: error: unrecognized arguments: --output-model-tipe\nDid you mean: --output-model-type?\n"
+}

--- a/tests/data/expected/main/cli_option_suggestions/deduplicated_option.txt
+++ b/tests/data/expected/main/cli_option_suggestions/deduplicated_option.txt
@@ -1,0 +1,4 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: --output-model-tipe --output-model-tipe
+Did you mean: --output-model-type?

--- a/tests/data/expected/main/cli_option_suggestions/missing_option_value.txt
+++ b/tests/data/expected/main/cli_option_suggestions/missing_option_value.txt
@@ -1,0 +1,3 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: argument --output-model-type: expected one argument

--- a/tests/data/expected/main/cli_option_suggestions/multiple_options.txt
+++ b/tests/data/expected/main/cli_option_suggestions/multiple_options.txt
@@ -1,0 +1,4 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: --output-model-tipe --input-file-tipe
+Did you mean: --output-model-type, --input-file-type?

--- a/tests/data/expected/main/cli_option_suggestions/option_terminator.txt
+++ b/tests/data/expected/main/cli_option_suggestions/option_terminator.txt
@@ -1,0 +1,3 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: -- --output-model-tipe

--- a/tests/data/expected/main/cli_option_suggestions/output_model_type.txt
+++ b/tests/data/expected/main/cli_option_suggestions/output_model_type.txt
@@ -1,0 +1,4 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: --output-model-tipe
+Did you mean: --output-model-type?

--- a/tests/data/expected/main/cli_option_suggestions/output_model_type_with_value.txt
+++ b/tests/data/expected/main/cli_option_suggestions/output_model_type_with_value.txt
@@ -1,0 +1,4 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: --output-model-tipe=pydantic_v2.BaseModel
+Did you mean: --output-model-type?

--- a/tests/data/expected/main/cli_option_suggestions/positional_argument.txt
+++ b/tests/data/expected/main/cli_option_suggestions/positional_argument.txt
@@ -1,0 +1,3 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: not-an-option

--- a/tests/data/expected/main/cli_option_suggestions/unknown_option.txt
+++ b/tests/data/expected/main/cli_option_suggestions/unknown_option.txt
@@ -1,0 +1,3 @@
+usage:
+  datamodel-codegen [options]
+pytest: error: unrecognized arguments: --not-a-valid-option

--- a/tests/main/test_cli_fast_paths.py
+++ b/tests/main/test_cli_fast_paths.py
@@ -161,11 +161,43 @@ def _run_module_help_fast_path() -> dict[str, Any]:
                 "code": code,
                 "stdout": stdout.getvalue(),
                 "imported_arguments": "datamodel_code_generator.arguments" in sys.modules,
+                "imported_difflib": "difflib" in sys.modules,
                 "imported_format": "datamodel_code_generator.format" in sys.modules,
                 "imported_json_config": "datamodel_code_generator.json_config" in sys.modules,
                 "imported_pydantic": "pydantic" in sys.modules,
                 "imported_validators": "datamodel_code_generator.validators" in sys.modules,
             }))
+            """
+        )
+    )
+
+
+def _run_generate_prompt_invalid_option_fast_path() -> dict[str, Any]:
+    return _run_probe(
+        textwrap.dedent(
+            """
+            import contextlib
+            import io
+            import json
+            import runpy
+            import sys
+
+            sys.argv = ["datamodel-codegen", "--generate-prompt", "--output-model-tipe"]
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                try:
+                    runpy.run_module("datamodel_code_generator.__main__", run_name="__main__")
+                except SystemExit as exc:
+                    code = exc.code
+                else:
+                    code = None
+
+            print(json.dumps({
+                "code": code,
+                "stderr": stderr.getvalue(),
+                "imported_difflib": "difflib" in sys.modules,
+                "imported_pydantic": "pydantic" in sys.modules,
+            }, indent=2, sort_keys=True))
             """
         )
     )
@@ -566,6 +598,7 @@ def test_help_fast_path_skips_json_config_and_formatter_imports() -> None:
     assert fast_path["code"] == 0
     assert "Generate Python data models" in fast_path["stdout"]
     assert fast_path["imported_arguments"] is True
+    assert fast_path["imported_difflib"] is False
     assert fast_path["imported_format"] is False
     assert fast_path["imported_json_config"] is False
     assert fast_path["imported_pydantic"] is False
@@ -685,6 +718,16 @@ def test_invalid_args_skip_pydantic_import() -> None:
     assert invalid_args["code"] == 2
     assert "--unknown-option" in invalid_args["stderr"]
     assert invalid_args["imported_pydantic"] is False
+
+
+def test_generate_prompt_fast_path_suggests_invalid_options() -> None:
+    """The prompt fast path retains unknown-option suggestions."""
+    result = _run_generate_prompt_invalid_option_fast_path()
+
+    assert_output(
+        f"{json.dumps(result, indent=2, sort_keys=True)}\n",
+        ROOT / "tests/data/expected/main/cli_fast_paths/generate_prompt_invalid_option.txt",
+    )
 
 
 @pytest.mark.allow_direct_assert

--- a/tests/main/test_main_general.py
+++ b/tests/main/test_main_general.py
@@ -96,6 +96,7 @@ assert_file_content = create_assert_file_content(EXPECTED_MAIN_PATH)
 BLACK_VERSION = version.parse(black.__version__)
 BLACK_LT_233 = version.parse("23.3.0") > BLACK_VERSION
 BLACK_LT_24 = version.parse("24.0.0") > BLACK_VERSION
+CLI_OPTION_SUGGESTIONS_PATH = EXPECTED_MAIN_PATH / "cli_option_suggestions"
 
 
 class _GenerateParseAbort(BaseException):
@@ -452,6 +453,43 @@ def test_show_help(no_color: bool, capsys: pytest.CaptureFixture[str]) -> None:
         expected_code=Exit.OK,
         capsys=capsys,
         expected_stdout_path=EXPECTED_MAIN_PATH / "help" / ("no_color.txt" if no_color else "color.txt"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_stderr_name"),
+    [
+        (["--output-model-tipe"], "output_model_type.txt"),
+        (["--output-model-tipe=pydantic_v2.BaseModel"], "output_model_type_with_value.txt"),
+        (["--output-model-tipe", "--input-file-tipe"], "multiple_options.txt"),
+        (["--output-model-tipe", "--output-model-tipe"], "deduplicated_option.txt"),
+        (["--not-a-valid-option"], "unknown_option.txt"),
+        (["not-an-option"], "positional_argument.txt"),
+        (["--", "--output-model-tipe"], "option_terminator.txt"),
+        (["--output-model-type"], "missing_option_value.txt"),
+    ],
+    ids=[
+        "close-match",
+        "close-match-with-value",
+        "multiple-options",
+        "deduplicated-option",
+        "no-match",
+        "positional",
+        "option-terminator",
+        "missing-value",
+    ],
+)
+def test_invalid_cli_option_suggestions(
+    args: list[str], expected_stderr_name: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Suggest close option names without changing unrelated parser errors."""
+    run_main_with_system_exit(args, expected_code=Exit.ERROR)
+    assert_output(
+        capsys
+        .readouterr()
+        .err.replace("usage: \n", "usage:\n")
+        .replace(f"{arg_parser.prog}: error:", "pytest: error:"),
+        CLI_OPTION_SUGGESTIONS_PATH / expected_stderr_name,
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI error messages now suggest likely correct options when an unrecognized option is entered.
  * Suggestions work with options that include values and multiple invalid options while avoiding duplicate recommendations.
  * Option suggestions remain available in fast command paths, including prompt generation.

* **Bug Fixes**
  * Improved handling of option terminators, positional arguments, and missing option values without changing standard parser errors when no match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->